### PR TITLE
change performance plotting in cuda file and python

### DIFF
--- a/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -322,17 +322,17 @@ int main(int argc, char **argv)
     // --- 3a. SGoodHel
 #ifdef __CUDACC__
     if ( iiter == 0 )
-    {    
+    {
       const std::string ghelKey = "3a SGoodHel";
       timermap.start( ghelKey );
-      
+
       // ... 3a1. Compute good helicity mask on the device
       gProc::sigmaKin_getGoodHel<<<gpublocks, gputhreads>>>(devMomenta, devIsGoodHel);
       checkCuda( cudaPeekAtLastError() );
-      
+
       // ... 3a2. Copy back good helicity mask to the host
       checkCuda( cudaMemcpy( hstIsGoodHel, devIsGoodHel, nbytesIsGoodHel, cudaMemcpyDeviceToHost ) );
-      
+
       // ... 3a3. Copy back good helicity list to constant memory on the device
       gProc::sigmaKin_setGoodHel(hstIsGoodHel);
     }
@@ -430,219 +430,9 @@ int main(int argc, char **argv)
   // **************************************
 
   // === STEP 9 FINALISE
-  // --- 9a Dump after the loop
-  const std::string dumpKey = "9a DumpAll ";
-  timermap.start(dumpKey);
 
-  if (!(verbose || debug || perf))
-  {
-    std::cout << std::endl;
-  }
-
-  if (perf)
-  {
-    double sumrtim = 0;
-    double sqsrtim = 0;
-    double minrtim = rambtimes[0];
-    double maxrtim = rambtimes[0];
-    for ( int iiter = 0; iiter < niter; ++iiter )
-    {
-      sumrtim += rambtimes[iiter];
-      sqsrtim += rambtimes[iiter]*rambtimes[iiter];
-      minrtim = std::min( minrtim, rambtimes[iiter] );
-      maxrtim = std::max( maxrtim, rambtimes[iiter] );
-    }
-    //double meanrtim = sumrtim / niter; // unused
-    //double stdrtim = std::sqrt( sqsrtim / niter - meanrtim * meanrtim ); // unused
-
-    double sumwtim = 0;
-    double sqswtim = 0;
-    double minwtim = wavetimes[0];
-    double maxwtim = wavetimes[0];
-    for ( int iiter = 0; iiter < niter; ++iiter )
-    {
-      sumwtim += wavetimes[iiter];
-      sqswtim += wavetimes[iiter]*wavetimes[iiter];
-      minwtim = std::min( minwtim, wavetimes[iiter] );
-      maxwtim = std::max( maxwtim, wavetimes[iiter] );
-    }
-    double meanwtim = sumwtim / niter;
-    double stdwtim = std::sqrt( sqswtim / niter - meanwtim * meanwtim );
-
-    int nnan = 0;
-    double sumelem = 0;
-    double sqselem = 0;
-    double minelem = matrixelementALL[0];
-    double maxelem = matrixelementALL[0];
-    for ( int ievtALL = 0; ievtALL < nevtALL; ++ievtALL )
-    {
-      if ( std::isnan( matrixelementALL[ievtALL] ) )
-      {
-        if ( debug ) // only printed out with "-p -d" (matrixelementALL is not filled without -p)
-          std::cout << "WARNING! ME[" << ievtALL << "} is nan" << std::endl;
-        nnan++;
-        continue;
-      }
-      sumelem += matrixelementALL[ievtALL];
-      sqselem += matrixelementALL[ievtALL]*matrixelementALL[ievtALL];
-      minelem = std::min( minelem, (double)matrixelementALL[ievtALL] );
-      maxelem = std::max( maxelem, (double)matrixelementALL[ievtALL] );
-    }
-    double meanelem = sumelem / ( nevtALL - nnan );
-    double stdelem = std::sqrt( sqselem / ( nevtALL - nnan) - meanelem * meanelem );
-
-    std::cout << "***************************************" << std::endl
-              << "NumIterations             = " << niter << std::endl
-              << "NumThreadsPerBlock        = " << gputhreads << std::endl
-              << "NumBlocksPerGrid          = " << gpublocks << std::endl
-              << "---------------------------------------" << std::endl
-#if defined MGONGPU_FPTYPE_DOUBLE
-              << "FP precision              = DOUBLE (nan=" << nnan << ")" << std::endl
-#elif defined MGONGPU_FPTYPE_FLOAT
-              << "FP precision              = FLOAT (nan=" << nnan << ")" << std::endl
-#endif
-#ifdef __CUDACC__
-#if defined MGONGPU_CXTYPE_CUCOMPLEX
-              << "Complex type              = CUCOMPLEX" << std::endl
-#elif defined MGONGPU_CXTYPE_THRUST
-              << "Complex type              = THRUST::COMPLEX" << std::endl
-#endif
-#else
-              << "Complex type              = STD::COMPLEX" << std::endl
-#endif
-              << "RanNumb memory layout     = AOSOA[" << neppR << "]"
-              << ( neppR == 1 ? " == AOS" : "" ) << std::endl
-              << "Momenta memory layout     = AOSOA[" << neppM << "]" 
-              << ( neppM == 1 ? " == AOS" : "" ) << std::endl
-#ifdef __CUDACC__
-              << "Wavefunction GPU memory   = LOCAL" << std::endl
-#endif
-#ifdef __CUDACC__
-#if defined MGONGPU_CURAND_ONDEVICE
-              << "Curand generation         = DEVICE (CUDA code)" << std::endl
-#elif defined MGONGPU_CURAND_ONHOST
-              << "Curand generation         = HOST (CUDA code)" << std::endl
-#endif
-#else
-              << "Curand generation         = HOST (C++ code)" << std::endl
-#endif
-              << "---------------------------------------" << std::endl
-              << "NumberOfEntries           = " << niter << std::endl
-              << std::scientific
-              << "TotalTimeInWaveFuncs      = " << sumwtim << " sec" << std::endl
-              << "MeanTimeInWaveFuncs       = " << meanwtim << " sec" << std::endl
-              << "StdDevTimeInWaveFuncs     = " << stdwtim << " sec" << std::endl
-              << "MinTimeInWaveFuncs        = " << minwtim << " sec" << std::endl
-              << "MaxTimeInWaveFuncs        = " << maxwtim << " sec" << std::endl
-              << "---------------------------------------" << std::endl
-      //<< "ProcessID:                = " << getpid() << std::endl
-      //<< "NProcesses                = " << process.nprocesses << std::endl
-              << "TotalEventsComputed       = " << nevtALL << std::endl
-              << "RamboEventsPerSec         = " << nevtALL/sumrtim << " sec^-1" << std::endl
-              << "MatrixElemEventsPerSec    = " << nevtALL/sumwtim << " sec^-1" << std::endl;
-
-    std::cout << "***************************************" << std::endl
-              << "NumMatrixElements(notNan) = " << nevtALL - nnan << std::endl
-              << std::scientific
-              << "MeanMatrixElemValue       = " << meanelem << " GeV^" << meGeVexponent << std::endl
-              << "StdErrMatrixElemValue     = " << stdelem/sqrt(nevtALL) << " GeV^" << meGeVexponent << std::endl
-              << "StdDevMatrixElemValue     = " << stdelem << " GeV^" << meGeVexponent << std::endl
-              << "MinMatrixElemValue        = " << minelem << " GeV^" << meGeVexponent << std::endl
-              << "MaxMatrixElemValue        = " << maxelem << " GeV^" << meGeVexponent << std::endl;
-    
-    if(json){
-      std::ofstream jsonFile;
-      std::string perffile = std::to_string(date) + "-perf-test-run" + std::to_string(run) + ".json";
-      perffile = "./perf/data/" + perffile;
-
-      //Checks if file exists
-      std::ifstream fileCheck;
-      bool fileExists = false;
-      fileCheck.open(perffile);
-      if(fileCheck){
-        fileExists = true;
-        fileCheck.close();
-      }
-      
-      jsonFile.open(perffile, std::ios_base::app);
-      
-      if(!fileExists){
-        jsonFile << "[" << std::endl;
-      }
-      else{
-        //deleting the last bracket and outputting a ", "
-        std::string temp = "truncate -s-1 " + perffile;
-        const char *command = temp.c_str();
-        system(command);
-        jsonFile << ", " << std::endl;
-      }
-      
-      jsonFile << "{" << std::endl
-      << "\"NumIterations\": " << niter << ", " << std::endl
-      << "\"NumThreadsPerBlock\": " << gputhreads << ", " << std::endl
-      << "\"NumBlocksPerGrid\": " << gpublocks << ", " << std::endl
-#if defined MGONGPU_FPTYPE_DOUBLE
-      << "\"FP precision\": " << "\"DOUBLE (nan=" << nnan << ")\"" << ", " << std::endl
-#elif defined MGONGPU_FPTYPE_FLOAT
-      << "\"FP precision\": " << "FLOAT (nan=" << nnan << ")" << ", " << std::endl
-#endif
-#ifdef __CUDACC__
-#if defined MGONGPU_CXTYPE_CUCOMPLEX
-      << "\"Complex type\": " << "\"CUCOMPLEX\"" << ", " << std::endl
-#elif defined MGONGPU_CXTYPE_THRUST
-      << "\"Complex type\": " << "\"THRUST::COMPLEX\"" << ", " << std::endl
-#endif
-#else
-      << "\"Complex type\": " << "\"STD::COMPLEX\"" << ", " << std::endl
-#endif
-      << "\"RanNumb memory layout\": " << "\"AOSOA[" << neppR << "]\""
-      << ( neppR == 1 ? " == AOS" : "" ) << ", " << std::endl
-      << "\"Momenta memory layout\": " << "\"AOSOA[" << neppM << "]\""
-      << ( neppM == 1 ? " == AOS" : "" ) << ", " << std::endl
-#ifdef __CUDACC__
-      << "\"Wavefunction GPU memory\": " << "\"LOCAL\"" << ", " << std::endl
-#endif
-#ifdef __CUDACC__
-#if defined MGONGPU_CURAND_ONDEVICE
-      << "\"Curand generation\": " << "\"DEVICE (CUDA code)\"" << ", " << std::endl
-#elif defined MGONGPU_CURAND_ONHOST
-      << "\"Curand generation\": " << "\"HOST (CUDA code)\"" << ", " << std::endl
-#endif
-#else
-      << "\"Curand generation\": " << "\"HOST (C++ code)\"" << ", " << std::endl
-#endif
-      << "\"NumberOfEntries\": " << niter << ", " << std::endl
-      //<< std::scientific //Not sure about this
-      << "\"TotalTimeInWaveFuncs\": "  << "\"" << std::to_string(sumwtim) << " sec" << "\"" << ", " << std::endl
-      << "\"MeanTimeInWaveFuncs\": "  << "\"" << std::to_string(meanwtim) << " sec" << "\"" << ", " << std::endl
-      << "\"StdDevTimeInWaveFuncs\": " << "\"" << std::to_string(stdwtim) << " sec" << "\"" << ", " << std::endl
-      << "\"MinTimeInWaveFuncs\": " << "\"" << std::to_string(minwtim) << " sec" << "\"" << ", " << std::endl
-      << "\"MaxTimeInWaveFuncs\": " << "\"" << std::to_string(maxwtim) << " sec" << "\"" << ", " << std::endl
-
-//<< "ProcessID:                = " << getpid() << std::endl
-//<< "NProcesses                = " << process.nprocesses << std::endl
-      << "\"TotalEventsComputed\": " << nevtALL << ", " << std::endl
-      << "\"RamboEventsPerSec\": " << "\"" << std::to_string(nevtALL/sumrtim) << " sec^-1" << "\"" << ", " << std::endl
-      << "\"MatrixElemEventsPerSec\": " << "\"" << std::to_string(nevtALL/sumwtim) << " sec^-1" << "\"" << ", " << std::endl
-
-
-      << "\"NumMatrixElements(notNan)\": " << nevtALL - nnan << ", " << std::endl
-      << std::scientific
-      << "\"MeanMatrixElemValue\": " << "\"" << std::to_string(meanelem) << " GeV^" << std::to_string(meGeVexponent) << "\"" << ", " << std::endl
-      << "\"StdErrMatrixElemValue\": " << "\"" << std::to_string(stdelem/sqrt(nevtALL)) << " GeV^" << std::to_string(meGeVexponent) << "\"" << ", " << std::endl
-      << "\"StdDevMatrixElemValue\": " << "\"" << std::to_string(stdelem) << " GeV^" << std::to_string(meGeVexponent) << "\"" << ", " << std::endl
-      << "\"MinMatrixElemValue\": " << "\"" << std::to_string(minelem) << " GeV^" << std::to_string(meGeVexponent) << "\"" << ", " << std::endl
-      << "\"MaxMatrixElemValue\": " << "\"" << std::to_string(maxelem) << " GeV^" << std::to_string(meGeVexponent) <<  "\"" << std::endl
-      << "}" << std::endl
-      << "]";
-      jsonFile.close();
-    }
-  }
-
-  
-
-  // --- 9b. Destroy curand generator
-  const std::string dgenKey = "9b GenDestr";
+  // --- 9a. Destroy curand generator
+  const std::string dgenKey = "9a GenDestr";
   timermap.start( dgenKey );
 #ifdef __CUDACC__
   grambo2toNm0::destroyGenerator( rnGen );
@@ -650,8 +440,8 @@ int main(int argc, char **argv)
   rambo2toNm0::destroyGenerator( rnGen );
 #endif
 
-  // --- 9c Free memory structures
-  const std::string freeKey = "9c MemFree ";
+  // --- 9b Free memory structures
+  const std::string freeKey = "9b MemFree ";
   timermap.start( freeKey );
 
 #ifdef __CUDACC__
@@ -674,16 +464,256 @@ int main(int argc, char **argv)
   delete[] hstRnarray;
 #endif
 
-  delete[] rambtimes;
-  delete[] wavetimes;
-  delete[] matrixelementALL;
-
 #ifdef __CUDACC__
-  // --- 9d. Finalise cuda
-  const std::string cdrsKey = "9d CudReset";
+  // --- 9c. Finalise cuda
+  const std::string cdrsKey = "9c CudReset";
   timermap.start( cdrsKey );
   checkCuda( cudaDeviceReset() ); // this is needed by cuda-memcheck --leak-check full
 #endif
+
+
+// --- 9d Dump after the loop
+const std::string dumpKey = "9d DumpScrn";
+timermap.start(dumpKey);
+
+if (!(verbose || debug || perf))
+{
+  std::cout << std::endl;
+}
+
+if (perf)
+{
+  double sumrtim = 0;
+  double sqsrtim = 0;
+  double minrtim = rambtimes[0];
+  double maxrtim = rambtimes[0];
+  for ( int iiter = 0; iiter < niter; ++iiter )
+  {
+    sumrtim += rambtimes[iiter];
+    sqsrtim += rambtimes[iiter]*rambtimes[iiter];
+    minrtim = std::min( minrtim, rambtimes[iiter] );
+    maxrtim = std::max( maxrtim, rambtimes[iiter] );
+  }
+  //double meanrtim = sumrtim / niter; // unused
+  //double stdrtim = std::sqrt( sqsrtim / niter - meanrtim * meanrtim ); // unused
+
+  double sumwtim = 0;
+  double sqswtim = 0;
+  double minwtim = wavetimes[0];
+  double maxwtim = wavetimes[0];
+  for ( int iiter = 0; iiter < niter; ++iiter )
+  {
+    sumwtim += wavetimes[iiter];
+    sqswtim += wavetimes[iiter]*wavetimes[iiter];
+    minwtim = std::min( minwtim, wavetimes[iiter] );
+    maxwtim = std::max( maxwtim, wavetimes[iiter] );
+  }
+  double meanwtim = sumwtim / niter;
+  double stdwtim = std::sqrt( sqswtim / niter - meanwtim * meanwtim );
+
+  int nnan = 0;
+  double sumelem = 0;
+  double sqselem = 0;
+  double minelem = matrixelementALL[0];
+  double maxelem = matrixelementALL[0];
+  for ( int ievtALL = 0; ievtALL < nevtALL; ++ievtALL )
+  {
+    if ( std::isnan( matrixelementALL[ievtALL] ) )
+    {
+      if ( debug ) // only printed out with "-p -d" (matrixelementALL is not filled without -p)
+        std::cout << "WARNING! ME[" << ievtALL << "} is nan" << std::endl;
+      nnan++;
+      continue;
+    }
+    sumelem += matrixelementALL[ievtALL];
+    sqselem += matrixelementALL[ievtALL]*matrixelementALL[ievtALL];
+    minelem = std::min( minelem, (double)matrixelementALL[ievtALL] );
+    maxelem = std::max( maxelem, (double)matrixelementALL[ievtALL] );
+  }
+  double meanelem = sumelem / ( nevtALL - nnan );
+  double stdelem = std::sqrt( sqselem / ( nevtALL - nnan) - meanelem * meanelem );
+
+  std::cout << "***************************************" << std::endl
+            << "NumIterations             = " << niter << std::endl
+            << "NumThreadsPerBlock        = " << gputhreads << std::endl
+            << "NumBlocksPerGrid          = " << gpublocks << std::endl
+            << "---------------------------------------" << std::endl
+#if defined MGONGPU_FPTYPE_DOUBLE
+            << "FP precision              = DOUBLE (nan=" << nnan << ")" << std::endl
+#elif defined MGONGPU_FPTYPE_FLOAT
+            << "FP precision              = FLOAT (nan=" << nnan << ")" << std::endl
+#endif
+#ifdef __CUDACC__
+#if defined MGONGPU_CXTYPE_CUCOMPLEX
+            << "Complex type              = CUCOMPLEX" << std::endl
+#elif defined MGONGPU_CXTYPE_THRUST
+            << "Complex type              = THRUST::COMPLEX" << std::endl
+#endif
+#else
+            << "Complex type              = STD::COMPLEX" << std::endl
+#endif
+            << "RanNumb memory layout     = AOSOA[" << neppR << "]"
+            << ( neppR == 1 ? " == AOS" : "" ) << std::endl
+            << "Momenta memory layout     = AOSOA[" << neppM << "]"
+            << ( neppM == 1 ? " == AOS" : "" ) << std::endl
+#ifdef __CUDACC__
+            << "Wavefunction GPU memory   = LOCAL" << std::endl
+#endif
+#ifdef __CUDACC__
+#if defined MGONGPU_CURAND_ONDEVICE
+            << "Curand generation         = DEVICE (CUDA code)" << std::endl
+#elif defined MGONGPU_CURAND_ONHOST
+            << "Curand generation         = HOST (CUDA code)" << std::endl
+#endif
+#else
+            << "Curand generation         = HOST (C++ code)" << std::endl
+#endif
+            << "---------------------------------------" << std::endl
+            << "NumberOfEntries           = " << niter << std::endl
+            << std::scientific
+            << "TotalTimeInWaveFuncs      = " << sumwtim << " sec" << std::endl
+            << "MeanTimeInWaveFuncs       = " << meanwtim << " sec" << std::endl
+            << "StdDevTimeInWaveFuncs     = " << stdwtim << " sec" << std::endl
+            << "MinTimeInWaveFuncs        = " << minwtim << " sec" << std::endl
+            << "MaxTimeInWaveFuncs        = " << maxwtim << " sec" << std::endl
+            << "---------------------------------------" << std::endl
+    //<< "ProcessID:                = " << getpid() << std::endl
+    //<< "NProcesses                = " << process.nprocesses << std::endl
+            << "TotalEventsComputed       = " << nevtALL << std::endl
+            << "RamboEventsPerSec         = " << nevtALL/sumrtim << " sec^-1" << std::endl
+            << "MatrixElemEventsPerSec    = " << nevtALL/sumwtim << " sec^-1" << std::endl;
+
+  std::cout << "***************************************" << std::endl
+            << "NumMatrixElements(notNan) = " << nevtALL - nnan << std::endl
+            << std::scientific
+            << "MeanMatrixElemValue       = " << meanelem << " GeV^" << meGeVexponent << std::endl
+            << "StdErrMatrixElemValue     = " << stdelem/sqrt(nevtALL) << " GeV^" << meGeVexponent << std::endl
+            << "StdDevMatrixElemValue     = " << stdelem << " GeV^" << meGeVexponent << std::endl
+            << "MinMatrixElemValue        = " << minelem << " GeV^" << meGeVexponent << std::endl
+            << "MaxMatrixElemValue        = " << maxelem << " GeV^" << meGeVexponent << std::endl;
+
+  const std::string jsonKey = "9e DumpJson";
+  timermap.start(jsonKey);
+
+  if(json) {
+    std::ofstream jsonFile;
+    std::string perffile = std::to_string(date) + "-perf-test-run" + std::to_string(run) + ".json";
+    perffile = "./perf/data/" + perffile;
+
+    //Checks if file exists
+    std::ifstream fileCheck;
+    bool fileExists = false;
+    fileCheck.open(perffile);
+    if(fileCheck){
+      fileExists = true;
+      fileCheck.close();
+    }
+
+    jsonFile.open(perffile, std::ios_base::app);
+
+    if(!fileExists){
+      jsonFile << "[" << std::endl;
+    }
+    else{
+      //deleting the last bracket and outputting a ", "
+      std::string temp = "truncate -s-1 " + perffile;
+      const char *command = temp.c_str();
+      system(command);
+      jsonFile << ", " << std::endl;
+    }
+
+    jsonFile << "{" << std::endl
+    << "\"NumIterations\": " << niter << ", " << std::endl
+    << "\"NumThreadsPerBlock\": " << gputhreads << ", " << std::endl
+    << "\"NumBlocksPerGrid\": " << gpublocks << ", " << std::endl
+  #if defined MGONGPU_FPTYPE_DOUBLE
+    << "\"FP precision\": "
+    << "\"DOUBLE (nan=" << nnan << ")\"," << std::endl
+  #elif defined MGONGPU_FPTYPE_FLOAT
+    << "\"FP precision\": " << "FLOAT (nan=" << nnan << ")," << std::endl
+  #endif
+  << "\"Complex type\": "
+  #ifdef __CUDACC__
+  #if defined MGONGPU_CXTYPE_CUCOMPLEX
+    << "\"CUCOMPLEX\"," << std::endl
+  #elif defined MGONGPU_CXTYPE_THRUST
+    << "\"THRUST::COMPLEX\"," << std::endl
+  #endif
+  #else
+    << "\"STD::COMPLEX\"," << std::endl
+  #endif
+    << "\"RanNumb memory layout\": " << "\"AOSOA[" << neppR << "]\""
+    << ( neppR == 1 ? " == AOS" : "" ) << ", " << std::endl
+    << "\"Momenta memory layout\": " << "\"AOSOA[" << neppM << "]\""
+    << ( neppM == 1 ? " == AOS" : "" ) << ", " << std::endl
+  #ifdef __CUDACC__
+    << "\"Wavefunction GPU memory\": " << "\"LOCAL\"," << std::endl
+  #endif
+    << "\"Curand generation\": "
+  #ifdef __CUDACC__
+  #if defined MGONGPU_CURAND_ONDEVICE
+    << "\"DEVICE (CUDA code)\"," << std::endl
+  #elif defined MGONGPU_CURAND_ONHOST
+    << "\"HOST (CUDA code)\"," << std::endl
+  #endif
+  #else
+    << "\"HOST (C++ code)\"," << std::endl
+  #endif
+    << "\"NumberOfEntries\": " << niter << "," << std::endl
+    //<< std::scientific //Not sure about this
+    << "\"TotalTimeInWaveFuncs\": "
+    << "\"" << std::to_string(sumwtim) << " sec\"," << std::endl
+    << "\"MeanTimeInWaveFuncs\": "
+    << "\"" << std::to_string(meanwtim) << " sec\"," << std::endl
+    << "\"StdDevTimeInWaveFuncs\": "
+    << "\"" << std::to_string(stdwtim) << " sec\"," << std::endl
+    << "\"MinTimeInWaveFuncs\": "
+    << "\"" << std::to_string(minwtim) << " sec\"," << std::endl
+    << "\"MaxTimeInWaveFuncs\": "
+    << "\"" << std::to_string(maxwtim) << " sec\"," << std::endl
+
+  //<< "ProcessID:                = " << getpid() << std::endl
+  //<< "NProcesses                = " << process.nprocesses << std::endl
+    << "\"TotalEventsComputed\": " << nevtALL << "," << std::endl
+    << "\"RamboEventsPerSec\": "
+    << "\"" << std::to_string(nevtALL/sumrtim) << " sec^-1\"," << std::endl
+    << "\"MatrixElemEventsPerSec\": "
+    << "\"" << std::to_string(nevtALL/sumwtim) << " sec^-1\"," << std::endl
+
+
+    << "\"NumMatrixElements(notNan)\": " << nevtALL - nnan << "," << std::endl
+    << std::scientific
+    << "\"MeanMatrixElemValue\": "
+    << "\"" << std::to_string(meanelem) << " GeV^"
+    << std::to_string(meGeVexponent) << "\"," << std::endl
+    << "\"StdErrMatrixElemValue\": "
+    << "\"" << std::to_string(stdelem/sqrt(nevtALL)) << " GeV^"
+    << std::to_string(meGeVexponent) << "\"," << std::endl
+    << "\"StdDevMatrixElemValue\": "
+    << "\"" << std::to_string(stdelem)
+    << " GeV^" << std::to_string(meGeVexponent) << "\"," << std::endl
+    << "\"MinMatrixElemValue\": "
+    << "\"" << std::to_string(minelem) << " GeV^"
+    << std::to_string(meGeVexponent) << "\"," << std::endl
+    << "\"MaxMatrixElemValue\": "
+    << "\"" << std::to_string(maxelem) << " GeV^"
+    << std::to_string(meGeVexponent) <<  "\"," << std::endl;
+
+    timermap.dump(jsonFile, true);
+
+    jsonFile << "}" << std::endl << "]";
+    jsonFile.close();
+  }
+}
+
+const std::string jsonKey = "9e FinalDel";
+timermap.start(jsonKey);
+
+delete[] rambtimes;
+delete[] wavetimes;
+delete[] matrixelementALL;
+
+
 
   // *** STOP THE NEW TIMERS ***
   timermap.stop();

--- a/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/timermap.h
+++ b/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/timermap.h
@@ -1,9 +1,10 @@
-#ifndef MGONGPUTIMERMAP_H 
+#ifndef MGONGPUTIMERMAP_H
 #define MGONGPUTIMERMAP_H 1
 
 #include <cassert>
 #include <map>
 #include <string>
+#include <fstream>
 
 #include "nvtx.h"
 #include "timer.h"
@@ -58,7 +59,7 @@ namespace mgOnGpu
     }
 
     // Dump the overall results
