### PR TITLE
Makeinfo

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,6 +14,8 @@ jobs:
         working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
     steps:
     - uses: actions/checkout@v2
+    - name: make info
+      run: make info
     - name: make
       run: make
     - name: make check
@@ -33,6 +35,8 @@ jobs:
         working-directory: epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
     steps:
     - uses: actions/checkout@v2
+    - name: make info
+      run: make info
     - name: make
       run: make
     - name: make check
@@ -44,6 +48,8 @@ jobs:
         working-directory: epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
     steps:
     - uses: actions/checkout@v2
+    - name: make info
+      run: make info
     - name: make
       run: make
     - name: make check

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -137,6 +137,12 @@ test: force
 	./gcheck.exe -v 1 32 1
 
 info:
+	@hostname
+	@cat /proc/cpuinfo | grep "model name" | sort -u
+	@cat /proc/cpuinfo | grep "flags" | sort -u
+	@cat /proc/cpuinfo | grep "cpu cores" | sort -u
+	@cat /proc/cpuinfo | grep "physical id" | sort -u
+	@echo ""
 ifneq ($(NVCC),)
 	$(NVCC) --version
 	@echo ""


### PR DESCRIPTION
Add 'make info' to the github CI. Add host information to 'make info' in epoch1. 

This is useful to debug issues in vectorization. I had avx512 builds by default, but I was getting these errors
https://github.com/madgraph5/madgraph4gpu/pull/132/checks?check_run_id=2173809398
```
Run make check
Makefile:64: CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda
build.avx512/runTest.exe
make: *** [Makefile:136: check] Illegal instruction (core dumped)
Error: Process completed with exit code 2.
```

I fixed this by using avx2 by default if the Makefile finds that avx512 is not supported, but I want to debug further related issues.

Also, its useful to print th envcc and gcc versionof the CI.

I am extracting these commits out of the klas barnch as a standalone PR