### PR TITLE
FIXES for clang: dump gcc toolchain and ensure nvcc actually uses it

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -74,7 +74,7 @@ else
 endif
 
 # Set the host compiler for nvcc
-override NVCC := $(NVCC) -ccbin $(subst ccache ,,$(CXX))
+CUFLAGS += -ccbin $(subst ccache ,,$(CXX))
 
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -148,9 +148,9 @@ $(info Building in BUILDDIR=$(BUILDDIR) for tag=$(TAG))
 ifeq ($(USECCACHE)$(shell echo $(CXX) | grep ccache),1)
   override CXX:=ccache $(CXX)
 endif
-ifeq ($(USECCACHE)$(shell echo $(AR) | grep ccache),1)
-  override AR:=ccache $(AR)
-endif
+#ifeq ($(USECCACHE)$(shell echo $(AR) | grep ccache),1)
+#  override AR:=ccache $(AR)
+#endif
 ifneq ($(NVCC),)
   ifeq ($(USECCACHE)$(shell echo $(NVCC) | grep ccache),1)
     override NVCC:=ccache $(NVCC)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -74,7 +74,7 @@ else
 endif
 
 # Set the host compiler for nvcc
-override NVCC := $(NVCC) -ccbin $(CXX)
+override NVCC := $(NVCC) -ccbin $(subst ccache ,,$(CXX))
 
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -73,6 +73,9 @@ else
   override RNDGEN = common
 endif
 
+# Set the host compiler for nvcc
+override NVCC := $(NVCC) -ccbin $(CXX)
+
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]
 # [See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96476]

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -311,7 +311,13 @@ ifneq ($(NVCC),)
 	$(NVCC) --version
 	@echo ""
 endif
+ifneq ($(shell $(CXX) --version | grep ^clang),)
+	@echo $(CXX) -v
+	@$(CXX) -v |& egrep -v '(Found|multilib)'
+	@readelf -p .comment `$(CXX) -print-libgcc-file-name` |& grep 'GCC: (GNU)' | grep -v Warning | sort -u | awk '{print "GCC toolchain:",$$5}'
+else
 	$(CXX) --version
+endif
 
 force:
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -40,13 +40,11 @@ endif
 
 # If CUDA_HOME is not set, try to set it from the location of nvcc
 ifndef CUDA_HOME
-  NVCC ?= $(shell which nvcc 2>/dev/null)
-  ifneq ($(NVCC),)
-    # NVCC is in the PATH or set explicitly
-    CUDA_HOME  = $(patsubst %bin/nvcc,%,$(NVCC))
-    CUDA_HOME := $(warning No CUDA_HOME exported. Using "$(CUDA_HOME)") $(CUDA_HOME)
-  endif
+  CUDA_HOME = $(patsubst %bin/nvcc,%,$(shell which nvcc 2>/dev/null))
+  $(warning CUDA_HOME was not set - try using "$(CUDA_HOME)")
 endif
+
+# Set NVCC as $(CUDA_HOME)/bin/nvcc if it exists
 ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   NVCC = $(CUDA_HOME)/bin/nvcc
   CUARCHNUM=70
@@ -67,7 +65,8 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   cu_objects  = $(BUILDDIR)/gCPPProcess.o
 else
   # No cuda. Switch cuda compilation off and go to common random numbers in C++
-  NVCC       := $(warning CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda)
+  $(warning CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda)
+  NVCC       := 
   USE_NVTX   :=
   CULIBFLAGS :=
   override RNDGEN = common

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -306,14 +306,17 @@ info:
 	@cat /proc/cpuinfo | grep "cpu cores" | sort -u
 	@cat /proc/cpuinfo | grep "physical id" | sort -u
 	@echo ""
+	@echo USECCACHE=$(USECCACHE)
 ifeq ($(USECCACHE),1)
 	ccache --version | head -1
-	@echo ""
 endif
+	@echo ""
+	@echo NVCC=$(NVCC)
 ifneq ($(NVCC),)
 	$(NVCC) --version
-	@echo ""
 endif
