### PR TITLE
Add perf stat to the throughput script + Minor patches to streamline printouts

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -519,7 +519,7 @@ int main(int argc, char **argv)
 
     if (verbose)
     {
-      std::cout << "************************************************************************" << std::endl
+      std::cout << std::string(79, '*') << std::endl
                 << "Iteration #" << iiter+1 << " of " << niter << std::endl;
       if (perf) std::cout << "Wave function time: " << wavetime << std::endl;
     }
@@ -551,7 +551,7 @@ int main(int argc, char **argv)
                     << std::endl
                     << std::defaultfloat; // default format: affects all floats
         }
-        std::cout << std::string(80, '-') << std::endl;
+        std::cout << std::string(79, '-') << std::endl;
         // Display matrix elements
         std::cout << " Matrix element = "
 #ifndef MGONGPU_CPPSIMD
@@ -560,7 +560,7 @@ int main(int argc, char **argv)
                   << hstMEs[ievt/neppM][ievt%neppM]
 #endif
                   << " GeV^" << meGeVexponent << std::endl; // FIXME: assume process.nprocesses == 1
-        std::cout << std::string(80, '-') << std::endl;
+        std::cout << std::string(79, '-') << std::endl;
       }
       // Fill the arrays with ALL MEs and weights
 #ifndef MGONGPU_CPPSIMD
@@ -718,7 +718,7 @@ int main(int argc, char **argv)
 #endif
 #endif
     // Dump all configuration parameters and all results
-    std::cout << "***************************************************************************" << std::endl
+    std::cout << std::string(79, '*') << std::endl
 #ifdef __CUDACC__
               << "Process                     = " << XSTRINGIFY(MG_EPOCH_PROCESS_ID) << "_CUDA"
               << " [" << process.getCompiler() << "]" << std::endl
@@ -729,7 +729,7 @@ int main(int argc, char **argv)
               << "NumBlocksPerGrid            = " << gpublocks << std::endl
               << "NumThreadsPerBlock          = " << gputhreads << std::endl
               << "NumIterations               = " << niter << std::endl
-              << "---------------------------------------------------------------------------" << std::endl
+              << std::string(79, '-') << std::endl
 #if defined MGONGPU_FPTYPE_DOUBLE
               << "FP precision                = DOUBLE (NaN/abnormal=" << nabn << ", zero=" << nzero << ")" << std::endl
 #elif defined MGONGPU_FPTYPE_FLOAT
@@ -792,7 +792,7 @@ int main(int argc, char **argv)
 #endif
 #endif
       //<< "MatrixElements compiler     = " << process.getCompiler() << std::endl
-              << "---------------------------------------------------------------------------" << std::endl
+              << std::string(79, '-') << std::endl
               << "NumberOfEntries             = " << niter << std::endl
               << std::scientific // fixed format: affects all floats (default precision: 6)
               << "TotalTime[Rnd+Rmb+ME] (123) = ( " << sumgtim+sumrtim+sumwtim << std::string(16, ' ') << " )  sec" << std::endl
@@ -804,7 +804,7 @@ int main(int argc, char **argv)
               << "[Min,Max]TimeInMatrixElems  = [ " << minwtim
               << " ,  " << maxwtim << " ]  sec" << std::endl
       //<< "StdDevTimeInWaveFuncs       = ( " << stdwtim << std::string(16, ' ') << " )  sec" << std::endl
-              << "---------------------------------------------------------------------------" << std::endl
+              << std::string(79, '-') << std::endl
       //<< "ProcessID:                  = " << getpid() << std::endl
       //<< "NProcesses                  = " << process.nprocesses << std::endl
               << "TotalEventsComputed         = " << nevtALL << std::endl
@@ -819,7 +819,7 @@ int main(int argc, char **argv)
               << "EvtsPerSec[MatrixElems] (3) = ( " << nevtALL/sumwtim
               << std::string(16, ' ') << " )  sec^-1" << std::endl
               << std::defaultfloat; // default format: affects all floats
-    std::cout << "***************************************************************************" << std::endl
+    std::cout << std::string(79, '*') << std::endl
               << "NumMatrixElems(notAbnormal) = " << nevtALL - nabn << std::endl
               << std::scientific // fixed format: affects all floats (default precision: 6)
               << "MeanMatrixElemValue         = ( " << meanelem
@@ -967,9 +967,9 @@ int main(int argc, char **argv)
   timermap.stop();
   if (perf)
   {
-    std::cout << "***************************************************************************" << std::endl;
+    std::cout << std::string(79, '*') << std::endl;
     timermap.dump();
-    std::cout << "***************************************************************************" << std::endl;
+    std::cout << std::string(79, '*') << std::endl;
   }
 
   //std::cout << "ALL OK" << std::endl;

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -34,6 +34,8 @@
 #define STRINGIFY(s) #s
 #define XSTRINGIFY(s) STRINGIFY(s)
 
