### PR TITLE
[ep1 cuda eemm] Make Makefiles more installation independent.

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -1,33 +1,53 @@
-LIBDIR =../../lib
-INCDIRS=-I. -I../../src -I../../../../../tools/
-MODELLIB=model_sm
-CXXFLAGS= -O3 -std=c++11 $(INCDIRS) $(USE_NVTX) -Wall -Wshadow ${MGONGPU_CONFIG}
-LIBFLAGS= -L$(LIBDIR) -l$(MODELLIB)
-CXX=g++
-NVCC?=$(shell which nvcc)
-ifeq (, $(NVCC))
-	NVCC=@echo No nvcc to run nvcc
-else
-	USE_NVTX?=-DUSE_NVTX
-	CUARCHNUM=70
-	#CUARCHNUM=61 #(For Pascal Architecture Cards)
-	CUINC=-I/usr/local/cuda/targets/x86_64-linux/include
-	CULIBFLAGS= -L/usr/local/cuda/targets/x86_64-linux/lib -lcurand
-	CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
-	# CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
-	CUFLAGS= -O3 $(INCDIRS) $(USE_NVTX) $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
-	# Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
-	###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
-	###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)
-	###CUFLAGS+= --maxrregcount 96 # degrades throughput: 4.1E8 (16384 32 12) up to 4.5E8 (65536 128 12)
-	###CUFLAGS+= --maxrregcount 64 # degrades throughput: 1.7E8 (16384 32 12) flat at 1.7E8 (65536 128 12)
+LIBDIR   = ../../lib
+TOOLSDIR = ../../../../../tools/
+INCFLAGS = -I. -I../../src -I$(TOOLSDIR)
+MODELLIB = model_sm
+OPTFLAGS = -O3
+CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow $(MGONGPU_CONFIG)
+LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
+CXX     ?= g++
+
+#Export CUDA_HOME to select a cuda installation
+ifndef CUDA_HOME
+  NVCC ?= $(shell which nvcc 2>/dev/null)
+  ifneq ($(NVCC),)
+    # NVCC is in the PATH or set explicitly
+    CUDA_HOME  = $(patsubst %bin/nvcc,%,$(NVCC))
+    CUDA_HOME := $(warning No CUDA_HOME exported. Using "$(CUDA_HOME)") $(CUDA_HOME)
+  endif
 endif
+
+ifdef CUDA_HOME
+  NVCC = $(CUDA_HOME)/bin/nvcc
+  CUARCHNUM=70
+  #CUARCHNUM=61 #(For Pascal Architecture Cards)
+  USE_NVTX?=-DUSE_NVTX
+  CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
+  # CUARCHFLAGS= -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
+  CUINC       = -I$(CUDA_HOME)/include/
+  CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcuda -lcurand
+  CUFLAGS= $(OPTFLAGS) -std=c++14 $(INCFLAGS) $(CUINC) $(USE_NVTX) $(CUARCHFLAGS) -use_fast_math -lineinfo $(MGONGPU_CONFIG)
+  # Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)
+  ###CUFLAGS+= --maxrregcount 160 # improves throughput: 6.9E8 (16384 32 12) up to 7.7E8 (65536 128 12)
+  ###CUFLAGS+= --maxrregcount 128 # improves throughput: 7.3E8 (16384 32 12) up to 7.6E8 (65536 128 12)
+  ###CUFLAGS+= --maxrregcount 96 # degrades throughput: 4.1E8 (16384 32 12) up to 4.5E8 (65536 128 12)
+  ###CUFLAGS+= --maxrregcount 64 # degrades throughput: 1.7E8 (16384 32 12) flat at 1.7E8 (65536 128 12)
+
+  cu_main     = gcheck.exe
+  cu_objects  = gCPPProcess.o
+else
+  # No cuda. Switch cuda compilation off and go to common random numbers in C++
+  NVCC       := $(warning No cuda found. Export CUDA_HOME to compile with cuda)
+  USE_NVTX   :=
+  CULIBFLAGS :=
+  ifndef MGONGPU_CONFIG
+    export MGONGPU_CONFIG = -DMGONGPU_COMMONRAND_ONHOST
+  endif
+endif
+
 MAKEDEBUG=
 
-cu_main=gcheck.exe
 cxx_main=check.exe
-
-cu_objects=gCPPProcess.o gcheck.o
 cxx_objects=CPPProcess.o
 
 # Assuming uname is available, detect if architecture is power
@@ -36,21 +56,16 @@ ifeq ($(UNAME_P),ppc64le)
     CUFLAGS+= -Xcompiler -mno-float128
 endif
 
-all:
-	cd ../../src && make
-	make $(cu_main)
-	make $(cxx_main)
+all: ../../src $(cu_main) $(cxx_main)
 
-debug: CXXFLAGS:=$(filter-out -O3,$(CXXFLAGS))
-debug: CXXFLAGS += -g -O0 -DDEBUG2
-debug: CUFLAGS:=$(filter-out -lineinfo,$(CUFLAGS))
-debug: CUFLAGS:=$(filter-out -O3,$(CUFLAGS))
-debug: CUFLAGS += -g -G
+debug: OPTFLAGS = -g -O0 -DDEBUG2
+debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
+debug: CUFLAGS += -G
 debug: MAKEDEBUG := debug
