### PR TITLE
Add feature to produce common random numbers.

### DIFF
--- a/examples/gpu/eemumu_AV/SubProcesses/Makefile
+++ b/examples/gpu/eemumu_AV/SubProcesses/Makefile
@@ -1,13 +1,13 @@
 CUARCHNUM=70
 #CUARCHNUM=61 #(For Pascal Architecture Cards)
 LIBDIR=../../lib
-INCDIR=../../src
+INCDIRS=-I. -I../../src
 MODELLIB=model_sm
-CXXFLAGS= -O3 -I. -I$(INCDIR) -DUSE_NVTX -Wall -Wshadow
-###CXXFLAGS= -O2 -I. -I$(INCDIR) -DUSE_NVTX -Wall -Wshadow
+CXXFLAGS= -O3 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
+###CXXFLAGS= -O2 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
 CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
 # CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
-CUFLAGS= -O3 -I. -I$(INCDIR) -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo 
+CUFLAGS= -O3 $(INCDIRS) -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo
 # Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
 ###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
 ###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)

--- a/examples/gpu/eemumu_AV/SubProcesses/Makefile
+++ b/examples/gpu/eemumu_AV/SubProcesses/Makefile
@@ -1,7 +1,7 @@
 CUARCHNUM=70
 #CUARCHNUM=61 #(For Pascal Architecture Cards)
 LIBDIR=../../lib
-INCDIRS=-I. -I../../src
+INCDIRS=-I. -I../../src -I../../../../../tools/
 MODELLIB=model_sm
 CXXFLAGS= -O3 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
 ###CXXFLAGS= -O2 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
@@ -61,7 +61,7 @@ $(cu_main): $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
 	$(NVCC) -o $@ $(cu_objects) $(LIBFLAGS) $(CUARCHFLAGS) -lcuda -lcurand
 
 $(cxx_main): $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) check.o
-	$(CXX) -o $@ $(cxx_objects) check.o -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcurand
+	$(CXX) -o $@ $(cxx_objects) check.o -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS) -lcurand
 
 .PHONY: clean
 

--- a/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/examples/gpu/eemumu_AV/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -19,6 +19,7 @@
 
 #include "CPPProcess.h"
 #include "timermap.h"
