### PR TITLE
CORI tests - first performance benefit of AVX512/zmm

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -63,8 +63,7 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   CUARCHFLAGS = -arch=compute_$(CUARCHNUM)
   ###CUARCHFLAGS = -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
   CUINC       = -I$(CUDA_HOME)/include/
-  #CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcuda -lcurand
-  CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcurand # CORI?
+  CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcurand # NB: -lcuda is not needed here!
   CUOPTFLAGS  = -lineinfo
   CUFLAGS     = $(OPTFLAGS) $(CUOPTFLAGS) -std=c++14 $(INCFLAGS) $(CUINC) $(USE_NVTX) $(CUARCHFLAGS) -use_fast_math
   # Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)

--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -63,7 +63,8 @@ ifneq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
   CUARCHFLAGS = -arch=compute_$(CUARCHNUM)
   ###CUARCHFLAGS = -gencode arch=compute_$(CUARCHNUM),code=sm_$(CUARCHNUM)
   CUINC       = -I$(CUDA_HOME)/include/
-  CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcuda -lcurand
+  #CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcuda -lcurand
+  CULIBFLAGS  = -L$(CUDA_HOME)/lib64/ -lcurand # CORI?
   CUOPTFLAGS  = -lineinfo
   CUFLAGS     = $(OPTFLAGS) $(CUOPTFLAGS) -std=c++14 $(INCFLAGS) $(CUINC) $(USE_NVTX) $(CUARCHFLAGS) -use_fast_math
   # Without -maxrregcount: baseline throughput: 6.5E8 (16384 32 12) up to 7.3E8 (65536 128 12)


### PR DESCRIPTION
Interesting, first time I see AVX512z better than AVX512y...
Unfortunately I have no perf to chech better

```
On cori04 [CPU: Intel(R) Xeon(R) Gold 6148 CPU] [GPU: 1x Tesla V100-SXM2-16GB]:
=========================================================================
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 10.1.0)]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 7.520234e+08                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 1.425600e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     0.542458 sec
real    0m0.663s
==PROF== Profiling "sigmaKin": launch__registers_per_thread 122
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 10.1.0)]
FP precision                = FLOAT (NaN/abnormal=2, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 1.636039e+09                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 3.453580e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
TOTAL       :     0.580860 sec
real    0m0.685s
==PROF== Profiling "sigmaKin": launch__registers_per_thread 48
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
=========================================================================
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 1.728110e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     5.001435 sec
real    0m5.017s
=Symbols in CPPProcess.o= (~sse4:  638) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 3.367340e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.211082 sec
real    0m3.226s
=Symbols in CPPProcess.o= (~sse4: 3291) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 6.840681e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     2.201916 sec
real    0m2.217s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2792) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 6.926176e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     2.213485 sec
real    0m2.229s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2690) (512y:   51) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 7.523325e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     2.148971 sec
real    0m2.165s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1283) (512y:   64) (512z: 2125)
-------------------------------------------------------------------------Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 1.565369e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
TOTAL       :     5.129722 sec
real    0m5.140s
=Symbols in CPPProcess.o= (~sse4:  584) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 5.567020e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
TOTAL       :     2.318101 sec
real    0m2.329s
=Symbols in CPPProcess.o= (~sse4: 3974) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 1.227348e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     1.632430 sec
real    0m1.643s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3130) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 1.315622e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     1.571972 sec
real    0m1.583s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3027) (512y:   26) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 10.1.0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 80
EvtsPerSec[MECalcOnly] (3a) = ( 1.656728e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
TOTAL       :     1.449660 sec
real    0m1.461s
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1724) (512y:   13) (512z: 2235)
=========================================================================
```