+	@echo ""
+	@echo CXX=$(CXX)
 ifneq ($(shell $(CXX) --version | grep ^clang),)
 	@echo $(CXX) -v
 	@$(CXX) -v |& egrep -v '(Found|multilib)'

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -41,7 +41,7 @@ endif
 # If CUDA_HOME is not set, try to set it from the location of nvcc
 ifndef CUDA_HOME
   CUDA_HOME = $(patsubst %bin/nvcc,%,$(shell which nvcc 2>/dev/null))
-  $(warning CUDA_HOME was not set - try using "$(CUDA_HOME)")
+  $(warning CUDA_HOME was not set: using "$(CUDA_HOME)")
 endif
 
 # Set NVCC as $(CUDA_HOME)/bin/nvcc if it exists

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -296,13 +296,17 @@ namespace Proc
   const std::string CPPProcess::getCompiler()
   {
     std::stringstream out;
+    // CUDA (nvcc) version
 #ifdef __CUDACC__
 #if defined __CUDACC_VER_MAJOR__ && defined __CUDACC_VER_MINOR__ && defined __CUDACC_VER_BUILD__
     out << "nvcc " << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__ << "." << __CUDACC_VER_BUILD__;
 #else
     out << "nvcc UNKNOWN";
 #endif
-#elif defined __clang__
+    out << " (";
+#endif
+    // CXX (clang or gcc) version
+#if defined __clang__
 #if defined __clang_major__ && defined __clang_minor__ && defined __clang_patchlevel__
     out << "clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__;
     // Get the clang gcc toolchain
@@ -313,16 +317,23 @@ namespace Proc
     std::array<char, 128> tchainbuf;
     while ( fgets( tchainbuf.data(), tchainbuf.size(), tchainpipe.get() ) != nullptr ) tchainout += tchainbuf.data();
     tchainout.pop_back(); // remove trailing newline
+#ifdef __CUDACC__
+    out << ", gcc " << tchainout;
+#else
     out << " (gcc " << tchainout << ")";
+#endif
 #else
     out << "clang UNKNOWKN";
 #endif
 #else
 #if defined __GNUC__ && defined __GNUC_MINOR__ && defined __GNUC_PATCHLEVEL__
-    out << "gcc (GCC) " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+    out << "gcc " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
 #else
     out << "gcc UNKNOWKN";
 #endif
+#endif
+#ifdef __CUDACC__
+    out << ")";
 #endif
     return out.str();
   }

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
+#include <memory>
 
 #include "mgOnGpuConfig.h"
 #include "mgOnGpuTypes.h"
@@ -304,6 +305,15 @@ namespace Proc
 #elif defined __clang__
 #if defined __clang_major__ && defined __clang_minor__ && defined __clang_patchlevel__
     out << "clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__;
+    // Get the clang gcc toolchain
+    std::string tchaincmd = "readelf -p .comment $(${CXX} -print-libgcc-file-name) |& grep 'GCC: (GNU)' | grep -v Warning | sort -u | awk '{print $5}'";
+    std::unique_ptr<FILE, decltype(&pclose)> tchainpipe( popen( tchaincmd.c_str(), "r" ), pclose );
+    if ( !tchainpipe ) throw std::runtime_error( "`readelf ...` failed?" );
+    std::array<char, 128> tchainbuf;
+    std::string tchainout;
+    while ( fgets( tchainbuf.data(), tchainbuf.size(), tchainpipe.get() ) != nullptr ) tchainout += tchainbuf.data();
+    tchainout.pop_back(); // remove trailing newline
+    out << " (gcc " << tchainout << ")";
 #else
     out << "clang UNKNOWKN";
 #endif

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -306,11 +306,11 @@ namespace Proc
 #if defined __clang_major__ && defined __clang_minor__ && defined __clang_patchlevel__
     out << "clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__;
     // Get the clang gcc toolchain
+    std::string tchainout;
     std::string tchaincmd = "readelf -p .comment $(${CXX} -print-libgcc-file-name) |& grep 'GCC: (GNU)' | grep -v Warning | sort -u | awk '{print $5}'";
     std::unique_ptr<FILE, decltype(&pclose)> tchainpipe( popen( tchaincmd.c_str(), "r" ), pclose );
     if ( !tchainpipe ) throw std::runtime_error( "`readelf ...` failed?" );
     std::array<char, 128> tchainbuf;
