### PR TITLE
Fix race condition in omp parallel for

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -3,7 +3,8 @@ TOOLSDIR = ../../../../../tools
 INCFLAGS = -I. -I../../src -I$(TOOLSDIR)
 MODELLIB = model_sm
 OPTFLAGS = -O3
-CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow -Wextra -fopenmp $(MGONGPU_CONFIG)
+OMPFLAGS?= -fopenmp
+CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow -Wextra $(OMPFLAGS) $(MGONGPU_CONFIG)
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
 CXX     ?= g++
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -703,7 +703,11 @@ namespace Proc
 
 #ifndef __CUDACC__
     // ** START LOOP ON IEVT **
-#pragma omp parallel for
+    // - default(none): No variables are shared by default
+    // - shared(...): As the name says
+    // - firstprivate: give each thread its own copy, and initialise with value from outside
+    // This means that each thread computes its own good helicity states. Before, this was implicitly shared, i.e. race condition.
+#pragma omp parallel for default(none) shared(allmomenta, allMEs) firstprivate(sigmakin_itry, sigmakin_goodhel, nevt)
     for (int ievt = 0; ievt < nevt; ++ievt)
 #endif
     {

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <cstdlib>

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -1,6 +1,7 @@
 INCFLAGS = -I.
 OPTFLAGS = -O3
-CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow -Wextra -fopenmp $(MGONGPU_CONFIG)
+OMPFLAGS?= -fopenmp
+CXXFLAGS = $(OPTFLAGS) -std=c++11 $(INCFLAGS) $(USE_NVTX) -Wall -Wshadow -Wextra $(OMPFLAGS) $(MGONGPU_CONFIG)
 LIBDIR   = ../lib
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
 CXX     ?= g++


### PR DESCRIPTION
- Fix #103, race condition in parallel for
- Fix missing include
- Fix compilation with clang.

**Note**:
Although this fixes a race condition, we can potentially still get different results in dependence of number of threads, namely if analysing events 0-9 and computing good helicities will give a different result than analysing events 100-109, for example.
I think that the physics should be robust against that, but I'm not 100% sure.

That's probably not a problem, though, since when starting 2 madgraph processes with different random numbers, you are in the same situation: Helicities get computed from different events.