### PR TITLE
[tests] Add epoch1_eemumu_GPU and use gcc9 in the CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -49,11 +49,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make info
-      run: make info
+      run: source /opt/rh/gcc-toolset-9/enable; make info
     - name: make
-      run: make
+      run: source /opt/rh/gcc-toolset-9/enable; make
     - name: make check
-      run: make check
+      run: source /opt/rh/gcc-toolset-9/enable; make check
   epoch2_eemumu_GPU:
     runs-on: self-hosted
     defaults:
@@ -62,8 +62,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make info
-      run: make info
+      run: source /opt/rh/gcc-toolset-9/enable; make info
     - name: make
-      run: make
+      run: source /opt/rh/gcc-toolset-9/enable; make
     - name: make check
-      run: make check
+      run: source /opt/rh/gcc-toolset-9/enable; make check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,6 +7,14 @@ on:
     branches: [ master ]
 
 jobs:
+  debug_builds:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: make epoch1
+      run: make -C epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
+    - name: make epoch2
+      run: make -C epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
   epoch1_eemumu:
     runs-on: ubuntu-latest
     defaults:
@@ -20,19 +28,24 @@ jobs:
       run: make
     - name: make check
       run: make check
-  debug_builds:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: make epoch1
-      run: make -C epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
-    - name: make epoch2
-      run: make -C epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
   epoch2_eemumu:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
+    steps:
+    - uses: actions/checkout@v2
+    - name: make info
+      run: make info
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+  epoch1_eemumu_GPU:
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
     steps:
     - uses: actions/checkout@v2
     - name: make info

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -18,14 +18,15 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifeq ($(NVCC),)
-  CUINC = -I$(CUDA_HOME)/include
+ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
+  NVCC = $(CUDA_HOME)/bin/nvcc
+  CUINC = -I$(CUDA_HOME)/include/
 endif
 
 # Assuming uname is available, detect if architecture is power
 UNAME_P := $(shell uname -p)
 ifeq ($(UNAME_P),ppc64le)
-    CUFLAGS+= -Xcompiler -mno-float128
+  CUFLAGS+= -Xcompiler -mno-float128
 endif
 
 target=$(LIBDIR)/libmodel_sm.a

--- a/epoch2/cuda/ee_mumu/src/Makefile
+++ b/epoch2/cuda/ee_mumu/src/Makefile
@@ -15,14 +15,15 @@ ifndef CUDA_HOME
   endif
 endif
 
-ifneq ($(NVCC),)
-  CUINC = -I$(CUDA_HOME)/include
+ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
+  NVCC = $(CUDA_HOME)/bin/nvcc
+  CUINC = -I$(CUDA_HOME)/include/
 endif
 
 # Assuming uname is available, detect if architecture is power
 UNAME_P := $(shell uname -p)
 ifeq ($(UNAME_P),ppc64le)
-    CUFLAGS+= -Xcompiler -mno-float128
+  CUFLAGS+= -Xcompiler -mno-float128
 endif
 
 target=$(LIBDIR)/libmodel_sm.a


### PR DESCRIPTION
This is related to issue #139: once I merge epoch2 into epoch1, the latter will be my main reference. However only epoch2 is tested on the GPU so far. Here I am adding epoch1 to GPU tests too.

This probably depends on issue #138 being fixed. I think we need gcc9 to build (not sure if immediately or only when vectorization is there). I will open this as a WIP PR so that the CI can get tested.