-debug: $(cu_main) $(cxx_main)
+debug: all
 
 $(LIBDIR)/lib$(MODELLIB).a:
-	@cd ../../src && make $(MAKEDEBUG)
+	$(MAKE) -C ../../src $(MAKEDEBUG)
 
 gcheck.o: gcheck.cu *.h ../../src/*.h ../../src/*.cu
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
@@ -61,16 +76,16 @@ gcheck.o: gcheck.cu *.h ../../src/*.h ../../src/*.cu
 %.o : %.cc *.h ../../src/*.h
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CUINC) -c $< -o $@
 
-$(cu_main): $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
-	$(NVCC) -o $@ $(cu_objects) $(LIBFLAGS) $(CUARCHFLAGS) -lcuda -lcurand
+$(cu_main): gcheck.o $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
+	$(NVCC) $< -o $@ $(cu_objects) $(CUARCHFLAGS) $(LIBFLAGS) $(CULIBFLAGS)
 
-$(cxx_main): $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) check.o
-	$(CXX) -o $@ $(cxx_objects) check.o -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+$(cxx_main): check.o $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects)
+	$(CXX) $< -o $@ $(cxx_objects) $(CPPFLAGS) $(CXXFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 
 .PHONY: clean
 
 clean:
-	cd ../../src && make clean
+	make -C ../../src clean
 	rm -f *.o *.exe
 
 memcheck: $(cu_main)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -98,6 +98,13 @@ perf: force
 test: force
 	./gcheck.exe -v 1 32 1
 
+info:
+ifdef CUDA_HOME
+	$(NVCC) --version
+	echo ""
+endif
+	$(CXX) --version
+
 force:
 
 #Allowed values for this option: 'compute_30', 'compute_32', 'compute_35', 'compute_37', 'compute_50', 'compute_52', 'compute_53', 'compute_60', 'compute_61', 'compute_62', 'compute_70', 'compute_72', 'compute_75', 'sm_30', 'sm_32', 'sm_35', 'sm_37', 'sm_50', 'sm_52', 'sm_53', 'sm_60', 'sm_61', 'sm_62', 'sm_70', 'sm_72', 'sm_75'.

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -1,12 +1,23 @@
-CUARCHNUM=70
-LIBDIR=../lib
-CXXFLAGS= -O3 -I. -DUSE_NVTX -Wall -Wshadow ${MGONGPU_CONFIG}
-###CXXFLAGS= -O2 -I. -DUSE_NVTX -Wall -Wshadow 
-CUARCHFLAGS= -arch=compute_$(CUARCHNUM)
-CUFLAGS= -O3 -I. -DUSE_NVTX $(CUARCHFLAGS) -use_fast_math -lineinfo ${MGONGPU_CONFIG}
-CUINC=/usr/local/cuda/targets/x86_64-linux/include
-NVCC=nvcc
-CXX=g++
+INCFLAGS = -I.
+OPTFLAGS = -O3
+CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow $(MGONGPU_CONFIG)
+LIBDIR   = ../lib
+LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
+CXX     ?= g++
+
+#Export CUDA_HOME to select a cuda installation
+ifndef CUDA_HOME
+  NVCC ?= $(shell which nvcc 2>/dev/null)
+  ifneq ($(NVCC),)
+    # NVCC is in the PATH or set explicitly
+    CUDA_HOME  = $(patsubst %bin/nvcc,%,$(NVCC))
+    CUDA_HOME := $(warning No CUDA_HOME exported. Using "$(CUDA_HOME)") $(CUDA_HOME)
+  endif
+endif
+
+ifdef CUDA_HOME
+  CUINC = -I$(CUDA_HOME)/include/
+endif
 
 # Assuming uname is available, detect if architecture is power
 UNAME_P := $(shell uname -p)
@@ -20,15 +31,14 @@ cu_objects= # NB grambo.cu must be included by gcheck.cu (no rdc)
 
 all: $(target)
 
-debug: CXXFLAGS:=$(filter-out -O3,$(CXXFLAGS))
-debug: CUFLAGS:=$(filter-out -lineinfo,$(CUFLAGS))
-debug: CXXFLAGS += -g -O0 -DDEBUG2
+debug: OPTFLAGS = -g -O0 -DDEBUG2
+debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
 debug: CUFLAGS += -G
 debug: $(target)
 
 # NB: cuda includes are needed in the C++ code for curand.h
 %.o : %.cc *.h
-	$(CXX)  $(CPPFLAGS) $(CXXFLAGS) -I$(CUINC) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CUINC) -c $< -o $@
 
 #%.o : %.cu *.h
 #	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@


### PR DESCRIPTION
Reorganise Makefiles to prepare it for addition of tests.
(This version of the makefile runs already in #52, but took here a separate PR for easier reviewing).

- Remove hard-coded CUDA paths. Instead, react to CUDA_HOME if exported.
- Replace "cd xxx && make" by the more standard "make -C".
- If no nvcc is found and no MGONGPU_CONFIG is given, automatically switch to C++ random numbers.
This allows for compiling the CPU-only code.
- Separate optimisation flags from other C++ flags. This facilitates
switching between debug and optimised builds, because only one variable needs to be overwritten.
- Protect all cuda-related variables with a conditional, so the
corresponding targets don't get built.

Fixes #55.