### PR TITLE
[ggttgg] two functional bug fixes in the ME calculation and one in the Makefile

### DIFF
--- a/epoch2/cuda/gg_ttgg/SubProcesses/Makefile
+++ b/epoch2/cuda/gg_ttgg/SubProcesses/Makefile
@@ -65,6 +65,9 @@ $(LIBDIR)/lib$(MODELLIB).a:
 gcheck_sa.o: gcheck_sa.cu *.h ../../src/*.h ../../src/*.cu
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
+CPPProcess.o : ../../src/HelAmps_sm.cu
+gCPPProcess.o : ../../src/HelAmps_sm.cu
+
 %.o : %.cu *.h ../../src/*.h
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 

--- a/epoch2/cuda/gg_ttgg/src/HelAmps_sm.cu
+++ b/epoch2/cuda/gg_ttgg/src/HelAmps_sm.cu
@@ -84,7 +84,8 @@ const int ipar)  // input: particle# out of npar
     if (pp == 0.0)
     {
       sqm[0] = sqrt(std::abs(fmass)); 
-      sqm[1] = (fmass < 0) ? - abs(sqm[0]) : abs(sqm[0]); 
+      //sqm[1] = (fmass < 0) ? - abs(sqm[0]) : abs(sqm[0]); // BUG issue #198
+      sqm[1] = (fmass < 0) ? -sqm[0] : sqm[0];
       ip = (1 + nh)/2; 
       im = (1 - nh)/2; 
       fi[2] = ip * sqm[ip]; 
@@ -344,8 +345,8 @@ const int ipar)  // input: particle# out of npar
       else
       {
         vc[3] = cxtype(-hel * sqh, 0.0); 
-        vc[4] = cxtype(0.0, nsvahl * (p3 < 0) ? - abs(sqh)
-        : abs(sqh)); 
+        //vc[4] = cxtype(0.0, nsvahl * (p3 < 0) ? - abs(sqh) : abs(sqh)); // BUG issue #198
+        vc[4] = cxtype(0.0, nsvahl * (p3 < 0) ? -sqh : sqh);
       }
     }
   }
@@ -364,8 +365,8 @@ const int ipar)  // input: particle# out of npar
     else
     {
       vc[3] = cxtype(-hel * sqh, 0.0); 
-      vc[4] = 
-      cxtype(0.0, nsv * (p3 < 0) ? - abs(sqh) : abs(sqh)); 
+      //vc[4] = cxtype(0.0, nsv * (p3 < 0) ? - abs(sqh) : abs(sqh)); // BUG issue #198
+      vc[4] = cxtype(0.0, nsv * (p3 < 0) ? -sqh : sqh);
     }
   }
   return; 
@@ -430,7 +431,8 @@ const int ipar)  // input: particle# out of npar
     if (pp == 0.000)
     {
       sqm[0] = sqrt(std::abs(fmass)); 
-      sqm[1] = (fmass < 0) ? - abs(sqm[0]) : abs(sqm[0]); 
+      //sqm[1] = (fmass < 0) ? - abs(sqm[0]) : abs(sqm[0]); // BUG issue #198
+      sqm[1] = (fmass < 0) ? -sqm[0] : sqm[0];
       ip = -((1 - nh)/2) * nhel; 
       im = (1 + nh)/2 * nhel; 
       fo[2] = im * sqm[std::abs(ip)]; 

--- a/epoch2/cuda/gg_ttgg/src/HelAmps_sm.cu
+++ b/epoch2/cuda/gg_ttgg/src/HelAmps_sm.cu
@@ -62,9 +62,7 @@ const int ipar)  // input: particle# out of npar
   using std::min; 
 #endif
 
-
-
-  // const fptype& pvec0 = pIparIp4Ievt( allmomenta, ipar, 0, ievt );
+  const fptype& pvec0 = pIparIp4Ievt(allmomenta, ipar, 0, ievt);
   const fptype& pvec1 = pIparIp4Ievt(allmomenta, ipar, 1, ievt); 
   const fptype& pvec2 = pIparIp4Ievt(allmomenta, ipar, 2, ievt); 
   const fptype& pvec3 = pIparIp4Ievt(allmomenta, ipar, 3, ievt); 
@@ -74,7 +72,8 @@ const int ipar)  // input: particle# out of npar
   int ip, im, nh; 
 
   fptype p[4] = {0, pvec1, pvec2, pvec3}; 
-  p[0] = sqrt(p[1] * p[1] + p[2] * p[2] + p[3] * p[3] + fmass * fmass); 
+  //p[0] = sqrt(p[1] * p[1] + p[2] * p[2] + p[3] * p[3] + fmass * fmass); // AV: BUG?! (NOT AS IN THE FORTRAN)
+  p[0] = pvec0; // AV: BUG FIX (DO AS IN THE FORTRAN)
   fi[0] = cxtype(-p[0] * nsf, -p[3] * nsf); 
   fi[1] = cxtype(-p[1] * nsf, -p[2] * nsf); 
   nh = nhel * nsf; 


### PR DESCRIPTION
Two bug fixes in the ME calculation
- first (fix issue #198, cuda and C++ were giving different results, now fixed): avoid using "abs" for floats, this truncates to integers
- second (changes both CUDA and C++ in the same way): the handling of energy and mass in ixxxxx was different from that in the Fortran, I now am using the Fortran version as in epoch1 eemumu... @oliviermattelaer can you please cross check and comment? otherwise I would have to fix it also in epoch1 eemumu (an dthen for upstream posrts)

In addition, a third bug fix in the Makefile, the code must be recuit if HelAmps changes