### PR TITLE
[eemumu epoch1] Make code compile without CUDA

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -3,11 +3,11 @@ CUARCHNUM=70
 LIBDIR=../../lib
 INCDIRS=-I. -I../../src -I../../../../../tools/
 MODELLIB=model_sm
-CXXFLAGS= -O3 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
+CXXFLAGS= -O3 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow ${MGONGPU_CONFIG}
 ###CXXFLAGS= -O2 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
 CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
 # CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
-CUFLAGS= -O3 $(INCDIRS) -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo
+CUFLAGS= -O3 $(INCDIRS) -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
 # Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
 ###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
 ###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -1,23 +1,27 @@
-CUARCHNUM=70
-#CUARCHNUM=61 #(For Pascal Architecture Cards)
-LIBDIR=../../lib
+LIBDIR =../../lib
 INCDIRS=-I. -I../../src -I../../../../../tools/
 MODELLIB=model_sm
-CXXFLAGS= -O3 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow ${MGONGPU_CONFIG}
-###CXXFLAGS= -O2 $(INCDIRS) -DUSE_NVTX -Wall -Wshadow
-CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
-# CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
-CUFLAGS= -O3 $(INCDIRS) -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
-# Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
-###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
-###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)
-###CUFLAGS+= --maxrregcount 96 # degrades throughput: 4.1E8 (16384 32 12) up to 4.5E8 (65536 128 12)
-###CUFLAGS+= --maxrregcount 64 # degrades throughput: 1.7E8 (16384 32 12) flat at 1.7E8 (65536 128 12)
-CUINC=/usr/local/cuda/targets/x86_64-linux/include
+CXXFLAGS= -O3 -std=c++11 $(INCDIRS) $(USE_NVTX) -Wall -Wshadow ${MGONGPU_CONFIG}
 LIBFLAGS= -L$(LIBDIR) -l$(MODELLIB)
-CULIBFLAGS= -L/usr/local/cuda/targets/x86_64-linux/lib
-NVCC=nvcc
 CXX=g++
+NVCC?=$(shell which nvcc)
+ifeq (, $(NVCC))
+	NVCC=@echo No nvcc to run nvcc
+else
+	USE_NVTX?=-DUSE_NVTX
+	CUARCHNUM=70
+	#CUARCHNUM=61 #(For Pascal Architecture Cards)
+	CUINC=-I/usr/local/cuda/targets/x86_64-linux/include
+	CULIBFLAGS= -L/usr/local/cuda/targets/x86_64-linux/lib -lcurand
+	CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
+	# CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
+	CUFLAGS= -O3 $(INCDIRS) $(USE_NVTX) $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
+	# Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
+	###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
+	###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)
+	###CUFLAGS+= --maxrregcount 96 # degrades throughput: 4.1E8 (16384 32 12) up to 4.5E8 (65536 128 12)
+	###CUFLAGS+= --maxrregcount 64 # degrades throughput: 1.7E8 (16384 32 12) flat at 1.7E8 (65536 128 12)
+endif
 MAKEDEBUG=
 
 cu_main=gcheck.exe