-    std::string tchainout;
     while ( fgets( tchainbuf.data(), tchainbuf.size(), tchainpipe.get() ) != nullptr ) tchainout += tchainbuf.data();
     tchainout.pop_back(); // remove trailing newline
     out << " (gcc " << tchainout << ")";

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -296,7 +296,7 @@ namespace Proc
   const std::string CPPProcess::getCompiler()
   {
     std::stringstream out;
-    // CUDA (nvcc) version
+    // CUDA version (NVCC)
 #ifdef __CUDACC__
 #if defined __CUDACC_VER_MAJOR__ && defined __CUDACC_VER_MINOR__ && defined __CUDACC_VER_BUILD__
     out << "nvcc " << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__ << "." << __CUDACC_VER_BUILD__;
@@ -305,11 +305,11 @@ namespace Proc
 #endif
     out << " (";
 #endif
-    // CXX (clang or gcc) version
+    // CLANG version (either as CXX or as host compiler inside NVCC)
 #if defined __clang__
 #if defined __clang_major__ && defined __clang_minor__ && defined __clang_patchlevel__
     out << "clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__;
-    // Get the clang gcc toolchain
+    // GCC toolchain version inside CLANG
     std::string tchainout;
     std::string tchaincmd = "readelf -p .comment $(${CXX} -print-libgcc-file-name) |& grep 'GCC: (GNU)' | grep -v Warning | sort -u | awk '{print $5}'";
     std::unique_ptr<FILE, decltype(&pclose)> tchainpipe( popen( tchaincmd.c_str(), "r" ), pclose );
@@ -326,6 +326,7 @@ namespace Proc
     out << "clang UNKNOWKN";
 #endif
 #else
+    // GCC version (either as CXX or as host compiler inside NVCC)
 #if defined __GNUC__ && defined __GNUC_MINOR__ && defined __GNUC_PATCHLEVEL__
     out << "gcc " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
 #else

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -926,20 +926,20 @@ int main(int argc, char **argv)
              << "\"Curand generation\": "
 #ifdef __CUDACC__
 #if defined MGONGPU_COMMONRAND_ONHOST
-             << "\"COMMON RANDOM HOST (CUDA code)\"," << std::endl
+             << "\"COMMON RANDOM HOST (CUDA code)\"," << std::endl;
 #elif defined MGONGPU_CURAND_ONDEVICE
-             << "\"CURAND DEVICE (CUDA code)\"," << std::endl
+             << "\"CURAND DEVICE (CUDA code)\"," << std::endl;
 #elif defined MGONGPU_CURAND_ONHOST
-             << "\"CURAND HOST (CUDA code)\"," << std::endl
+             << "\"CURAND HOST (CUDA code)\"," << std::endl;
 #endif
 #else
 #if defined MGONGPU_COMMONRAND_ONHOST
-             << "\"COMMON RANDOM (C++ code)\"," << std::endl
+             << "\"COMMON RANDOM (C++ code)\"," << std::endl;
 #else
-             << "\"CURAND (C++ code)\"," << std::endl
+             << "\"CURAND (C++ code)\"," << std::endl;
 #endif
 #endif
-             << "\"NumberOfEntries\": " << niter << "," << std::endl
+    jsonFile << "\"NumberOfEntries\": " << niter << "," << std::endl
       //<< std::scientific // Not sure about this
              << "\"TotalTime[Rnd+Rmb+ME] (123)\": \""
              << std::to_string(sumgtim+sumrtim+sumwtim) << " sec\","

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -728,10 +728,10 @@ int main(int argc, char **argv)
 #ifndef __CUDACC__
     // Get the output of "nproc --all" (https://stackoverflow.com/a/478960)
     std::string nprocall;
-    std::array<char, 128> nprocbuf;
     std::unique_ptr<FILE, decltype(&pclose)> nprocpipe( popen( "nproc --all", "r" ), pclose );
-    if ( !nprocpipe ) throw std::runtime_error("`nproc --all` failed?");
-    while ( fgets( nprocbuf.data(), nprocbuf.size(), nprocpipe.get()) != nullptr ) nprocall += nprocbuf.data();
+    if ( !nprocpipe ) throw std::runtime_error( "`nproc --all` failed?" );
+    std::array<char, 128> nprocbuf;
+    while ( fgets( nprocbuf.data(), nprocbuf.size(), nprocpipe.get() ) != nullptr ) nprocall += nprocbuf.data();
 #endif
 #ifdef MGONGPU_CPPSIMD
 #ifdef MGONGPU_HAS_CXTYPE_REF

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -236,7 +236,7 @@ function runNcuReq() {
 }
 
 if nvidia-smi -L > /dev/null 2>&1; then gpuTxt=$(nvidia-smi -L | awk '{print $3,$4,$5}'); else gpuTxt=none; fi
-cpuTxt=$(cat /proc/cpuinfo | grep '^model name' | head -1 | awk '{i0=index($0,"Intel"); i1=index($0," @"); print substr($0,i0,i1-i0)}')
+cpuTxt=$(cat /proc/cpuinfo | grep '^model name' | head -1 | awk '{i0=index($0,"Intel"); i1=index($0," @"); if (i1>0) {print substr($0,i0,i1-i0)} else {print substr($0,i0)}}')
 echo -e "On $HOSTNAME [CPU: $cpuTxt] [GPU: $gpuTxt]:"
 
 lastExe=

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -23,7 +23,7 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
 endif
 
 # Set the host compiler for nvcc
-override NVCC := $(NVCC) -ccbin $(subst ccache ,,$(CXX))
+CUFLAGS += -ccbin $(subst ccache ,,$(CXX))
 
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -10,20 +10,23 @@ CXX     ?= g++
 
 # If CUDA_HOME is not set, try to set it from the location of nvcc
 ifndef CUDA_HOME
-  NVCC ?= $(shell which nvcc 2>/dev/null)
-  ifneq ($(NVCC),)
-    # NVCC is in the PATH or set explicitly
-    CUDA_HOME  = $(patsubst %bin/nvcc,%,$(NVCC))
-    CUDA_HOME := $(warning No CUDA_HOME exported. Using "$(CUDA_HOME)") $(CUDA_HOME)
-  endif
+  CUDA_HOME = $(patsubst %bin/nvcc,%,$(shell which nvcc 2>/dev/null))
+  #$(warning CUDA_HOME was not set: using "$(CUDA_HOME)")
 endif
+
+# Set NVCC as $(CUDA_HOME)/bin/nvcc if it exists
+# (NB: only CUINC is needed: cuda includes are needed in the C++ code for curand.h)
 ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
-  NVCC = $(CUDA_HOME)/bin/nvcc
+  #NVCC = $(CUDA_HOME)/bin/nvcc
   CUINC = -I$(CUDA_HOME)/include/
+else
+  # No cuda. Switch cuda compilation off and go to common random numbers in C++
+  #$(warning CUDA_HOME is not set or is invalid. Export CUDA_HOME to compile with cuda)
+  NVCC := 
 endif
 
 # Set the host compiler for nvcc
-CUFLAGS += -ccbin $(subst ccache ,,$(CXX))
+#CUFLAGS += -ccbin $(subst ccache ,,$(CXX))
 
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]
@@ -47,10 +50,10 @@ CXXFLAGS+= $(AVXFLAGS)
 ###$(info FPTYPE=$(FPTYPE))
 ifeq ($(FPTYPE),d)
   CXXFLAGS += -DMGONGPU_FPTYPE_DOUBLE
