### PR TITLE
[devsync] add cudaDeviceSynchronize for better timing measurements

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -497,6 +497,7 @@ int main(int argc, char **argv)
     gProc::sigmaKin<<<gpublocks, gputhreads, ntpbMAX*sizeof(float)>>>(devMomenta.get(), devMEs.get());
 #endif
     checkCuda( cudaPeekAtLastError() );
+    checkCuda( cudaDeviceSynchronize() );
 #else
     Proc::sigmaKin(hstMomenta.get(), hstMEs.get(), nevt);
 #endif

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -4,11 +4,11 @@ omp=0
 avxall=0
 ep2=0
 cpp=1
+ab3=0
 
 function usage()
 {
-  echo "Usage: $0 [-omp] [-avxall] [-ep2]"
-  echo "Usage: $0 [-nocpp] [-ep2]"
+  echo "Usage: $0 [-nocpp|[-omp][-avxall]] [-ep2] [-3a3b]"
   exit 1
 }
 
@@ -28,6 +28,9 @@ while [ "$1" != "" ]; do
     shift
   elif [ "$1" == "-ep2" ]; then
     ep2=1
+    shift
+  elif [ "$1" == "-3a3b" ]; then
+    ab3=1
     shift
   else
     usage
@@ -90,6 +93,7 @@ function runExe() {
   # Optionally add other patterns here for some specific configurations (e.g. clang)
   pattern="${pattern}|CUCOMPLEX"
   pattern="${pattern}|COMMON RANDOM"
+  if [ "${ab3}" == "1" ]; then pattern="${pattern}|3a|3b"; fi
   if perf --version >& /dev/null; then
     # -- Newer version using perf stat
     pattern="${pattern}|instructions|cycles"

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -72,7 +72,7 @@ pwd
 make AVX=none
 if [ "${avxall}" == "1" ]; then make AVX=sse4; fi
 if [ "${avxall}" == "1" ]; then make AVX=avx2; fi
-make AVX=512y # always consider 512y as the reference, even if for clang avx2 is slightly faster...
+if [ "${cpp}" == "1" ]; then make AVX=512y; fi # always consider 512y as the C++ reference, even if for clang avx2 is slightly faster
 if [ "${avxall}" == "1" ]; then make AVX=512z; fi
 popd >& /dev/null
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -3,37 +3,57 @@
 omp=0
 avxall=0
 ep2=0
+cpp=1
+
+function usage()
+{
+  echo "Usage: $0 [-omp] [-avxall] [-ep2]"
+  echo "Usage: $0 [-nocpp] [-ep2]"
+  exit 1
+}
 
 while [ "$1" != "" ]; do
   if [ "$1" == "-omp" ]; then
+    if [ "${cpp}" == "0" ]; then echo "ERROR! Options -omp and -nocpp are incompatible"; usage; fi
     omp=1
     shift
   elif [ "$1" == "-avxall" ]; then
+    if [ "${cpp}" == "0" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
     avxall=1
+    shift
+  elif [ "$1" == "-nocpp" ]; then
+    if [ "${avxall}" == "1" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
+    if [ "${omp}" == "1" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
+    cpp=0
     shift
   elif [ "$1" == "-ep2" ]; then
     ep2=1
     shift
   else
-    echo "Usage: $0 [-omp] [-avxall] [-ep2]"
-    exit 1
+    usage
   fi
 done
 
 exes=
 exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/gcheck.exe"
-exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
+if [ "${cpp}" == "1" ]; then 
+  exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
+fi
 if [ "${avxall}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4/check.exe"
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2/check.exe"
 fi
-exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y/check.exe"
+if [ "${cpp}" == "1" ]; then 
+  exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y/check.exe"
+fi
 if [ "${avxall}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z/check.exe"
 fi
 if [ "${ep2}" == "1" ]; then 
   exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
-  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
+  if [ "${cpp}" == "1" ]; then 
+    exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
+  fi
 fi
 
 export USEBUILDDIR=1

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -35,7 +35,18 @@ while [ "$1" != "" ]; do
 done
 
 exes=
+
+#===============================
+# CUDA (epoch1 and epoch2)
+#===============================
 exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/gcheck.exe"
+if [ "${ep2}" == "1" ]; then 
+  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+fi
+
+#===============================
+# C++ (epoch1 and epoch2)
+#===============================
 if [ "${cpp}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
 fi
@@ -50,7 +61,6 @@ if [ "${avxall}" == "1" ]; then
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z/check.exe"
 fi
 if [ "${ep2}" == "1" ]; then 
-  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
   if [ "${cpp}" == "1" ]; then 
     exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
   fi
@@ -98,10 +108,16 @@ function runNcu() {
   $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe -p 2048 256 1 | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
 }
 
+lastExe=
 echo -e "\nOn $HOSTNAME ($(nvidia-smi -L | awk '{print $5}')):"
 for exe in $exes; do
   if [ ! -f $exe ]; then continue; fi
-  echo "-------------------------------------------------------------------------"
+  if [ "$(basename $exe)" != "$lastExe" ]; then
+    echo "========================================================================="
+    lastExe=$(basename $exe)
+  else
+    echo "-------------------------------------------------------------------------"
+  fi
   unset OMP_NUM_THREADS
   runExe $exe
   if [ "${exe%%/check*}" != "${exe}" ]; then 
@@ -115,4 +131,4 @@ for exe in $exes; do
     runNcu $exe
   fi
 done
-echo "-------------------------------------------------------------------------"
+echo "========================================================================="

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
+set +x
+
 omp=0
 avxall=0
 ep2=0
 cpp=1
 ab3=0
+ggttgg=0
+verbose=0
 
 function usage()
 {
-  echo "Usage: $0 [-nocpp|[-omp][-avxall]] [-ep2] [-3a3b]"
+  echo "Usage: $0 [-nocpp|[-omp][-avxall]] [-ep2] [-3a3b] [-ggttgg] [-v]"
   exit 1
 }
 
@@ -32,6 +36,12 @@ while [ "$1" != "" ]; do
   elif [ "$1" == "-3a3b" ]; then
     ab3=1
     shift
+  elif [ "$1" == "-ggttgg" ]; then
+    ggttgg=1
+    shift
+  elif [ "$1" == "-v" ]; then
+    verbose=1
+    shift
   else
     usage
   fi
@@ -39,17 +49,17 @@ done
 
 exes=
 
-#===============================
-# CUDA (epoch1 and epoch2)
-#===============================
+#=====================================
+# CUDA (eemumu/epoch1, eemumu/epoch2)
+#=====================================
 exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/gcheck.exe"
 if [ "${ep2}" == "1" ]; then 
   exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
 fi
 
-#===============================
-# C++ (epoch1 and epoch2)
-#===============================
+#=====================================
+# C++ (eemumu/epoch1, eemumu/epoch2)
+#=====================================
 if [ "${cpp}" == "1" ]; then 
   exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none/check.exe"
 fi
@@ -66,6 +76,22 @@ fi
 if [ "${ep2}" == "1" ]; then 
   if [ "${cpp}" == "1" ]; then 
     exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.exe"
+  fi
+fi
+
+#=====================================
+# CUDA (ggttgg/epoch2)
+#=====================================
+if [ "${ggttgg}" == "1" ]; then 
+  exes="$exes ../../../../../epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/gcheck.exe"
+fi
+
+#=====================================
+# C++ (ggttgg/epoch2)
+#=====================================
+if [ "${ggttgg}" == "1" ]; then 
+  if [ "${cpp}" == "1" ]; then 
+    exes="$exes ../../../../../epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/check.exe"
   fi
 fi
 
@@ -86,8 +112,16 @@ if [ "${ep2}" == "1" ]; then
   popd >& /dev/null
 fi
 
+if [ "${ggttgg}" == "1" ]; then 
+  pushd ../../../../../epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg >& /dev/null
+  pwd
+  make
+  popd >& /dev/null
+fi
+
 function runExe() {
   exe=$1
+  args="$2"
   ###echo "runExe $exe OMP=$OMP_NUM_THREADS"
   pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|MeanMatrix|FP precision|TOTAL       :"
   # Optionally add other patterns here for some specific configurations (e.g. clang)
@@ -98,24 +132,39 @@ function runExe() {
     # -- Newer version using perf stat
     pattern="${pattern}|instructions|cycles"
     pattern="${pattern}|elapsed"
-    perf stat $exe -p 2048 256 12 2>&1 | egrep "(${pattern})" | grep -v "Performance counter stats"
+    if [ "${verbose}" == "1" ]; then set -x; fi
+    perf stat $exe $args 2>&1 | egrep "(${pattern})" | grep -v "Performance counter stats"
+    set +x
   else
     # -- Older version using time
     # For TIMEFORMAT see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
-    TIMEFORMAT=$'real\t%3lR' && time $exe -p 2048 256 12 2>&1 | egrep "(${pattern})"
+    if [ "${verbose}" == "1" ]; then set -x; fi
+    TIMEFORMAT=$'real\t%3lR' && time $exe $args 2>&1 | egrep "(${pattern})"
+    set +x
   fi
 }
 
 function runNcu() {
   exe=$1
+  args="$2"
   ###echo "runExe $exe OMP=$OM_NUM_THREADS (NCU)"
-  $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe -p 2048 256 1 | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
+  if [ "${verbose}" == "1" ]; then set -x; fi
+  $(which ncu) --metrics launch__registers_per_thread --target-processes all --kernel-id "::sigmaKin:" --print-kernel-base mangled $exe $args | egrep '(sigmaKin|registers)' | tr "\n" " " | awk '{print $1, $2, $3, $15, $17}'
+  set +x
 }
 
 lastExe=
 echo -e "\nOn $HOSTNAME ($(nvidia-smi -L | awk '{print $5}')):"
 for exe in $exes; do
   if [ ! -f $exe ]; then continue; fi
+  if [ "${exe%%/gg_ttgg*}" != "${exe}" ]; then 
+    # This is a good GPU middle point: tput is 1.5x lower with "32 256 1", only a few% higher with "128 256 1"
+    exeArgs="-p 64 256 1"
+    ncuArgs="-p 64 256 1"
+  else
+    exeArgs="-p 2048 256 12"
+    ncuArgs="-p 2048 256 1"
+  fi
   if [ "$(basename $exe)" != "$lastExe" ]; then
     echo "========================================================================="
     lastExe=$(basename $exe)
@@ -123,16 +172,16 @@ for exe in $exes; do
     echo "-------------------------------------------------------------------------"
   fi
   unset OMP_NUM_THREADS
-  runExe $exe
+  runExe $exe "$exeArgs"
   if [ "${exe%%/check*}" != "${exe}" ]; then 
     obj=${exe%%/check*}/CPPProcess.o; ./simdSymSummary.sh -stripdir ${obj}
     if [ "${omp}" == "1" ]; then 
       echo "-------------------------------------------------------------------------"
       export OMP_NUM_THREADS=$(nproc --all)
-      runExe $exe
+      runExe $exe "$exeArgs"
     fi
   elif [ "${exe%%/gcheck*}" != "${exe}" ]; then 
-    runNcu $exe
+    runNcu $exe "$ncuArgs"
   fi
 done
 echo "========================================================================="

--- a/epoch1/cuda/ee_mumu/SubProcesses/profile.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/profile.sh
@@ -115,6 +115,7 @@ if [ "$tag" != "nogui" ]; then
   else
     logs=logs
   fi
+  if [ ! -d $logs ]; then mkdir -p $logs; fi
   trace=$logs/eemumuAV_${tag}_`date +%m%d_%H%M`_b${arg1}_t${arg2}_i${arg3}
   if [ "$label" != "" ]; then trace=${trace}_${label}; fi
   

--- a/epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/gcheck_sa.cu
+++ b/epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/gcheck_sa.cu
@@ -390,6 +390,7 @@ int main(int argc, char **argv)
     gProc::sigmaKin<<<gpublocks, gputhreads, ntpbMAX*sizeof(float)>>>(devMomenta.get(), devMEs.get());
 #endif
     checkCuda( cudaPeekAtLastError() );
+    checkCuda( cudaDeviceSynchronize() );
 #else
     Proc::sigmaKin(hstMomenta.get(), hstMEs.get(), nevt);
 #endif


### PR DESCRIPTION
@roiser @oliviermattelaer this is related to what we discussed during the last week

I am adding a cudaDeviceSynchronize between sigmakin and the copy of ME from device to host

The overall throughput does not change (*), while the relative split of sigmakin and copyDtoH changes enormously. Now it is clear that the copy takes around the same time as the sigmakin calculation for eemumu, while for ggttgg it is totally negligible with respect to it.

(*) NB: I am observing big fluctuations on the VM, and they actually come from the copy, while the calculation is rather stable. For eemumu this transaltes into large fluctuations (between 6.0 and 6.5E8, lower than the usual 7.3E8 that it should be). This is discussed in https://cern.service-now.com/service-portal?id=ticket&table=u_request_fulfillment&n=RQF1789593

Before adding cudaDeviceSynchronzie
```
On itscrd70.cern.ch (V100S-PCIE-32GB):
=========================================================================
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.0.221]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 6.568678e+08                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
3a SigmaKin :     0.000086 sec
3b CpDTHmes :     0.009492 sec
TOTAL       :     0.742937 sec
     2,594,268,110      cycles                    #    2.658 GHz
     3,534,129,010      instructions              #    1.36  insn per cycle
       1.045660455 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 120
-------------------------------------------------------------------------
FP precision               = DOUBLE (nan=0)
EvtsPerSec[MatrixElems] (3)= ( 4.397884e+05                 )  sec^-1
MeanMatrixElemValue        = ( 5.532387e+01 +- 5.501866e+01 )  GeV^-4
3a SigmaKin :     0.000009 sec
3b CpDTHmes :     0.037245 sec
TOTAL       :     0.606138 sec
     2,201,855,033      cycles                    #    2.656 GHz
     2,955,778,217      instructions              #    1.34  insn per cycle
       0.890392160 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
=========================================================================
``` 

After adding cudaDeviceSynchronize
```
On itscrd70.cern.ch (V100S-PCIE-32GB):
=========================================================================
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.0.221]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 6.480230e+08                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
3a SigmaKin :     0.004613 sec
3b CpDTHmes :     0.005095 sec
TOTAL       :     0.743895 sec
     2,601,684,149      cycles                    #    2.657 GHz
     3,532,142,253      instructions              #    1.36  insn per cycle
       1.049697294 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 120
-------------------------------------------------------------------------
FP precision               = DOUBLE (nan=0)
EvtsPerSec[MatrixElems] (3)= ( 4.427943e+05                 )  sec^-1
MeanMatrixElemValue        = ( 5.532387e+01 +- 5.501866e+01 )  GeV^-4
3a SigmaKin :     0.036976 sec
3b CpDTHmes :     0.000026 sec
TOTAL       :     0.651707 sec
     2,224,902,887      cycles                    #    2.657 GHz
     2,976,495,038      instructions              #    1.34  insn per cycle
       0.941813933 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
=========================================================================
```

By the way, I am using 2048 256 12 for eemumu, against 64 256 1 for ggttgg. This means I am copying 32x12 ie 384 times less data in ggttgg. In eemumu it takes 5095 usec, in ggttgg 26 usec to copy the data, so a factor 200 difference, this looks vaguely reasonable.