### PR TITLE
Clarify issues with cxtype_ref on gcc/clang + Test clang11.1 and clang12.0

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -14,16 +14,12 @@ CXX     ?= g++
 # AVX choice (example: "make AVX=none")
 ifneq ($(AVX),)
 ###$(info Using AVX='$(AVX)' according to user input)
-else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo)$(shell $(CXX) --version | grep ^clang),1)
+else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 override AVX = 512y
 ###$(info Using AVX='$(AVX)' as no user input exists)
 else
 override AVX = avx2
-ifneq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 $(warning Using AVX='$(AVX)' because host does not support avx512vl)
-else
-$(warning Using AVX='$(AVX)' because this is faster than avx512vl for clang)
-endif
 endif
 ###$(info AVX=$(AVX))
 
@@ -33,9 +29,9 @@ endif
 ifeq ($(AVX),sse4)
 override AVXFLAGS = -march=nehalem # SSE4.2 with 128 width (xmm registers)
 else ifeq ($(AVX),avx2)
-override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers) [DEFAULT for clang]
+override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers)
 else ifeq ($(AVX),512y)
-override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT for gcc]
+override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT]
 else ifeq ($(AVX),512z)
 override AVXFLAGS = -march=skylake-avx512 -DMGONGPU_PVW512 # AVX512 with 512 width (zmm registers)
 else ifneq ($(AVX),none)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -14,12 +14,16 @@ CXX     ?= g++
 # AVX choice (example: "make AVX=none")
 ifneq ($(AVX),)
 ###$(info Using AVX='$(AVX)' according to user input)
-else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
+else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo)$(shell $(CXX) --version | grep ^clang),1)
 override AVX = 512y
 ###$(info Using AVX='$(AVX)' as no user input exists)
 else
 override AVX = avx2
+ifneq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 $(warning Using AVX='$(AVX)' because host does not support avx512vl)
+else
+$(warning Using AVX='$(AVX)' because this is faster than avx512vl for clang)
+endif
 endif
 ###$(info AVX=$(AVX))
 
@@ -29,9 +33,9 @@ endif
 ifeq ($(AVX),sse4)
 override AVXFLAGS = -march=nehalem # SSE4.2 with 128 width (xmm registers)
 else ifeq ($(AVX),avx2)
-override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers)
+override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers) [DEFAULT for clang]
 else ifeq ($(AVX),512y)
-override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT]
+override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT for gcc]
 else ifeq ($(AVX),512z)
 override AVXFLAGS = -march=skylake-avx512 -DMGONGPU_PVW512 # AVX512 with 512 width (zmm registers)
 else ifneq ($(AVX),none)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -11,14 +11,6 @@ CXXFLAGS+= -ffast-math # see issue #117
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
 CXX     ?= g++
 
-# Disable OpenMP for clang 11.0.0 (workaround for SPI-1875)
-# NB: "#ifdef _OPENMP" is valid if -fopenmp is present
-# [No need to also remove -lgomp from cuda runTest: cuda is currently disabled for clang11]
-ifeq ($(shell $(CXX) --version | head -1),clang version 11.0.0)
-override OMPFLAGS=
-$(warning Disabling OpenMP for clang 11.0.0)
-endif
-
 # AVX choice (example: "make AVX=none")
 ifneq ($(AVX),)
 ###$(info Using AVX='$(AVX)' according to user input)

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -49,6 +49,7 @@ popd >& /dev/null
 pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|MeanMatrix|FP precision|TOTAL       :"
 # Optionally add other patterns here for some specific configurations (e.g. clang)
 pattern="${pattern}|CUCOMPLEX"
+pattern="${pattern}|COMMON RANDOM"
 pattern="(${pattern})"
 
 echo -e "\nOn $HOSTNAME:"

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -10,16 +10,12 @@ CXX     ?= g++
 # AVX choice (example: "make AVX=none")
 ifneq ($(AVX),)
 ###$(info Using AVX='$(AVX)' according to user input)
