### PR TITLE
Fix 'make distclean' - the second 'make distclean fails

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,4 +19,4 @@ gtest: googletest/build
 
 clean:
 	rm -rf googletest
-	rm src/*.o
+	rm -f src/*.o


### PR DESCRIPTION
Minor issue: 'make distclean' fails if called twice in a row