### PR TITLE
[ggttgg ep2] Workaround: disable test builds

### DIFF
--- a/epoch2/cuda/gg_ttgg/SubProcesses/Makefile
+++ b/epoch2/cuda/gg_ttgg/SubProcesses/Makefile
@@ -51,7 +51,7 @@ ifeq ($(UNAME_P),ppc64le)
     CUFLAGS+= -Xcompiler -mno-float128
 endif
 
-all: ../../src $(cu_main) $(cxx_main) runTest.exe
+all: ../../src $(cu_main) $(cxx_main) #runTest.exe
 
 debug: OPTFLAGS = -g -O0 -DDEBUG2
 debug: CUFLAGS := $(filter-out -lineinfo,$(CUFLAGS))


### PR DESCRIPTION
This is a minimal change to allow that the code runs out of the box for Carl Vuosalo's team.

Anyway epoch2 was already running out of the box.. not bad!

PS This fixes the build issue that was there before (not sure why it was [saying it was?] removing googletest?)
```
make[1]: Entering directory `/afs/cern.ch/user/a/avalassi/GPU2020/madgraph4gpuTer/tools'
rm -rf googletest
make[1]: Leaving directory `/afs/cern.ch/user/a/avalassi/GPU2020/madgraph4gpuTer/tools'
make -C ../../../../../tools/
make[1]: Entering directory `/afs/cern.ch/user/a/avalassi/GPU2020/madgraph4gpuTer/tools'
rm -rf googletest
make[1]: Leaving directory `/afs/cern.ch/user/a/avalassi/GPU2020/madgraph4gpuTer/tools'
/cvmfs/sft.cern.ch/lcg/releases/gcc/9.2.0-afc57/x86_64-centos7/bin/g++  -O3 -std=c++11 -I. -I../../src -I../../../../../tools/ -I../../../../../tools//googletest/googletest/include/ -DUSE_NVTX -Wall -Wshadow  -I/usr/local/cuda-11.0/include/ -c runTest.cc -o runTest.o
runTest.cc:24:10: fatal error: gtest/gtest.h: No such file or directory
   24 | #include <gtest/gtest.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make: *** [runTest.o] Error 1
```