### PR TITLE
Minimal changes to add clang support

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -97,13 +97,21 @@ runTest.exe: LIBFLAGS += -L$(GTESTLIBDIR)/ -lgtest -lgtest_main
 runTest.exe: runTest.o $(TESTDIR)/src/MadgraphTest.o $(TESTDIR)/include/*.h
 runTest.exe: cxx_objects += runTest.o $(TESTDIR)/src/MadgraphTest.o
 runTest.exe: cu_objects  += runTest_cu.o
+ifneq ($(findstring clang++,$(CXX)),)
+runTest.exe: LIBFLAGS += -L$(patsubst %bin/clang++,%lib,$(CXX))
+endif
+
 ifeq ($(NVCC),)
 runTest.exe: $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(GTESTLIBS)
 	$(CXX) -o $@ $(cxx_objects) $(CPPFLAGS) $(CXXFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 else
 runTest.exe runTest_cu.o &: runTest.cc $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(cu_objects) $(GTESTLIBS)
 	$(NVCC) -o runTest_cu.o -c -x cu runTest.cc $(CPPFLAGS) $(CUFLAGS)
+ifneq ($(findstring clang++,$(CXX)),)
+	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) $(CPPFLAGS) $(CUFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lomp
+else
 	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) $(CPPFLAGS) $(CUFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lgomp
+endif
 endif
 
 $(GTESTLIBS):

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -107,11 +107,7 @@ runTest.exe: $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(GTESTLIBS)
 else
 runTest.exe runTest_cu.o &: runTest.cc $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(cu_objects) $(GTESTLIBS)
 	$(NVCC) -o runTest_cu.o -c -x cu runTest.cc $(CPPFLAGS) $(CUFLAGS)
-ifneq ($(findstring clang++,$(CXX)),)
-	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) $(CPPFLAGS) $(CUFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lomp
-else
 	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) $(CPPFLAGS) $(CUFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lgomp
-endif
 endif
 
 $(GTESTLIBS):

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -557,15 +557,15 @@ namespace Proc
 
   //--------------------------------------------------------------------------
 
-  CPPProcess::CPPProcess( int numiterations,
+  CPPProcess::CPPProcess( int /*numiterations*/,
                           int gpublocks,
                           int gputhreads,
                           bool verbose )
-    : m_numiterations( numiterations )
-    , gpu_nblocks( gpublocks )
-    , gpu_nthreads( gputhreads )
-    , dim( gpu_nblocks * gpu_nthreads )
-    , m_verbose( verbose )
+    : //m_numiterations( numiterations ), 
+      gpu_nblocks( gpublocks ), 
+      gpu_nthreads( gputhreads ), 
+      dim( gpu_nblocks * gpu_nthreads ), 
+      m_verbose( verbose )
   {
 #ifdef __CUDACC__
     // Helicities for the process - nodim

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
@@ -100,7 +100,7 @@ namespace Proc
     static const int ncomb = 16;
     static const int wrows = 6;
 
-    cxtype** amp;
+    //cxtype** amp;
 
     // Pointer to the model parameters
     Parameters_sm * pars;

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.h
@@ -86,7 +86,7 @@ namespace Proc
 
   private:
 
-    int m_numiterations;
+    //int m_numiterations;
 
     // gpu variables
     int gpu_nblocks;


### PR DESCRIPTION
This patch fixes two build warnings (unused variables) and especially a link error for runTest.exe.
```
/cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/bin/clang++  -O3  -std=c++11 -I. -I../../src -I../../../../../tools -DUSE_NVTX -Wall -Wshadow -Wextra -fopenmp  -ffast-math  -I/usr/local/cuda-11.0/include/ -c CPPProcess.cc -o CPPProcess.o
In file included from CPPProcess.cc:444:
./CPPProcess.h:89:9: warning: private field 'm_numiterations' is not used [-Wunused-private-field]
    int m_numiterations;
        ^
./CPPProcess.h:103:14: warning: private field 'amp' is not used [-Wunused-private-field]
    cxtype** amp;
             ^
2 warnings generated.
/cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/bin/clang++ check.o -o check.exe CPPProcess.o  -O3  -std=c++11 -I. -I../../src -I../../../../../tools -DUSE_NVTX -Wall -Wshadow -Wextra -fopenmp  -ffast-math  -ldl -pthread -L../../lib -lmodel_sm -L/usr/local/cuda-11.0/lib64/ -lcuda -lcurand
/cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/bin/clang++  -O3  -std=c++11 -I. -I../../src -I../../../../../tools -I../../../../../test/googletest/googletest/include/ -I../../../../../test/include/ -DUSE_NVTX -Wall -Wshadow -Wextra -fopenmp  -ffast-math  -I/usr/local/cuda-11.0/include/ -c runTest.cc -o runTest.o
/cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/bin/clang++  -O3  -std=c++11 -I. -I../../src -I../../../../../tools -I../../../../../test/googletest/googletest/include/ -I../../../../../test/include/ -DUSE_NVTX -Wall -Wshadow -Wextra -fopenmp  -ffast-math  -I/usr/local/cuda-11.0/include/ -c ../../../../../test/src/MadgraphTest.cc -o ../../../../../test/src/MadgraphTest.o
/usr/local/cuda-11.0/bin/nvcc -o runTest_cu.o -c -x cu runTest.cc  -O3  -lineinfo -std=c++14 -I. -I../../src -I../../../../../tools -I../../../../../test/googletest/googletest/include/ -I../../../../../test/include/ -I/usr/local/cuda-11.0/include/ -DUSE_NVTX -arch=compute_70 -use_fast_math 
/usr/local/cuda-11.0/bin/nvcc -o runTest.exe CPPProcess.o runTest.o ../../../../../test/src/MadgraphTest.o gCPPProcess.o runTest_cu.o  -O3  -lineinfo -std=c++14 -I. -I../../src -I../../../../../tools -I../../../../../test/googletest/googletest/include/ -I../../../../../test/include/ -I/usr/local/cuda-11.0/include/ -DUSE_NVTX -arch=compute_70 -use_fast_math  -ldl -L../../lib -lmodel_sm -L../../../../../test/googletest/build/lib// -lgtest -lgtest_main -L/usr/local/cuda-11.0/lib64/ -lcuda -lcurand -lcuda -lgomp
CPPProcess.o: In function `Proc::sigmaKin(double const*, double*, int)':
CPPProcess.cc:(.text+0x29df): undefined reference to `__kmpc_fork_call'
CPPProcess.o: In function `.omp_outlined.':
CPPProcess.cc:(.text+0x2a69): undefined reference to `__kmpc_for_static_init_4'
CPPProcess.cc:(.text+0x2a93): undefined reference to `__kmpc_for_static_fini'
collect2: error: ld returned 1 exit status
make: *** [runTest.exe] Error 1
```

To solve the link error, the fix is to add the clang library via -L explicitly.

Initially I had also used -lomp instead of -lgomp: later on, however, I realised that -lgomp could be used also for clang, as libgomp.so is a symlink to libomp.so (in all clang installations I found on SFT cvmfs):
```
ls -l /cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/lib/libgomp.so 
lrwxrwxrwx. 1 cvmfs cvmfs 9 Apr  3  2020 /cvmfs/sft.cern.ch/lcg/releases/clang/10.0.0-62e61/x86_64-centos7/lib/libgomp.so -> libomp.so*
```
