### PR TITLE
Various LTO tests (emulate LTO by inline, use -flto only on one file, etc)

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -92,7 +92,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
   CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
-  CXXFLAGS+= -fno-semantic-interposition 
+  ######CXXFLAGS+= -fno-semantic-interposition # no benefit (neither alone, nor combined with -flto)
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -231,9 +231,9 @@ $(BUILDDIR)/%.o : %.cu *.h ../../src/*.h
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
 # Apply special build flags only to CPPProcess.cc (-flto)
-$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h
-	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -flto $(CUINC) -c $< -o $@
+#$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h
+#	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
+#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -flto $(CUINC) -c $< -o $@
 
 ### Apply special build flags only to CPPProcess.cc (AVXFLAGS)
 ###$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -92,6 +92,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
   ###CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
+  CXXFLAGS+= -fno-semantic-interposition 
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -91,7 +91,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
-  CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
+  ###CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -91,7 +91,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
-  ###CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
+  CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -91,7 +91,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
-  CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
+  ###CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
   ######CXXFLAGS+= -fno-semantic-interposition # no benefit (neither alone, nor combined with -flto)
 endif
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -91,7 +91,7 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # would increase to none=4.08-4.12E6, sse4=4.99-5.03E6!
 else
-  ###CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
+  CXXFLAGS+= -flto # also on Intel this would increase throughputs by a factor 2 to 4...
   CXXFLAGS+= -fno-semantic-interposition 
 endif
 

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -230,9 +230,15 @@ $(BUILDDIR)/%.o : %.cu *.h ../../src/*.h
 	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
 	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -c $< -o $@
 
-#$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h
-#	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
-#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(AVXFLAGS) $(CUINC) -c $< -o $@
+# Apply special build flags only to CPPProcess.cc (-flto)
+$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h
+	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -flto $(CUINC) -c $< -o $@
+
+### Apply special build flags only to CPPProcess.cc (AVXFLAGS)
+###$(BUILDDIR)/CPPProcess.o : CPPProcess.cc *.h ../../src/*.h
+###	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
+###	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(AVXFLAGS) $(CUINC) -c $< -o $@
 
 $(BUILDDIR)/%.o : %.cc *.h ../../src/*.h
 	@if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -59,6 +59,9 @@ namespace Proc
   // Evaluate |M|^2 for each subprocess
   // NB: calculate_wavefunctions ADDS |M|^2 for given ihel to running sum of |M|^2 over helicities for given event(s)
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void calculate_wavefunctions( int ihel,
                                 const fptype_sv* allmomenta, // input: momenta as AOSOA[npagM][npar][4][neppM], nevt=npagM*neppM
                                 fptype_sv* allMEs            // output: allMEs[npagM][neppM], final |M|^2 averaged over helicities

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -522,7 +522,8 @@ namespace Proc
 
 //==========================================================================
 
-// Strictly speaking, this is only needed for CUDA (to avoid rdc)
+// This was initially added to both C++ and CUDA in order to avoid RDC in CUDA (issue #51)
+// This is now also needed by C++ LTO-like optimizations via inlining (issue #229)
 #include "../../src/HelAmps_sm.cc"
 
 //==========================================================================

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/simdSym.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/simdSym.sh
@@ -79,6 +79,12 @@ function listSyms() {
 ###dump=$1; shift; listSyms $* # for debugging
 
 function mainListSyms() {
+  # Command line arguments: --disassemble-all?
+  dis=-d
+  if [ "$1" == "-D" ]; then
+    dis=-D
+    shift
+  fi
   # Command line arguments: select file
   if [ "$1" == "" ] || [ "$2" != "" ]; then
     echo "Usage:   $0 <filename>"
@@ -88,7 +94,7 @@ function mainListSyms() {
   file=$1
   # Disassemble selected file
   dump=${file}.objdump
-  objdump -d -C $file > ${dump}
+  objdump $dis -C $file > ${dump}
   # List symbols in selected file
   listSyms
 }

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/simdSymSummary.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/simdSymSummary.sh
@@ -43,6 +43,7 @@ function mainSummarizeSyms() {
 
   # Disassemble selected file
   # Use cut -f3- to print only the assembly code after two leading fields separated by tabs
+  objdump -d -C $file > ${file}.objdump # unnecessary but useful for debugging
   dumptmp=${file}.objdump.tmp
   if [ "$helamps" == "0" ]; then
     objdump -d -C $file | awk '/^ +[[:xdigit:]]+:\t/' | cut -f3- > ${dumptmp}

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/testxxx.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/testxxx.cc
@@ -301,3 +301,13 @@ TEST( XTESTID_CPU( MG_EPOCH_PROCESS_ID ), testxxx )
     std::cout << "INFO: New reference data dumped to file '" << dumpFileName << "'" << std::endl;
   }
 }
+
+//==========================================================================
+
+// This is needed if C++ LTO-like inlining optimizations are used in CPPProcess.cc (issue #229)
+#ifdef MGONGPU_INLINE_HELAMPS
+#include "../../src/HelAmps_sm.cc"
+#endif
+
+//==========================================================================
+

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -4,8 +4,9 @@ set +x
 
 omp=0
 avxall=0
-ep2=0
 cpp=1
+cuda=1
+ep2=0
 ab3=0
 ggttgg=0
 div=0
@@ -16,7 +17,7 @@ verbose=0
 
 function usage()
 {
-  echo "Usage: $0 [-nocpp|[-omp][-avxall]] [-ep2] [-3a3b] [-ggttgg] [-div] [-req] [-flt|-fltonly] [-detailed] [-v]"
+  echo "Usage: $0 [-nocpp|[-omp][-avxall][-nocuda]] [-ep2] [-3a3b] [-ggttgg] [-div] [-req] [-flt|-fltonly] [-detailed] [-v]"
   exit 1
 }
 
@@ -33,9 +34,14 @@ while [ "$1" != "" ]; do
     if [ "${cpp}" == "0" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
     avxall=1
     shift
+  elif [ "$1" == "-nocuda" ]; then
+    if [ "${cpp}" == "0" ]; then echo "ERROR! Options -nocuda and -nocpp are incompatible"; usage; fi
+    cuda=0
+    shift
   elif [ "$1" == "-nocpp" ]; then
+    if [ "${omp}" == "1" ]; then echo "ERROR! Options -omp and -nocpp are incompatible"; usage; fi
     if [ "${avxall}" == "1" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
-    if [ "${omp}" == "1" ]; then echo "ERROR! Options -avxall and -nocpp are incompatible"; usage; fi
+    if [ "${cuda}" == "1" ]; then echo "ERROR! Options -nocuda and -nocpp are incompatible"; usage; fi
     cpp=0
     shift
   elif [ "$1" == "-ep2" ]; then
@@ -82,11 +88,13 @@ exes=
 #=====================================
 # CUDA (eemumu/epoch1, eemumu/epoch2)
 #=====================================
-for fptype in $df; do
-  exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_$fptype/gcheck.exe"
-done
-if [ "${ep2}" == "1" ]; then 
-  exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+if [ "${cuda}" == "1" ]; then
+  for fptype in $df; do
+    exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_$fptype/gcheck.exe"
+  done
+  if [ "${ep2}" == "1" ]; then 
+    exes="$exes ../../../../../epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/gcheck.exe"
+  fi
 fi
 
 #=====================================
@@ -116,8 +124,10 @@ fi
 #=====================================
 # CUDA (ggttgg/epoch2)
 #=====================================
-if [ "${ggttgg}" == "1" ]; then 
-  exes="$exes ../../../../../epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/gcheck.exe"
+if [ "${cuda}" == "1" ]; then
+  if [ "${ggttgg}" == "1" ]; then 
+    exes="$exes ../../../../../epoch2/cuda/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/gcheck.exe"
+  fi
 fi
 
 #=====================================

--- a/epoch1/cuda/ee_mumu/src/HelAmps_sm.cc
+++ b/epoch1/cuda/ee_mumu/src/HelAmps_sm.cc
@@ -55,6 +55,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void ixxxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const fptype fmass,
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -189,6 +192,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void ipzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                //const fptype fmass,        // ASSUME fmass==0
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -237,6 +243,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void imzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                //const fptype fmass,        // ASSUME fmass==0
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -285,6 +294,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void ixzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                //const fptype fmass,        // ASSUME fmass==0
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -346,6 +358,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void vxxxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const fptype vmass,
                const int nhel,              // input: -1, 0 (only if vmass!=0) or +1 (helicity of vector boson)
@@ -481,6 +496,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void sxxxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const fptype,                // WARNING: "smass" unused (missing in Fortran)
                const int,                   // WARNING: "nhel" unused (missing in Fortran) - scalar has no helicity
@@ -521,6 +539,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void oxxxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const fptype fmass,
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -656,6 +677,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void opzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const int nhel,              // input: -1 or +1 (helicity of fermion)
                const int nsf,               // input: +1 (particle) or -1 (antiparticle)
@@ -703,6 +727,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void omzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                const int nhel,              // input: -1 or +1 (helicity of fermion)
                const int nsf,               // input: +1 (particle) or -1 (antiparticle)
@@ -753,6 +780,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void oxzxxx( const fptype_sv* allmomenta, // input[(npar=4)*(np4=4)*nevt]
                //const fptype fmass,        // ASSUME fmass==0
                const int nhel,              // input: -1 or +1 (helicity of fermion)
@@ -812,6 +842,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV1_0( const cxtype_sv F1[],   // input: wavefunction1[6]
                const cxtype_sv F2[],   // input: wavefunction2[6]
                const cxtype_sv V3[],   // input: wavefunction3[6]
@@ -832,6 +865,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV1P0_3( const cxtype_sv F1[],     // input: wavefunction1[6]
                  const cxtype_sv F2[],     // input: wavefunction2[6]
                  const cxtype COUP,
@@ -856,6 +892,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV2_0( const cxtype_sv F1[],   // input: wavefunction1[6]
                const cxtype_sv F2[],   // input: wavefunction2[6]
                const cxtype_sv V3[],   // input: wavefunction3[6]
@@ -874,6 +913,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV2_3( const cxtype_sv F1[],   // input: wavefunction1[6]
                const cxtype_sv F2[],   // input: wavefunction2[6]
                const cxtype COUP,
@@ -901,6 +943,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV4_0( const cxtype_sv F1[],   // input: wavefunction1[6]
                const cxtype_sv F2[],   // input: wavefunction2[6]
                const cxtype_sv V3[],   // input: wavefunction3[6]
@@ -923,6 +968,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV4_3( const cxtype_sv F1[],   // input: wavefunction1[6]
                const cxtype_sv F2[],   // input: wavefunction2[6]
                const cxtype_sv COUP,
@@ -959,6 +1007,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV2_4_0( const cxtype_sv F1[],   // input: wavefunction1[6]
                  const cxtype_sv F2[],   // input: wavefunction2[6]
                  const cxtype_sv V3[],   // input: wavefunction3[6]
@@ -983,6 +1034,9 @@ namespace MG5_sm
   //--------------------------------------------------------------------------
 
   __device__
+#ifdef MGONGPU_INLINE_HELAMPS
+  inline
+#endif
   void FFV2_4_3( const cxtype_sv F1[],   // input: wavefunction1[6]
                  const cxtype_sv F2[],   // input: wavefunction2[6]
                  const cxtype COUP1,

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -47,7 +47,7 @@ else
   AR=gcc-ar # needed by -flto
   RANLIB=gcc-ranlib # needed by -flto
   CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
-  CXXFLAGS+= -fno-semantic-interposition 
+  ######CXXFLAGS+= -fno-semantic-interposition # no benefit (neither alone, nor combined with -flto)
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -44,9 +44,9 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 else
-  AR=gcc-ar # needed by -flto
-  RANLIB=gcc-ranlib # needed by -flto
-  CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  ###AR=gcc-ar # needed by -flto
+  ###RANLIB=gcc-ranlib # needed by -flto
+  ###CXXFLAGS+= -flto # NB: build error from src/Makefile unless gcc-ar and gcc-ranlib are used
   ######CXXFLAGS+= -fno-semantic-interposition # no benefit (neither alone, nor combined with -flto)
 endif
 

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -44,9 +44,9 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 else
-  ###AR=gcc-ar # needed by -flto
-  ###RANLIB=gcc-ranlib # needed by -flto
-  ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  AR=gcc-ar # needed by -flto
+  RANLIB=gcc-ranlib # needed by -flto
+  CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
   CXXFLAGS+= -fno-semantic-interposition 
 endif
 

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -6,7 +6,10 @@ CXXFLAGS+= -ffast-math # see issue #117
 ###CXXFLAGS+= -Ofast # performance is not different from --fast-math
 ###CXXFLAGS+= -g # FOR DEBUGGING ONLY
 LIBFLAGS = -L$(LIBDIR) -l$(MODELLIB)
-CXX     ?= g++
+
+# Note: AR and CXX are implicitly defined if not set externally
+# See https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+RANLIB = ranlib
 
 # Assuming uname is available, detect if architecture is PowerPC
 UNAME_P := $(shell uname -p)
@@ -41,7 +44,9 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 else
-  ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  AR=gcc-ar # needed by -flto
+  RANLIB=gcc-ranlib # needed by -flto
+  CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)
@@ -164,7 +169,7 @@ $(BUILDDIR)/%.o : %.cc *.h
 $(target): $(cxx_objects) $(cu_objects)
 	@if [ ! -d $(LIBDIR) ]; then mkdir -p $(LIBDIR); fi
 	$(AR) cru $@ $(cxx_objects) $(cu_objects)
-	ranlib $(target)
+	$(RANLIB) $(target)
 
 .PHONY: clean
 

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -44,9 +44,9 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 else
-  AR=gcc-ar # needed by -flto
-  RANLIB=gcc-ranlib # needed by -flto
-  CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  ###AR=gcc-ar # needed by -flto
+  ###RANLIB=gcc-ranlib # needed by -flto
+  ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -47,6 +47,7 @@ else
   ###AR=gcc-ar # needed by -flto
   ###RANLIB=gcc-ranlib # needed by -flto
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  CXXFLAGS+= -fno-semantic-interposition 
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -44,9 +44,9 @@ ifeq ($(UNAME_P),ppc64le)
   ###CXXFLAGS+= -ftree-vectorize # no change
   ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 else
-  ###AR=gcc-ar # needed by -flto
-  ###RANLIB=gcc-ranlib # needed by -flto
-  ###CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
+  AR=gcc-ar # needed by -flto
+  RANLIB=gcc-ranlib # needed by -flto
+  CXXFLAGS+= -flto # BUILD ERROR IF THIS ADDED IN SRC?!
 endif
 
 # PowerPC-specific CUDA compiler flags (to be reviewed!)

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -29,8 +29,8 @@
 
 // Inline all HelAmps functions? (CHOOSE ONLY ONE)
 // This optimization can gain almost a factor 4 in C++, similar to -flto (issue #229)
-#undef MGONGPU_INLINE_HELAMPS
-//#define MGONGPU_INLINE_HELAMPS 1
+//#undef MGONGPU_INLINE_HELAMPS
+#define MGONGPU_INLINE_HELAMPS 1
 
 // Cuda nsight compute (ncu) debug: add dummy lines to ease SASS program flow navigation
 #ifdef __CUDACC__

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -29,8 +29,8 @@
 
 // Inline all HelAmps functions? (CHOOSE ONLY ONE)
 // This optimization can gain almost a factor 4 in C++, similar to -flto (issue #229)
-//#undef MGONGPU_INLINE_HELAMPS
-#define MGONGPU_INLINE_HELAMPS 1
+#undef MGONGPU_INLINE_HELAMPS
+//#define MGONGPU_INLINE_HELAMPS 1
 
 // Cuda nsight compute (ncu) debug: add dummy lines to ease SASS program flow navigation
 #ifdef __CUDACC__

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -27,6 +27,11 @@
 //#define MGONGPU_CXTYPE_CUCOMPLEX 1 // ~5% slower (6.5E8 against 6.8E8)
 #endif
 
+// Inline all HelAmps functions? (CHOOSE ONLY ONE)
+// This optimization can gain almost a factor 4 in C++, similar to -flto (issue #229)
+//#undef MGONGPU_INLINE_HELAMPS
+#define MGONGPU_INLINE_HELAMPS 1
+
 // Cuda nsight compute (ncu) debug: add dummy lines to ease SASS program flow navigation
 #ifdef __CUDACC__
 #undef MGONGPU_NSIGHT_DEBUG // default

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ all: gtest src/MadgraphTest.o
 .PHONY: gtest
 
 googletest:
-	git clone https://github.com/google/googletest.git -b release-1.10.0 googletest
+	git clone https://github.com/google/googletest.git -b release-1.11.0 googletest
 
 googletest/build: googletest
 	mkdir -p $@


### PR DESCRIPTION
This is another patch for issue #229. The idea is to recover some of the LTO benefits with code changes such as inlining, rather than with the -flto build flag.