@@ -55,13 +59,13 @@ gcheck.o: gcheck.cu *.h ../../src/*.h ../../src/*.cu
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
 %.o : %.cc *.h ../../src/*.h
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(CUINC) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CUINC) -c $< -o $@
 
 $(cu_main): $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
 	$(NVCC) -o $@ $(cu_objects) $(LIBFLAGS) $(CUARCHFLAGS) -lcuda -lcurand
 
 $(cxx_main): $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) check.o
-	$(CXX) -o $@ $(cxx_objects) check.o -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS) -lcurand
+	$(CXX) -o $@ $(cxx_objects) check.o -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 
 .PHONY: clean
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -285,10 +285,10 @@ int main(int argc, char **argv)
     const std::string rngnKey = "1b GenRnGen";
     timermap.start( rngnKey );
 #ifdef MGONGPU_COMMONRAND_ONHOST
-    std::vector<double> commonRnd = commonRandomPromises[iiter].get_future().get();
+    std::vector<fptype> commonRnd = commonRandomPromises[iiter].get_future().get();
     assert( nRnarray == static_cast<int>( commonRnd.size() ) );
     // NB (PR #45): memcpy is strictly needed only in CUDA (copy to pinned memory), but keep it also in C++ for consistency
-    memcpy( hstRnarray, commonRandomNumbers.data(), nbytesRnarray );
+    memcpy( hstRnarray.get(), commonRnd.data(), nRnarray * sizeof(fptype) );
 #elif defined __CUDACC__
 #ifdef MGONGPU_CURAND_ONDEVICE
     grambo2toNm0::generateRnarray( rnGen, devRnarray.get(), nevt );

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -1,9 +1,9 @@
 CUARCHNUM=70
 LIBDIR=../lib
-CXXFLAGS= -O3 -I. -DUSE_NVTX -Wall -Wshadow 
+CXXFLAGS= -O3 -I. -DUSE_NVTX -Wall -Wshadow ${MGONGPU_CONFIG}
 ###CXXFLAGS= -O2 -I. -DUSE_NVTX -Wall -Wshadow 
 CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
-CUFLAGS= -O3 -I. -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo
+CUFLAGS= -O3 -I. -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
 CUINC=/usr/local/cuda/targets/x86_64-linux/include
 NVCC=nvcc
 CXX=g++

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -7,10 +7,14 @@
 // Memory layout for momenta: AOSOA, AOS, SOA (CHOOSE ONLY ONE)
 // AOSOA (ASA) layout is hardcoded: fine-tune it using the nepopR and neppM parameters below
 
+// Choose how random numbers are generated
+// If one of these macros has been set from outside with e.g. -DMGONGPU_CURAND_ONHOST, nothing happens.
+#if not defined MGONGPU_CURAND_ONDEVICE and not defined MGONGPU_CURAND_ONHOST and not defined MGONGPU_COMMONRAND_ONHOST
 // Curand random number generation (CHOOSE ONLY ONE)
 #define MGONGPU_CURAND_ONDEVICE 1 // default (curand: CUDA on device, C++ on host)
 //#define MGONGPU_CURAND_ONHOST 1 // (curand: CUDA on host, C++ on host)
 //#define MGONGPU_COMMONRAND_ONHOST 1 // (common rand: CUDA on host, C++ on host)
+#endif
 
 // Memory choice for wavefunctions: registries/"local", global, shared (CHOOSE ONLY ONE)
 // Local storage (registries plus spillover to local) is hardcoded: fine tune it using maxrregcount in the Makefile

--- a/epoch1/cuda/ee_mumu/src/rambo.cc
+++ b/epoch1/cuda/ee_mumu/src/rambo.cc
@@ -184,6 +184,8 @@ namespace rambo2toNm0
     return;
   }
 
+
+#if defined MGONGPU_CURAND_ONHOST or defined MGONGPU_CURAND_ONDEVICE
   //--------------------------------------------------------------------------
 
   // Create and initialise a curand generator
@@ -237,6 +239,7 @@ namespace rambo2toNm0
   }
 
   //--------------------------------------------------------------------------
+#endif
 
 }
 

--- a/epoch1/cuda/ee_mumu/src/rambo.h
+++ b/epoch1/cuda/ee_mumu/src/rambo.h
@@ -1,14 +1,15 @@
 #ifndef RAMBO_H
 #define RAMBO_H 1
 
-#include <cassert>
-
-#include "curand.h"
-
 #include "mgOnGpuConfig.h"
 #include "mgOnGpuTypes.h"
 
+#include <cassert>
+
 //--------------------------------------------------------------------------
+
+#if defined MGONGPU_CURAND_ONHOST or defined MGONGPU_CURAND_ONDEVICE
+#include "curand.h"
 
 #define checkCurand( code )                     \
   { assertCurand( code, __FILE__, __LINE__ ); }
@@ -21,6 +22,8 @@ inline void assertCurand( curandStatus_t code, const char *file, int line, bool 
     if ( abort ) assert( code == CURAND_STATUS_SUCCESS );
   }
 }
+
+#endif
 
 //--------------------------------------------------------------------------
 
@@ -60,6 +63,7 @@ namespace rambo2toNm0
 #endif
                         );
 
+#if defined MGONGPU_CURAND_ONHOST or defined MGONGPU_CURAND_ONDEVICE
   //--------------------------------------------------------------------------
 
   // Create and initialise a curand generator
@@ -85,6 +89,7 @@ namespace rambo2toNm0
                         const int nevt );      // input: #events
 
   //--------------------------------------------------------------------------
+#endif
 
 }
 


### PR DESCRIPTION
This disentangles testing and compilation without CUDA that was previously in #50 

In order to have automated tests, implement the following:
- Allow for setting compiler options from outside the Makefile using `MGONGPU_CONFIG=<option>`
- Make CPU version compile without cuda (requires `make MGONGPU_CONFIG=-DMGONGPU_COMMONRAND_ONHOST`,  `export MGONGPU_CONFIG=-DMGONGPU_COMMONRAND_ONHOST` or similar)
- When no cuda toolkit is found, the Makefile only compiles the CPU version. (also requires `-DMGONGPU_COMMONRAND_ONHOST` to not interfere with the default settings.)