### PR TITLE
Enable C++-only builds on a system which does have nvcc

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -21,7 +21,7 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifdef CUDA_HOME
+ifneq ($(wildcard $(CUDA_HOME)/.),)
   NVCC = $(CUDA_HOME)/bin/nvcc
   CUARCHNUM=70
   #CUARCHNUM=61 #(For Pascal Architecture Cards)
@@ -42,7 +42,7 @@ ifdef CUDA_HOME
   cu_objects  = gCPPProcess.o
 else
   # No cuda. Switch cuda compilation off and go to common random numbers in C++
-  NVCC       := $(warning No cuda found. Export CUDA_HOME to compile with cuda)
+  NVCC       := $(warning CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda)
   USE_NVTX   :=
   CULIBFLAGS :=
   ifndef MGONGPU_CONFIG
@@ -133,7 +133,7 @@ test: force
 	./gcheck.exe -v 1 32 1
 
 info:
-ifdef CUDA_HOME
+ifneq ($(wildcard $(CUDA_HOME)/.),)
 	$(NVCC) --version
 	@echo ""
 endif

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -21,7 +21,7 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifneq ($(wildcard $(CUDA_HOME)/.),)
+ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   NVCC = $(CUDA_HOME)/bin/nvcc
   CUARCHNUM=70
   #CUARCHNUM=61 #(For Pascal Architecture Cards)
@@ -133,7 +133,7 @@ test: force
 	./gcheck.exe -v 1 32 1
 
 info:
-ifneq ($(wildcard $(CUDA_HOME)/.),)
+ifneq ($(NVCC),)
 	$(NVCC) --version
 	@echo ""
 endif

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -8,7 +8,7 @@ LIBDIR   = ../lib
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
 CXX     ?= g++
 
-#Export CUDA_HOME to select a cuda installation
+# If CUDA_HOME is not set, try to set it from the location of nvcc
 ifndef CUDA_HOME
   NVCC ?= $(shell which nvcc 2>/dev/null)
   ifneq ($(NVCC),)
@@ -18,7 +18,7 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifneq ($(wildcard $(CUDA_HOME)/.),)
+ifeq ($(NVCC),)
   CUINC = -I$(CUDA_HOME)/include
 endif
 

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -18,8 +18,8 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifdef CUDA_HOME
-  CUINC = -I$(CUDA_HOME)/include/
+ifneq ($(wildcard $(CUDA_HOME)/.),)
+  CUINC = -I$(CUDA_HOME)/include
 endif
 
 # Assuming uname is available, detect if architecture is power
@@ -35,8 +35,8 @@ cu_objects= # NB grambo.cu must be included by gcheck.cu (no rdc)
 all: $(target)
 
 debug: OPTFLAGS = -g -O0 -DDEBUG2
-debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
-debug: CUFLAGS += -G
+#debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
+#debug: CUFLAGS += -G
 debug: $(target)
 
 # NB: cuda includes are needed in the C++ code for curand.h
@@ -46,9 +46,9 @@ debug: $(target)
 #%.o : %.cu *.h
 #	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
-$(target): $(cxx_objects) $(cu_objects)
-	if [ ! -d $(LIBDIR) ]; then mkdir $(LIBDIR); fi
-	$(AR) cru $@ $(cxx_objects) $(cu_objects)
+$(target): $(cxx_objects) #$(cu_objects)
+	if [ ! -d $(LIBDIR) ]; then mkdir -p $(LIBDIR); fi
+	$(AR) cru $@ $(cxx_objects) #$(cu_objects)
 	ranlib $(target)
 
 .PHONY: clean


### PR DESCRIPTION
Enable C++-only builds on a systema which does have nvcc

It is enough to "export CUDA_HOME=invalid" and only the C++ will be built
This enables emulating the CI tests