### PR TITLE
Upgrade googletest from 1.10.0 to 1.11.0

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ all: gtest src/MadgraphTest.o
 .PHONY: gtest
 
 googletest:
-	git clone https://github.com/google/googletest.git -b release-1.10.0 googletest
+	git clone https://github.com/google/googletest.git -b release-1.11.0 googletest
 
 googletest/build: googletest
 	mkdir -p $@

--- a/test/src/MadgraphTest.cc
+++ b/test/src/MadgraphTest.cc
@@ -167,3 +167,7 @@ TEST_P(MadgraphTestFloat, eemumu)
 {
   madgraphTestBody_eemumu();
 }
+
+// Fix errors in the upgrade of googletest from 1.10.0 to 1.11.0
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(MadgraphTestFloat);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(MadgraphTestDouble);


### PR DESCRIPTION
Upgrade googletest from 1.10.0 to 1.11.0

This is needed to port to gcc11.1 and avoid [-Werror=maybe-uninitialized]

A small fix in a test .cc is also required (fixed using the advice by googletest)