### PR TITLE
[epoch2] Enable C++-only builds on a system which does not have nvcc

### DIFF
--- a/epoch2/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch2/cuda/ee_mumu/SubProcesses/Makefile
@@ -1,6 +1,6 @@
 LIBDIR   = ../../lib
-TOOLSDIR = ../../../../../tools/
-TESTDIR  = ../../../../../test/
+TOOLSDIR = ../../../../../tools
+TESTDIR  = ../../../../../test
 INCFLAGS = -I. -I../../src -I$(TOOLSDIR)
 MODELLIB = model_sm
 OPTFLAGS = -O3
@@ -18,7 +18,7 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifdef CUDA_HOME
+ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   NVCC = $(CUDA_HOME)/bin/nvcc
   CUARCHNUM=70
   USE_NVTX?=-DUSE_NVTX
@@ -32,7 +32,7 @@ ifdef CUDA_HOME
   cu_objects  = gCPPProcess.o
 else
   # No cuda. Switch cuda compilation off and go to common random numbers in C++
-  NVCC       := $(warning No cuda found. Export CUDA_HOME to compile with cuda)
+  NVCC       := $(warning CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda)
   USE_NVTX   :=
   CULIBFLAGS :=
   ifndef MGONGPU_CONFIG
@@ -123,7 +123,7 @@ test: force
 	./gcheck.exe -v 1 32 1
 
 info:
-ifdef CUDA_HOME
+ifneq ($(NVCC),)
 	$(NVCC) --version
 	@echo ""
 endif

--- a/epoch2/cuda/ee_mumu/src/Makefile
+++ b/epoch2/cuda/ee_mumu/src/Makefile
@@ -15,10 +15,9 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifeq ($(NVCC),)
+ifneq ($(NVCC),)
   CUINC = -I$(CUDA_HOME)/include
 endif
-
 
 # Assuming uname is available, detect if architecture is power
 UNAME_P := $(shell uname -p)

--- a/epoch2/cuda/ee_mumu/src/Makefile
+++ b/epoch2/cuda/ee_mumu/src/Makefile
@@ -5,7 +5,7 @@ LIBDIR   = ../lib
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
 CXX     ?= g++
 
-#Export CUDA_HOME to select a cuda installation
+# If CUDA_HOME is not set, try to set it from the location of nvcc
 ifndef CUDA_HOME
   NVCC ?= $(shell which nvcc 2>/dev/null)
   ifneq ($(NVCC),)
@@ -15,8 +15,8 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifdef CUDA_HOME
-  CUINC = -I$(CUDA_HOME)/include/
+ifeq ($(NVCC),)
+  CUINC = -I$(CUDA_HOME)/include
 endif
 
 
@@ -33,8 +33,8 @@ cu_objects= # NB grambo.cu must be included by gcheck.cu (no rdc)
 all: $(target)
 
 debug: OPTFLAGS = -g -O0 -DDEBUG2
-debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
-debug: CUFLAGS += -G
+#debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))
+#debug: CUFLAGS += -G
 debug: $(target)
 
 # NB: cuda includes are needed in the C++ code for curand.h
@@ -44,9 +44,9 @@ debug: $(target)
 #%.o : %.cu *.h
 #	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
-$(target): $(cxx_objects) $(cu_objects)
-	if [ ! -d $(LIBDIR) ]; then mkdir $(LIBDIR); fi
-	$(AR) cru $@ $(cxx_objects) $(cu_objects)
+$(target): $(cxx_objects) #$(cu_objects)
+	if [ ! -d $(LIBDIR) ]; then mkdir -p $(LIBDIR); fi
+	$(AR) cru $@ $(cxx_objects) #$(cu_objects)
 	ranlib $(target)
 
 .PHONY: clean


### PR DESCRIPTION
This is the same for epoch2 as PR #133 was for epoch1

It is needed to fix the CI test failure in the initial PR #140 version