### PR TITLE
A few fixes for lxplus (T4) and for gcc8

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -98,7 +98,11 @@ namespace Proc
     // - shared: as the name says
     // - private: give each thread its own copy, without initialising
     // - firstprivate: give each thread its own copy, and initialise with value from outside
+#if not defined __clang__ && defined __GNUC__ && __GNUC__ < 9
+#pragma omp parallel for default(none) shared(allmomenta,allMEs,cf,cHel,cIPC,cIPD,denom,ihel) private (amp_sv,w_sv)
+#else
 #pragma omp parallel for default(none) shared(allmomenta,allMEs,cf,cHel,cIPC,cIPD,denom,ihel,npagV) private (amp_sv,w_sv)
+#endif
 #endif
     for ( int ipagV = 0; ipagV < npagV; ++ipagV )
 #endif

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -465,14 +465,14 @@ namespace Proc
 #ifdef MGONGPU_CPPSIMD
     for ( int ipagV = 0; ipagV < npagV; ++ipagV )
     {
-      allMEs[ipagV] /= denominators;
+      allMEs[ipagV] /= (fptype)denominators;
     }
 #else
 #ifndef __CUDACC__
     for ( int ievt = 0; ievt < nevt; ++ievt )
 #endif
     {
-      allMEs[ievt] /= denominators;
+      allMEs[ievt] /= (fptype)denominators;
     }
 #endif
     mgDebugFinalise();

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -76,7 +76,7 @@ function runNcu() {
   $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe -p 2048 256 1 | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
 }
 
-echo -e "\nOn $HOSTNAME:"
+echo -e "\nOn $HOSTNAME ($(nvidia-smi -L | awk '{print $5}')):"
 for exe in $exes; do
   if [ ! -f $exe ]; then continue; fi
   echo "-------------------------------------------------------------------------"

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -58,13 +58,16 @@ function runExe() {
   # Optionally add other patterns here for some specific configurations (e.g. clang)
   pattern="${pattern}|CUCOMPLEX"
   pattern="${pattern}|COMMON RANDOM"
-  # -- Older version using time
-  # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
-  ###TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
-  # -- Newer version using perf stat
-  pattern="${pattern}|instructions|cycles"
-  pattern="${pattern}|elapsed"
-  perf stat $exe -p 2048 256 12 2>&1 | egrep "(${pattern})" | grep -v "Performance counter stats"
+  if perf --version >& /dev/null; then
+    # -- Newer version using perf stat
+    pattern="${pattern}|instructions|cycles"
+    pattern="${pattern}|elapsed"
+    perf stat $exe -p 2048 256 12 2>&1 | egrep "(${pattern})" | grep -v "Performance counter stats"
+  else
+    # -- Older version using time
+    # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
+    TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
+  fi
 }
 
 function runNcu() {

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -38,18 +38,20 @@ fi
 
 export USEBUILDDIR=1
 pushd ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >& /dev/null
-  pwd
-  make AVX=none
-  if [ "${avxall}" == "1" ]; then make AVX=sse4; fi
-  if [ "${avxall}" == "1" ]; then make AVX=avx2; fi
-  make AVX=512y # always consider 512y as the reference, even if for clang avx2 is slightly faster...
-  if [ "${avxall}" == "1" ]; then make AVX=512z; fi
+pwd
+make AVX=none
+if [ "${avxall}" == "1" ]; then make AVX=sse4; fi
+if [ "${avxall}" == "1" ]; then make AVX=avx2; fi
+make AVX=512y # always consider 512y as the reference, even if for clang avx2 is slightly faster...
+if [ "${avxall}" == "1" ]; then make AVX=512z; fi
 popd >& /dev/null
 
-pushd ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >& /dev/null
+if [ "${ep2}" == "1" ]; then 
+  pushd ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum >& /dev/null
   pwd
   make
-popd >& /dev/null
+  popd >& /dev/null
+fi
 
 function runExe() {
   exe=$1


### PR DESCRIPTION
This includes a fix for a gcc8/OMP issue reported by both @roiser and @lfield 

I suggest we stick to gcc9.2 or above, but I fixed this and another gcc8 issue (with #ifdef that depend on __GNUC__)