### PR TITLE
Fixed warnings during compilation by replacing system with execlp

### DIFF
--- a/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -572,8 +572,9 @@ int main(int argc, char **argv)
       else{
         //deleting the last bracket and outputting a ", "
         std::string temp = "truncate -s-1 " + perffile;
+        std::string path = "/bin" + temp;
         const char *command = temp.c_str();
-        system(command);
+        execlp(path.c_str(), command, NULL);
         jsonFile << ", " << std::endl;
       }
       


### PR DESCRIPTION
Minor change to remove warnings created by `system()`, replacing it with `execlp`.