+#include "CommonRandomNumbers.h"
 
 bool is_number(const char *s) {
   const char *t = s;
@@ -159,6 +160,11 @@ int main(int argc, char **argv)
   const int nRnarray = np4*nparf*nevt; // (NB: ASA layout with nevt=npagR*neppR events per iteration)
   fptype* hstRnarray = nullptr; // AOSOA[npagR][nparf][np4][neppR] (NB: nevt=npagR*neppR)
 
+  std::vector<std::promise<std::vector<fptype>>> commonRandomPromises;
+  if (MGONGPU_COMMONRAND_ONHOST) {
+    CommonRandomNumbers::startGenerateAsync(commonRandomPromises, nRnarray, niter);
+  }
+
 #ifdef __CUDACC__
   const int nbytesRnarray = nRnarray * sizeof(fptype);
   fptype* devRnarray = 0; // AOSOA[npagR][nparf][np4][neppR] (NB: nevt=npagR*neppR)
@@ -167,7 +173,7 @@ int main(int argc, char **argv)
   checkCuda( cudaMallocHost( &hstRnarray, nbytesRnarray ) );
 #endif
 #endif
-  if (!hstRnarray) {
+  if (!hstRnarray && commonRandomPromises.empty()) {
     hstRnarray = new fptype[nRnarray]();
   }
   const int nMomenta = np4*npar*nevt; // (NB: nevt=npagM*neppM for ASA layouts)
@@ -255,17 +261,26 @@ int main(int argc, char **argv)
     const std::string rngnKey = "1b GenRnGen";
     timermap.start( rngnKey );
     fptype* hstRn = nullptr;
+    std::vector<double> commonRandomNumbers;
+
+    if (MGONGPU_COMMONRAND_ONHOST) {
+      commonRandomNumbers = commonRandomPromises[iiter].get_future().get();
+      hstRn = commonRandomNumbers.data();
+      assert( nRnarray == static_cast<int>(commonRandomNumbers.size()) );
+    } else {
 #ifdef __CUDACC__
 #if defined MGONGPU_CURAND_ONDEVICE
-    grambo2toNm0::generateRnarray( rnGen, devRnarray, nevt );
+      grambo2toNm0::generateRnarray( rnGen, devRnarray, nevt );
 #elif defined MGONGPU_CURAND_ONHOST
-    grambo2toNm0::generateRnarray( rnGen, hstRnarray, nevt );
-    hstRn = hstRnarray;
+      grambo2toNm0::generateRnarray( rnGen, hstRnarray, nevt );
+      hstRn = hstRnarray;
 #endif
 #else
-    rambo2toNm0::generateRnarray( rnGen, hstRnarray, nevt );
-    hstRn = hstRnarray;
+      rambo2toNm0::generateRnarray( rnGen, hstRnarray, nevt );
+      hstRn = hstRnarray;
 #endif
+    }
+
     //std::cout << "Got random numbers" << std::endl;
 
 #ifdef __CUDACC__

--- a/examples/gpu/eemumu_AV/src/mgOnGpuConfig.h
+++ b/examples/gpu/eemumu_AV/src/mgOnGpuConfig.h
@@ -10,6 +10,7 @@
 // Curand random number generation (CHOOSE ONLY ONE)
 #define MGONGPU_CURAND_ONDEVICE 1 // default
 //#define MGONGPU_CURAND_ONHOST 1
+#define MGONGPU_COMMONRAND_ONHOST false
 
 // Memory choice for wavefunctions: registries/"local", global, shared (CHOOSE ONLY ONE)
 // Local storage (registries plus spillover to local) is hardcoded: fine tune it using maxrregcount in the Makefile

--- a/examples/gpu/eemumu_AV/src/rambo.cc
+++ b/examples/gpu/eemumu_AV/src/rambo.cc
@@ -195,12 +195,8 @@ namespace rambo2toNm0
     //const curandRngType_t type = CURAND_RNG_PSEUDO_MRG32K3A;      // 0.71s    | 0.0012s  (better but slower, especially in c++)
     //const curandRngType_t type = CURAND_RNG_PSEUDO_MT19937;       // 21s      | 0.021s
     //const curandRngType_t type = CURAND_RNG_PSEUDO_PHILOX4_32_10; // 0.024s   | 0.00026s (used to segfault?)
-#ifdef __CUDACC__
-#if defined MGONGPU_CURAND_ONDEVICE
+#if defined __CUDACC__ and defined MGONGPU_CURAND_ONDEVICE
     checkCurand( curandCreateGenerator( pgen, type ) );
-#elif defined MGONGPU_CURAND_ONHOST
-    checkCurand( curandCreateGeneratorHost( pgen, type ) );
-#endif
 #else
     checkCurand( curandCreateGeneratorHost( pgen, type ) );
 #endif

--- a/tools/CommonRandomNumbers.h
+++ b/tools/CommonRandomNumbers.h
@@ -1,0 +1,89 @@
+/*
+ * CommonRandomNumbers.h
+ *
+ *  Created on: 04.11.2020
+ *      Author: Stephan Hageboeck
+ */
+
+#ifndef COMMONRANDOMNUMBERS_H_
+#define COMMONRANDOMNUMBERS_H_
+
+#include <vector>
+#include <random>
+#include <thread>
+#include <future>
+
+namespace CommonRandomNumbers {
+
+/// Create `n` random numbers using simple c++ engine.
+template<typename T>
+std::vector<T> generate(std::size_t n, std::minstd_rand::result_type seed = 1337) {
+  std::vector<T> result;
+  result.reserve(n);
+
+  std::minstd_rand generator(seed);
+  std::uniform_real_distribution<T> distribution(0.0, 1.0);
+
+  for (std::size_t i=0; i<n; ++i) {
+    result.push_back(distribution(generator));
+  }
+
+  return result;
+}
+
+
+/// Create `nBlock` blocks of random numbers.
+/// Each block uses a generator that's seeded with `seed + blockIndex`, and blocks are generated in parallel.
+template<typename T>
+std::vector<std::vector<T>> generateParallel(std::size_t nPerBlock, std::size_t nBlock, std::minstd_rand::result_type seed = 1337) {
+  std::vector<std::vector<T>> results(nBlock);
+  std::vector<std::thread> threads;
+  const auto partPerThread = nBlock/std::thread::hardware_concurrency() + (nBlock % std::thread::hardware_concurrency() != 0);
+
+  auto makeBlock = [nPerBlock,nBlock,seed,&results](std::size_t partitionBegin, std::size_t partitionEnd) {
+    for (std::size_t partition = partitionBegin; partition < partitionEnd && partition < nBlock; ++partition) {
+      results[partition] = generate<T>(nPerBlock, seed + partition);
+    }
+  };
+
+  for (unsigned int threadId = 0; threadId < std::thread::hardware_concurrency(); ++threadId) {
+    threads.emplace_back(makeBlock, threadId * partPerThread, (threadId+1) * partPerThread);
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  return results;
+}
+
+
+/// Starts asynchronous generation of random numbers. This uses as many threads as cores, and generates blocks of random numbers.
+/// These become available at unspecified times, but the blocks 0, 1, 2, ... are generated first.
+/// Each block is seeded with seed + blockIndex to generate stable sequences.
+/// \param[in/out] promises Vector of promise objects storing blocks of random numbers.
+/// \param[in] nPerBlock Configures number of entries generated per block.
+/// \param[in] nBlock Configures the number of blocks generated.
+/// \param[in] nThread Optional concurrency.
+/// \param[in] seed Optional seed.
+template<typename T>
+void startGenerateAsync(std::vector<std::promise<std::vector<T>>>& promises, std::size_t nPerBlock, std::size_t nBlock,
+    unsigned int nThread = std::thread::hardware_concurrency(), std::minstd_rand::result_type seed = 1337) {
+  promises.resize(nBlock);
+  std::vector<std::thread> threads;
+
+  auto makeBlocks = [=,&promises](std::size_t threadID) {
+    for (std::size_t partition = threadID; partition < nBlock; partition += nThread) {
+      auto values = generate<T>(nPerBlock, seed + partition);
+      promises[partition].set_value(std::move(values));
+    }
+  };
+
+  for (unsigned int threadId = 0; threadId < nThread; ++threadId) {
+    std::thread(makeBlocks, threadId).detach();
+  }
+}
+
+}
+
+#endif /* COMMONRANDOMNUMBERS_H_ */


### PR DESCRIPTION
- Add a header in `tools/` for creating reproducible common random numbers using c++11.
- Modify eemumu_AV such that it can make use of those.

Note that to increase the compiler coverage and to decrease the probability of errors, this uses
```
#define FLAG true/false
...
if (FLAG)
```
This way, the compiler checks both code paths for correct syntax, but no assembly is generated for the inactive path.