-else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo)$(shell $(CXX) --version | grep ^clang),1)
+else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 override AVX = 512y
 ###$(info Using AVX='$(AVX)' as no user input exists)
 else
 override AVX = avx2
-ifneq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 $(warning Using AVX='$(AVX)' because host does not support avx512vl)
-else
-$(warning Using AVX='$(AVX)' because this is faster than avx512vl for clang)
-endif
 endif
 ###$(info AVX=$(AVX))
 
@@ -29,9 +25,9 @@ endif
 ifeq ($(AVX),sse4)
 override AVXFLAGS = -march=nehalem # SSE4.2 with 128 width (xmm registers)
 else ifeq ($(AVX),avx2)
-override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers) [DEFAULT for clang]
+override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers)
 else ifeq ($(AVX),512y)
-override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT for gcc]
+override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT]
 else ifeq ($(AVX),512z)
 override AVXFLAGS = -march=skylake-avx512 -DMGONGPU_PVW512 # AVX512 with 512 width (zmm registers)
 else ifneq ($(AVX),none)

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -10,12 +10,16 @@ CXX     ?= g++
 # AVX choice (example: "make AVX=none")
 ifneq ($(AVX),)
 ###$(info Using AVX='$(AVX)' according to user input)
-else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
+else ifeq ($(shell grep -m1 -c avx512vl /proc/cpuinfo)$(shell $(CXX) --version | grep ^clang),1)
 override AVX = 512y
 ###$(info Using AVX='$(AVX)' as no user input exists)
 else
 override AVX = avx2
+ifneq ($(shell grep -m1 -c avx512vl /proc/cpuinfo),1)
 $(warning Using AVX='$(AVX)' because host does not support avx512vl)
+else
+$(warning Using AVX='$(AVX)' because this is faster than avx512vl for clang)
+endif
 endif
 ###$(info AVX=$(AVX))
 
@@ -25,9 +29,9 @@ endif
 ifeq ($(AVX),sse4)
 override AVXFLAGS = -march=nehalem # SSE4.2 with 128 width (xmm registers)
 else ifeq ($(AVX),avx2)
-override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers)
+override AVXFLAGS = -march=haswell # AVX2 with 256 width (ymm registers) [DEFAULT for clang]
 else ifeq ($(AVX),512y)
-override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT]
+override AVXFLAGS = -march=skylake-avx512 -mprefer-vector-width=256 # AVX512 with 256 width (ymm registers) [DEFAULT for gcc]
 else ifeq ($(AVX),512z)
 override AVXFLAGS = -march=skylake-avx512 -DMGONGPU_PVW512 # AVX512 with 512 width (zmm registers)
 else ifneq ($(AVX),none)

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
@@ -28,7 +28,8 @@ namespace mgOnGpu
   // If set: return a pair of (fptype&, fptype&) by non-const reference in cxtype_v::operator[]
   // This is forbidden in clang ("non-const reference cannot bind to vector element")
   // See also https://stackoverflow.com/questions/26554829
-#undef MGONGPU_HAS_CXTYPE_REF // clang default
+#define MGONGPU_HAS_CXTYPE_REF 1 // clang test
+  //#undef MGONGPU_HAS_CXTYPE_REF // clang default
 #else
 #define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
   //#undef MGONGPU_HAS_CXTYPE_REF // gcc test (very slightly slower? issue #182)

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
@@ -30,8 +30,8 @@ namespace mgOnGpu
   // See also https://stackoverflow.com/questions/26554829
 #undef MGONGPU_HAS_CXTYPE_REF // clang default
 #else
-  //#define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
-#undef MGONGPU_HAS_CXTYPE_REF // gcc test (issue #182)
+#define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
+  //#undef MGONGPU_HAS_CXTYPE_REF // gcc test (very slightly slower? issue #182)
 #endif
 
 #ifdef MGONGPU_HAS_CXTYPE_REF

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
@@ -30,8 +30,8 @@ namespace mgOnGpu
   // See also https://stackoverflow.com/questions/26554829
 #undef MGONGPU_HAS_CXTYPE_REF // clang default
 #else