-    void dump()
+    void dump(std::ostream& ostr = std::cout, bool json=false)
     {
       // Improve key formatting
       const std::string totalKey = "TOTAL      "; // "TOTAL(ANY) "?
@@ -85,21 +86,31 @@ namespace mgOnGpu
         if ( ip.first[0] == '2' || ip.first[0] == '3' ) total23 += ip.second;
         if ( ip.first[0] == '3' ) total3 += ip.second;
         ipart++;
-      }      
-      // Dump individual partition timers and the overall total 
-      for ( auto ip : m_partitionTimers )
-        std::cout << std::setw(maxsize) << ip.first << " : " 
-                  << std::fixed << std::setw(8) << ip.second << " sec" << std::endl;
-      std::cout << std::setw(maxsize) << totalKey << " : " 
-                << std::fixed << std::setw(8) << total << " sec" << std::endl;
-      //std::cout << std::setw(maxsize) << totalBut2Key << " : " 
-      //          << std::fixed << std::setw(8) << totalBut2 << " sec" << std::endl;
-      std::cout << std::setw(maxsize) << total123Key << " : " 
-                << std::fixed << std::setw(8) << total123 << " sec" << std::endl;
-      std::cout << std::setw(maxsize) << total23Key << " : " 
-                << std::fixed << std::setw(8) << total23 << " sec" << std::endl;
-      std::cout << std::setw(maxsize) << total3Key << " : " 
-                << std::fixed << std::setw(8) << total3 << " sec" << std::endl;
+      }
+      // Dump individual partition timers and the overall total
+      if (json) {
+        std::string s1 = "\"", s2 = "\" : \"", s3 = " sec\",";
+        for ( auto ip : m_partitionTimers )
+          ostr << s1 << ip.first << s2 << ip.second << s3 << std::endl;
+        ostr << s1 << totalKey << s2 << total << s3 << std::endl
+             << s1 << total123Key << s2 << total123 << s3 << std::endl
+             << s1 << total23Key << s2 << total23 << s3 << std::endl
+             << s1 << total3Key << s2 << total3 << "sec \"" << std::endl;
+      }
+      else {
+        for ( auto ip : m_partitionTimers )
+          ostr << std::setw(maxsize) << ip.first << " : "
+               << std::fixed << std::setw(8) << ip.second << " sec"
+               << std::endl;
+        ostr << std::setw(maxsize) << totalKey << " : "
+             << std::fixed << std::setw(8) << total << " sec" << std::endl
+             << std::setw(maxsize) << total123Key << " : "
+             << std::fixed << std::setw(8) << total123 << " sec" << std::endl
+             << std::setw(maxsize) << total23Key << " : "
+             << std::fixed << std::setw(8) << total23 << " sec" << std::endl
+             << std::setw(maxsize) << total3Key << " : "
+             << std::fixed << std::setw(8) << total3 << " sec" << std::endl;
+      }
     }
 
   private:


### PR DESCRIPTION
(cherry picked from commit f25e0bdf332382fdea384fdd4aba6593355ebb52)

change gcheck.exe to write the json info as late as possible (including the tear down processing times). Add those individual times to the json file

add two new plots for perf.py to print performance data in 2D with the same number of threads being the same color and size of circle on the plot. 

Another plot shows bar graphs of the timings for various numbers of blocks with fixed number of threads. 