### PR TITLE
Dump the gcc and nvcc version

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -640,18 +640,24 @@ namespace Proc
   //--------------------------------------------------------------------------
 
   // Retrieve the compiler that was used to build this module
-#ifndef __CUDACC__
   const std::string CPPProcess::getCompiler()
   {
     std::stringstream out;
+#ifdef __CUDACC__
+#if defined __CUDACC_VER_MAJOR__ && defined __CUDACC_VER_MINOR__ && defined __CUDACC_VER_BUILD__
+    out << "nvcc " << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__ << "." << __CUDACC_VER_BUILD__;
+#else
+    out << "nvcc UNKNOWN";
+#endif
+#else
 #if defined __GNUC__ && defined __GNUC_MINOR__ && defined __GNUC_PATCHLEVEL__
     out << "gcc (GCC) " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
 #else
-    out << "UNKNOWKN";
+    out << "gcc UNKNOWKN";
+#endif
 #endif
     return out.str();
   }
-#endif
 
   //--------------------------------------------------------------------------
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -30,7 +30,7 @@ namespace MG5_sm
                                      const int ievt )
   {
     //mapping for the various scheme AOS, OSA, ...
-    
+
     using mgOnGpu::np4;
     using mgOnGpu::npar;
     const int neppM = mgOnGpu::neppM; // ASA layout: constant at compile-time
@@ -636,6 +636,22 @@ namespace Proc
     //std::cout << std::setprecision(17) << "tIPD[0] = " << tIPD[0] << std::endl;
     //std::cout << std::setprecision(17) << "tIPD[1] = " << tIPD[1] << std::endl;
   }
+
+  //--------------------------------------------------------------------------
+
+  // Retrieve the compiler that was used to build this module
+#ifndef __CUDACC__
+  const std::string CPPProcess::getCompiler()
+  {
+    std::stringstream out;
+#if defined __GNUC__ && defined __GNUC_MINOR__ && defined __GNUC_PATCHLEVEL__
+    out << "gcc (GCC) " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+#else
+    out << "UNKNOWKN";
+#endif
+    return out.str();
+  }
+#endif
 
   //--------------------------------------------------------------------------
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
@@ -82,9 +82,7 @@ namespace Proc
     //static const int nprocesses = 1; // FIXME: assume process.nprocesses == 1
 
     // Retrieve the compiler that was used to build this module
-#ifndef __CUDACC__
     static const std::string getCompiler();
-#endif
 
   private:
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
@@ -81,6 +81,11 @@ namespace Proc
     static const int nexternal = mgOnGpu::npar;
     //static const int nprocesses = 1; // FIXME: assume process.nprocesses == 1
 
+    // Retrieve the compiler that was used to build this module
+#ifndef __CUDACC__
+    static const std::string getCompiler();
+#endif
+
   private:
 
     int m_numiterations;

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -646,8 +646,8 @@ int main(int argc, char **argv)
               << "Random number generation    = CURAND (C++ code)" << std::endl
 #endif
               << "OMP threads / `nproc --all` = " << omp_get_max_threads() << " / " << nprocall // includes a newline
-              << "MatrixElements compiler     = " << process.getCompiler() << std::endl
 #endif
+              << "MatrixElements compiler     = " << process.getCompiler() << std::endl
               << "-----------------------------------------------------------------------" << std::endl
               << "NumberOfEntries             = " << niter << std::endl
               << std::scientific // fixed format: affects all floats (default precision: 6)

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -646,6 +646,7 @@ int main(int argc, char **argv)
               << "Random number generation    = CURAND (C++ code)" << std::endl
 #endif
               << "OMP threads / `nproc --all` = " << omp_get_max_threads() << " / " << nprocall // includes a newline
+              << "MatrixElements compiler     = " << process.getCompiler() << std::endl
 #endif
               << "-----------------------------------------------------------------------" << std::endl
               << "NumberOfEntries             = " << niter << std::endl


### PR DESCRIPTION
A minor patch to dump the gcc and nvcc version of the ME calculation module.
Note that there is a factor 2 in the C++ between gcc8 and gcc9.