+#define SEP79 79
+
 bool is_number(const char *s) {
   const char *t = s;
   while (*t != '\0' && isdigit(*t))
@@ -519,7 +521,7 @@ int main(int argc, char **argv)
 
     if (verbose)
     {
-      std::cout << std::string(79, '*') << std::endl
+      std::cout << std::string(SEP79, '*') << std::endl
                 << "Iteration #" << iiter+1 << " of " << niter << std::endl;
       if (perf) std::cout << "Wave function time: " << wavetime << std::endl;
     }
@@ -551,7 +553,7 @@ int main(int argc, char **argv)
                     << std::endl
                     << std::defaultfloat; // default format: affects all floats
         }
-        std::cout << std::string(79, '-') << std::endl;
+        std::cout << std::string(SEP79, '-') << std::endl;
         // Display matrix elements
         std::cout << " Matrix element = "
 #ifndef MGONGPU_CPPSIMD
@@ -560,7 +562,7 @@ int main(int argc, char **argv)
                   << hstMEs[ievt/neppM][ievt%neppM]
 #endif
                   << " GeV^" << meGeVexponent << std::endl; // FIXME: assume process.nprocesses == 1
-        std::cout << std::string(79, '-') << std::endl;
+        std::cout << std::string(SEP79, '-') << std::endl;
       }
       // Fill the arrays with ALL MEs and weights
 #ifndef MGONGPU_CPPSIMD
@@ -718,7 +720,7 @@ int main(int argc, char **argv)
 #endif
 #endif
     // Dump all configuration parameters and all results
-    std::cout << std::string(79, '*') << std::endl
+    std::cout << std::string(SEP79, '*') << std::endl
 #ifdef __CUDACC__
               << "Process                     = " << XSTRINGIFY(MG_EPOCH_PROCESS_ID) << "_CUDA"
               << " [" << process.getCompiler() << "]" << std::endl
@@ -729,7 +731,7 @@ int main(int argc, char **argv)
               << "NumBlocksPerGrid            = " << gpublocks << std::endl
               << "NumThreadsPerBlock          = " << gputhreads << std::endl
               << "NumIterations               = " << niter << std::endl
-              << std::string(79, '-') << std::endl
+              << std::string(SEP79, '-') << std::endl
 #if defined MGONGPU_FPTYPE_DOUBLE
               << "FP precision                = DOUBLE (NaN/abnormal=" << nabn << ", zero=" << nzero << ")" << std::endl
 #elif defined MGONGPU_FPTYPE_FLOAT
@@ -792,7 +794,7 @@ int main(int argc, char **argv)
 #endif
 #endif
       //<< "MatrixElements compiler     = " << process.getCompiler() << std::endl
-              << std::string(79, '-') << std::endl
+              << std::string(SEP79, '-') << std::endl
               << "NumberOfEntries             = " << niter << std::endl
               << std::scientific // fixed format: affects all floats (default precision: 6)
               << "TotalTime[Rnd+Rmb+ME] (123) = ( " << sumgtim+sumrtim+sumwtim << std::string(16, ' ') << " )  sec" << std::endl
@@ -804,7 +806,7 @@ int main(int argc, char **argv)
               << "[Min,Max]TimeInMatrixElems  = [ " << minwtim
               << " ,  " << maxwtim << " ]  sec" << std::endl
       //<< "StdDevTimeInWaveFuncs       = ( " << stdwtim << std::string(16, ' ') << " )  sec" << std::endl
-              << std::string(79, '-') << std::endl
+              << std::string(SEP79, '-') << std::endl
       //<< "ProcessID:                  = " << getpid() << std::endl
       //<< "NProcesses                  = " << process.nprocesses << std::endl
               << "TotalEventsComputed         = " << nevtALL << std::endl
@@ -819,7 +821,7 @@ int main(int argc, char **argv)
               << "EvtsPerSec[MatrixElems] (3) = ( " << nevtALL/sumwtim
               << std::string(16, ' ') << " )  sec^-1" << std::endl
               << std::defaultfloat; // default format: affects all floats
-    std::cout << std::string(79, '*') << std::endl
+    std::cout << std::string(SEP79, '*') << std::endl
               << "NumMatrixElems(notAbnormal) = " << nevtALL - nabn << std::endl
               << std::scientific // fixed format: affects all floats (default precision: 6)
               << "MeanMatrixElemValue         = ( " << meanelem
@@ -967,9 +969,9 @@ int main(int argc, char **argv)
   timermap.stop();
   if (perf)
   {
-    std::cout << std::string(79, '*') << std::endl;
+    std::cout << std::string(SEP79, '*') << std::endl;
     timermap.dump();
-    std::cout << std::string(79, '*') << std::endl;
+    std::cout << std::string(SEP79, '*') << std::endl;
   }
 
   //std::cout << "ALL OK" << std::endl;

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -21,8 +21,8 @@ while [ "$1" != "" ]; do
 done
 
 exes=
-exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
 exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/gcheck.exe"
+exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
 if [ "${avxall}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4/check.exe"
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2/check.exe"
@@ -32,8 +32,8 @@ if [ "${avxall}" == "1" ]; then
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z/check.exe"
 fi
 if [ "${ep2}" == "1" ]; then 
-  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
   exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
 fi
 
 export USEBUILDDIR=1
@@ -58,8 +58,13 @@ function runExe() {
   # Optionally add other patterns here for some specific configurations (e.g. clang)
   pattern="${pattern}|CUCOMPLEX"
   pattern="${pattern}|COMMON RANDOM"
+  # -- Older version using time
   # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
-  TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
+  ###TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
+  # -- Newer version using perf stat
+  pattern="${pattern}|instructions|cycles"
+  pattern="${pattern}|elapsed"
+  perf stat $exe -p 2048 256 12 2>&1 | egrep "(${pattern})" | grep -v "Performance counter stats"
 }
 
 function runNcu() {

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -1,27 +1,24 @@
 #!/bin/bash
 
 omp=0
-if [ "$1" == "-omp" ]; then
-  omp=1
-  shift
-fi
-
 avxall=0
-if [ "$1" == "-avxall" ]; then
-  avxall=1
-  shift
-fi
-
 ep2=0
-if [ "$1" == "-ep2" ]; then
-  ep2=1
-  shift
-fi
 
-if [ "$1" != "" ]; then
-  echo "Usage: $0 [-omp] [-avxall] [-ep2]"
-  exit 1
-fi
+while [ "$1" != "" ]; do
+  if [ "$1" == "-omp" ]; then
+    omp=1
+    shift
+  elif [ "$1" == "-avxall" ]; then
+    avxall=1
+    shift
+  elif [ "$1" == "-ep2" ]; then
+    ep2=1
+    shift
+  else
+    echo "Usage: $0 [-omp] [-avxall] [-ep2]"
+    exit 1
+  fi
+done
 
 exes=
 exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -12,8 +12,14 @@ if [ "$1" == "-avxall" ]; then
   shift
 fi
 
+ep2=0
+if [ "$1" == "-ep2" ]; then
+  ep2=1
+  shift
+fi
+
 if [ "$1" != "" ]; then
-  echo "Usage: $0 [-omp] [-avxall]"
+  echo "Usage: $0 [-omp] [-avxall] [-ep2]"
   exit 1
 fi
 
@@ -28,8 +34,10 @@ exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mup
 if [ "${avxall}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z/check.exe"
 fi
-exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
-exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+if [ "${ep2}" == "1" ]; then 
+  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
+  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+fi
 
 export USEBUILDDIR=1
 pushd ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >& /dev/null

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -37,7 +37,7 @@ pushd ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >&
   make AVX=none
   if [ "${avxall}" == "1" ]; then make AVX=sse4; fi
   if [ "${avxall}" == "1" ]; then make AVX=avx2; fi
-  make AVX=512y
+  make AVX=512y # always consider 512y as the reference, even if for clang avx2 is slightly faster...
   if [ "${avxall}" == "1" ]; then make AVX=512z; fi
 popd >& /dev/null
 
@@ -46,28 +46,38 @@ pushd ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >&
   make
 popd >& /dev/null
 
-pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|MeanMatrix|FP precision|TOTAL       :"
-# Optionally add other patterns here for some specific configurations (e.g. clang)
-pattern="${pattern}|CUCOMPLEX"
-pattern="${pattern}|COMMON RANDOM"
-pattern="(${pattern})"
+function runExe() {
+  exe=$1
+  ###echo "runExe $exe OMP=$OMP_NUM_THREADS"
+  pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|MeanMatrix|FP precision|TOTAL       :"
+  # Optionally add other patterns here for some specific configurations (e.g. clang)
+  pattern="${pattern}|CUCOMPLEX"
+  pattern="${pattern}|COMMON RANDOM"
+  # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
+  TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
+}
+
+function runNcu() {
+  exe=$1
+  ###echo "runExe $exe OMP=$OM_NUM_THREADS (NCU)"
+  $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe -p 2048 256 1 | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
+}
 
 echo -e "\nOn $HOSTNAME:"
 for exe in $exes; do
   if [ ! -f $exe ]; then continue; fi
   echo "-------------------------------------------------------------------------"
   unset OMP_NUM_THREADS
-  # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
-  TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "$pattern"
+  runExe $exe
   if [ "${exe%%/check*}" != "${exe}" ]; then 
     obj=${exe%%/check*}/CPPProcess.o; ./simdSymSummary.sh -stripdir ${obj}
     if [ "${omp}" == "1" ]; then 
       echo "-------------------------------------------------------------------------"
       export OMP_NUM_THREADS=$(nproc --all)
-      TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "$pattern"
+      runExe $exe
     fi
   elif [ "${exe%%/gcheck*}" != "${exe}" ]; then 
-    $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe -p 2048 256 1 | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
+    runNcu $exe
   fi
 done
 echo "-------------------------------------------------------------------------"


### PR DESCRIPTION
This is mainly about adding perf stat to allow a better analysis of AVX512 and other vectorization scenarios (issue #173)

This assumes that perf stat works - which I am able to do on itscrd03, and for my older itscrd70 will come after solving issue #180 (a hard reboot of the VM)

I also added a few minor patches to sytreamline printouts