-  CUFLAGS  += -DMGONGPU_FPTYPE_DOUBLE
+  #CUFLAGS  += -DMGONGPU_FPTYPE_DOUBLE
 else ifeq ($(FPTYPE),f)
   CXXFLAGS += -DMGONGPU_FPTYPE_FLOAT
-  CUFLAGS  += -DMGONGPU_FPTYPE_FLOAT
+  #CUFLAGS  += -DMGONGPU_FPTYPE_FLOAT
 else
   $(error Unknown FPTYPE='$(FPTYPE)': only 'f' and 'd' are supported)
 endif
@@ -59,13 +62,13 @@ endif
 ###$(info RNDGEN=$(RNDGEN))
 ifeq ($(RNDGEN),curdev)
   CXXFLAGS += -DMGONGPU_CURAND_ONDEVICE
-  CUFLAGS  += -DMGONGPU_CURAND_ONDEVICE
+  #CUFLAGS  += -DMGONGPU_CURAND_ONDEVICE
 else ifeq ($(RNDGEN),curhst)
   CXXFLAGS += -DMGONGPU_CURAND_ONHOST
-  CUFLAGS  += -DMGONGPU_CURAND_ONHOST
+  #CUFLAGS  += -DMGONGPU_CURAND_ONHOST
 else ifeq ($(RNDGEN),common)
   CXXFLAGS += -DMGONGPU_COMMONRAND_ONHOST
