### PR TITLE
Add MECalc-only throughput (no DtoH copy)

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -506,17 +506,16 @@ int main(int argc, char **argv)
 
     // *** STOP THE NEW OLD-STYLE TIMER FOR MATRIX ELEMENTS (WAVEFUNCTIONS) ***
     wv3atime += timermap.stop(); // calc only
+    wavetime += wv3atime; // calc plus copy
 
 #ifdef __CUDACC__
     // --- 3b. CopyDToH MEs
     const std::string cmesKey = "3b CpDTHmes";
-    wavetime += wv3atime;
     timermap.start( cmesKey );
     checkCuda( cudaMemcpy( hstMEs.get(), devMEs.get(), nbytesMEs, cudaMemcpyDeviceToHost ) );
-#endif
-
     // *** STOP THE OLD OLD-STYLE TIMER FOR MATRIX ELEMENTS (WAVEFUNCTIONS) ***
     wavetime += timermap.stop(); // calc plus copy
+#endif
 
     // === STEP 4 FINALISE LOOP
     // --- 4a Dump within the loop

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -127,7 +127,7 @@ function runExe() {
   exe=$1
   args="$2"
   ###echo "runExe $exe $args OMP=$OMP_NUM_THREADS"
-  pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|MeanMatrix|FP precision|TOTAL       :"
+  pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|EvtsPerSec\[MECalc|MeanMatrix|FP precision|TOTAL       :"
   # Optionally add other patterns here for some specific configurations (e.g. clang)
   pattern="${pattern}|CUCOMPLEX"
   pattern="${pattern}|COMMON RANDOM"

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -127,8 +127,9 @@ function runExe() {
   exe=$1
   args="$2"
   ###echo "runExe $exe $args OMP=$OMP_NUM_THREADS"
-  pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[Matrix|EvtsPerSec\[MECalc|MeanMatrix|FP precision|TOTAL       :"
+  pattern="Process|fptype_sv|OMP threads|EvtsPerSec\[MECalc|MeanMatrix|FP precision|TOTAL       :"
   # Optionally add other patterns here for some specific configurations (e.g. clang)
+  if [ "${exe%%/gcheck*}" != "${exe}" ]; then pattern="${pattern}|EvtsPerSec\[Matrix"; fi
   pattern="${pattern}|CUCOMPLEX"
   pattern="${pattern}|COMMON RANDOM"
   if [ "${ab3}" == "1" ]; then pattern="${pattern}|3a|3b"; fi

--- a/epoch1/cuda/ee_mumu/SubProcesses/timermap.h
+++ b/epoch1/cuda/ee_mumu/SubProcesses/timermap.h
@@ -73,6 +73,7 @@ namespace mgOnGpu
       const std::string total1Key = "TOTAL   (1)";
       const std::string total2Key = "TOTAL   (2)";
       const std::string total3Key = "TOTAL   (3)";
+      const std::string total3aKey = "TOTAL  (3a)";
       size_t maxsize = 0;
       for ( auto ip : m_partitionTimers )
         maxsize = std::max( maxsize, ip.first.size() );
@@ -86,6 +87,7 @@ namespace mgOnGpu
       float total1 = 0;
       float total2 = 0;
       float total3 = 0;
+      float total3a = 0;
       for ( auto ip : m_partitionTimers )
       {
         total += ip.second;
@@ -95,6 +97,7 @@ namespace mgOnGpu
         if ( ip.first[0] == '1' ) total1 += ip.second;
         if ( ip.first[0] == '2' ) total2 += ip.second;
         if ( ip.first[0] == '3' ) total3 += ip.second;
+        if ( ip.first[0] == '3' && ip.first[1] == 'a' ) total3a += ip.second;
         ipart++;
       }
       // Dump individual partition timers and the overall total
@@ -107,7 +110,8 @@ namespace mgOnGpu
         ostr << s1 << totalKey << s2 << total << s3 << std::endl
              << s1 << total123Key << s2 << total123 << s3 << std::endl
              << s1 << total23Key << s2 << total23 << s3 << std::endl
-             << s1 << total3Key << s2 << total3 << " sec \"" << std::endl;
+             << s1 << total3Key << s2 << total3 << s3 << std::endl
+             << s1 << total3aKey << s2 << total3a << " sec \"" << std::endl;
         ostr << std::defaultfloat; // default format: affects all floats
       }
       else {
@@ -128,7 +132,9 @@ namespace mgOnGpu
              << std::setw(maxsize) << total2Key << " : "
              << std::setw(12) << total2 << " sec" << std::endl
              << std::setw(maxsize) << total3Key << " : "
-             << std::setw(12) << total3 << " sec" << std::endl;
+             << std::setw(12) << total3 << " sec" << std::endl
+             << std::setw(maxsize) << total3aKey << " : "
+             << std::setw(12) << total3a << " sec" << std::endl;
         ostr << std::defaultfloat; // default format: affects all floats
       }
     }

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -66,7 +66,8 @@ namespace mgOnGpu
   //const int nbpgMAX = 2048;
 
   // Maximum number of threads per block
-  const int ntpbMAX = 256;
+  //const int ntpbMAX = 256; // AV Apr2021: why had I set this to 256?
+  const int ntpbMAX = 1024; // NB: 512 is ok, but 1024 does fail with "too many resources requested for launch"
 
   // Vector sizes for AOSOA memory layouts (GPU coalesced memory access, CPU SIMD vectorization)
   // (these are all best kept as a compile-time constants: see issue #23)


### PR DESCRIPTION
Add MECalc-only throughput (no DtoH copy) as discussed in issue #22 

Another minor change, increase ntpbMAX to 1024 (was 256, but 512 works without issues on a V100)