-#define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
-  //#undef MGONGPU_HAS_CXTYPE_REF // gcc test
+  //#define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
+#undef MGONGPU_HAS_CXTYPE_REF // gcc test (issue #182)
 #endif
 
 #ifdef MGONGPU_HAS_CXTYPE_REF

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuVectors.h
@@ -28,11 +28,11 @@ namespace mgOnGpu
   // If set: return a pair of (fptype&, fptype&) by non-const reference in cxtype_v::operator[]
   // This is forbidden in clang ("non-const reference cannot bind to vector element")
   // See also https://stackoverflow.com/questions/26554829
-#define MGONGPU_HAS_CXTYPE_REF 1 // clang test
-  //#undef MGONGPU_HAS_CXTYPE_REF // clang default
+  //#define MGONGPU_HAS_CXTYPE_REF 1 // clang test (compilation fails also on clang 12.0, issue #182)
+#undef MGONGPU_HAS_CXTYPE_REF // clang default
 #else
 #define MGONGPU_HAS_CXTYPE_REF 1 // gcc default
-  //#undef MGONGPU_HAS_CXTYPE_REF // gcc test (very slightly slower? issue #182)
+  //#undef MGONGPU_HAS_CXTYPE_REF // gcc test (very slightly slower? issue #172)
 #endif
 
 #ifdef MGONGPU_HAS_CXTYPE_REF

--- a/epoch1/cuda/ee_mumu/src/rambo.cc
+++ b/epoch1/cuda/ee_mumu/src/rambo.cc
@@ -210,7 +210,7 @@ namespace rambo2toNm0
   // Seed a curand generator
   void seedGenerator( curandGenerator_t gen, unsigned long long seed )
   {
-    printf( "seedGenerator: seed %lld\n", seed );
+    //printf( "seedGenerator: seed %lld\n", seed );
     checkCurand( curandSetPseudoRandomGeneratorSeed( gen, seed ) );
   }
 
@@ -236,7 +236,7 @@ namespace rambo2toNm0
 #elif defined MGONGPU_FPTYPE_FLOAT
     checkCurand( curandGenerateUniform( gen, rnarray1d, np4*nparf*nevt ) );
 #endif
-    for ( int i=0; i<8; i++ ) printf( "%f %f %f %f\n", rnarray1d[i*4], rnarray1d[i*4+1], rnarray1d[i*4+2], rnarray1d[i*4+3] );
+    //for ( int i=0; i<8; i++ ) printf( "%f %f %f %f\n", rnarray1d[i*4], rnarray1d[i*4+1], rnarray1d[i*4+2], rnarray1d[i*4+3] );
   }
 
   //--------------------------------------------------------------------------

--- a/epoch1/cuda/ee_mumu/src/rambo.cc
+++ b/epoch1/cuda/ee_mumu/src/rambo.cc
@@ -210,6 +210,7 @@ namespace rambo2toNm0
   // Seed a curand generator
   void seedGenerator( curandGenerator_t gen, unsigned long long seed )
   {
+    printf( "seedGenerator: seed %lld\n", seed );
     checkCurand( curandSetPseudoRandomGeneratorSeed( gen, seed ) );
   }
 
@@ -235,6 +236,7 @@ namespace rambo2toNm0
 #elif defined MGONGPU_FPTYPE_FLOAT
     checkCurand( curandGenerateUniform( gen, rnarray1d, np4*nparf*nevt ) );
 #endif
+    for ( int i=0; i<8; i++ ) printf( "%f %f %f %f\n", rnarray1d[i*4], rnarray1d[i*4+1], rnarray1d[i*4+2], rnarray1d[i*4+3] );
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
Clarify issues with cxtype_ref on gcc/clang + Test clang11.1 and clang12.0

This addresses a mix of two related issues
- issue #172 about cxtype_ref: understood as not a bug, it depends on common rancom numbers (needed for clang11, 12 as cuda11 does not support them)
- issue #182 about testing the latest clang11.1 and clang12.0 with openmp support (removed the hack for clang 11.0 with no openmp in the cvmfs install I use)