-  CUFLAGS  += -DMGONGPU_COMMONRAND_ONHOST
+  #CUFLAGS  += -DMGONGPU_COMMONRAND_ONHOST
 else
   $(error Unknown RNDGEN='$(RNDGEN)': only 'curdev', 'curhst' and 'common' are supported)
 endif
@@ -96,9 +99,11 @@ endif
 ifeq ($(USECCACHE)$(shell echo $(AR) | grep ccache),1)
   override AR:=ccache $(AR)
 endif
-ifeq ($(USECCACHE)$(shell echo $(NVCC) | grep ccache),1)
-  override NVCC:=ccache $(NVCC)
-endif
+#ifneq ($(NVCC),)
+#  ifeq ($(USECCACHE)$(shell echo $(NVCC) | grep ccache),1)
+#    override NVCC:=ccache $(NVCC)
+#  endif
+#endif
 
 # Assuming uname is available, detect if architecture is power
 #UNAME_P := $(shell uname -p)
@@ -106,9 +111,10 @@ endif
 #  CUFLAGS+= -Xcompiler -mno-float128
 #endif
 
+# NB there are no cuda objects as we avoid rdc (e.g. grambo.cu is included by gcheck.cu)
 target=$(LIBDIR)/libmodel_sm.a
 cxx_objects=$(addprefix $(BUILDDIR)/, Parameters_sm.o read_slha.o rambo.o)
-cu_objects= # NB grambo.cu must be included by gcheck.cu (no rdc)
+cu_objects=
 
 all.$(TAG): $(BUILDDIR)/.build.$(TAG) $(target)
 
@@ -132,9 +138,9 @@ $(BUILDDIR)/%.o : %.cc *.h
 #	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
 #	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
-$(target): $(cxx_objects) #$(cu_objects)
+$(target): $(cxx_objects) $(cu_objects)
 	@if [ ! -d $(LIBDIR) ]; then mkdir -p $(LIBDIR); fi
-	$(AR) cru $@ $(cxx_objects) #$(cu_objects)
+	$(AR) cru $@ $(cxx_objects) $(cu_objects)
 	ranlib $(target)
 
 .PHONY: clean

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -23,7 +23,7 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
 endif
 
 # Set the host compiler for nvcc
-override NVCC := $(NVCC) -ccbin $(CXX)
+override NVCC := $(NVCC) -ccbin $(subst ccache ,,$(CXX))
 
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -22,6 +22,9 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   CUINC = -I$(CUDA_HOME)/include/
 endif
 
+# Set the host compiler for nvcc
+override NVCC := $(NVCC) -ccbin $(CXX)
+
 # Set the build flags appropriate to each AVX choice (example: "make AVX=none")
 # [NB MGONGPU_PVW512 is needed because "-mprefer-vector-width=256" is not exposed in a macro]
 # [See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96476]


### PR DESCRIPTION
This started off as a followup of issues reported by @hageboeck on itscrd04
- After an upgrade of clang from 10 to 11 by puppet, things no longer worked: he fixed it by upgrading cuda from 11.1 to 11.3 on his machine: he fixed i
- On my side however, using cvmfs clang, clang11.1 did not work because it was setup with gcc 10.3: I fixed it by downgrading the setup to gcc 10.2 (thanks to Dima, https://sft.its.cern.ch/jira/browse/SPI-1924)

As a followup:
- I understood there is a toolchain in clang and found a way to dump it (actually I am dumping the gcc used to build libgcc.a)
- As I was there, I also dumped the gcc/clang version used by nvcc
- I realised that nvcc with clang was NOT using clang, because "-ccbin" was missing, so I added that
- After adding that, nvcc builds did change and in particulary one failed, I added a simple fix for bracket nesting level

Now everything looks fine. Apart from the dumps, the main functional change is that nvcc builds with clang actually do use clang as host compiler
