### PR TITLE
Simultaneous builds and tests with and without inlining

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/Makefile
+++ b/epoch1/cuda/ee_mumu/SubProcesses/Makefile
@@ -43,6 +43,11 @@ ifeq ($(FPTYPE),)
   override FPTYPE = d
 endif
 
+# Set the default HELINL (inline helicities?) choice
+ifeq ($(HELINL),)
+  override HELINL = 0
+endif
+
 # Set the default RNDGEN (random number generator) choice
 ifeq ($(RNDGEN),)
   override RNDGEN = curdev
@@ -142,6 +147,15 @@ else
   $(error Unknown FPTYPE='$(FPTYPE)': only 'f' and 'd' are supported)
 endif
 
+# Set the build flags appropriate to each HELINL choice (example: "make HELINL=1")
+$(info HELINL=$(HELINL))
+ifeq ($(HELINL),1)
+  CXXFLAGS += -DMGONGPU_INLINE_HELAMPS
+  CUFLAGS  += -DMGONGPU_INLINE_HELAMPS
+else ifneq ($(HELINL),0)
+  $(error Unknown HELINL='$(HELINL)': only '0' and '1' are supported)
+endif
+
 # Set the build flags appropriate to each RNDGEN choice (example: "make RNDGEN=common")
 $(info RNDGEN=$(RNDGEN))
 ifeq ($(RNDGEN),curdev)
@@ -157,18 +171,19 @@ else
   $(error Unknown RNDGEN='$(RNDGEN)': only 'curdev', 'curhst' and 'common' are supported)
 endif
 
-# Export AVX, FPTYPE, RNDGEN so that it is not necessary to pass them to the src Makefile too
+# Export AVX, FPTYPE, HELINL, RNDGEN so that it is not necessary to pass them to the src Makefile too
 export AVX
 export FPTYPE
+export HELINL
 export RNDGEN
 
 # Build directory "short" tag (defines target and path to the optional build directory)
 # (Rationale: keep directory names shorter, e.g. do not include random number generator choice)
-override DIRTAG = $(AVX)_$(FPTYPE)
+override DIRTAG = $(AVX)_$(FPTYPE)_inl$(HELINL)
 
 # Build lockfile "full" tag (defines full specification of build options that cannot be intermixed)
 # (Rationale: avoid mixing of CUDA and no-CUDA environment builds with different random number generators)
-override TAG = $(AVX)_$(FPTYPE)_$(RNDGEN)
+override TAG = $(AVX)_$(FPTYPE)_inl$(HELINL)_$(RNDGEN)
 
 # Build directory: current directory by default, or build.$(DIRTAG) if USEBUILDDIR==1
 ifeq ($(USEBUILDDIR),1)

--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check.cc
@@ -751,10 +751,14 @@ int main(int argc, char **argv)
     std::cout << std::string(SEP79, '*') << std::endl
 #ifdef __CUDACC__
               << "Process                     = " << XSTRINGIFY(MG_EPOCH_PROCESS_ID) << "_CUDA"
-              << " [" << process.getCompiler() << "]" << std::endl
 #else
               << "Process                     = " << XSTRINGIFY(MG_EPOCH_PROCESS_ID) << "_CPP"
-              << " [" << process.getCompiler() << "]" << std::endl
+#endif
+              << " [" << process.getCompiler() << "]"
+#ifdef MGONGPU_INLINE_HELAMPS
+              << " [inlineHel=1]" << std::endl
+#else
+              << " [inlineHel=0]" << std::endl
 #endif
               << "NumBlocksPerGrid            = " << gpublocks << std::endl
               << "NumThreadsPerBlock          = " << gputhreads << std::endl

--- a/epoch1/cuda/ee_mumu/src/Makefile
+++ b/epoch1/cuda/ee_mumu/src/Makefile
@@ -97,6 +97,15 @@ else
   $(error Unknown FPTYPE='$(FPTYPE)': only 'f' and 'd' are supported)
 endif
 
+# Set the build flags appropriate to each HELINL choice (example: "make HELINL=1")
+###$(info HELINL=$(HELINL))
+ifeq ($(HELINL),1)
+  CXXFLAGS += -DMGONGPU_INLINE_HELAMPS
+  #CUFLAGS  += -DMGONGPU_INLINE_HELAMPS
+else ifneq ($(HELINL),0)
+  $(error Unknown HELINL='$(HELINL)': only '0' and '1' are supported)
+endif
+
 # Set the build flags appropriate to each RNDGEN choice (example: "make RNDGEN=common")
 ###$(info RNDGEN=$(RNDGEN))
 ifeq ($(RNDGEN),curdev)
@@ -114,11 +123,11 @@ endif
 
 # Build directory "short" tag (defines target and path to the optional build directory)
 # (Rationale: keep directory names shorter, e.g. do not include random number generator choice)
-override DIRTAG = $(AVX)_$(FPTYPE)
+override DIRTAG = $(AVX)_$(FPTYPE)_inl$(HELINL)
 
 # Build lockfile "full" tag (defines full specification of build options that cannot be intermixed)
 # (Rationale: avoid mixing of CUDA and no-CUDA environment builds with different random number generators)
-override TAG = $(AVX)_$(FPTYPE)_$(RNDGEN)
+override TAG = $(AVX)_$(FPTYPE)_inl$(HELINL)_$(RNDGEN)
 
 # Build directory: current directory by default, or build.$(DIRTAG) if USEBUILDDIR==1
 ifeq ($(USEBUILDDIR),1)

--- a/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
+++ b/epoch1/cuda/ee_mumu/src/mgOnGpuConfig.h
@@ -21,16 +21,17 @@
 //#define MGONGPU_FPTYPE_FLOAT 1 // 2.4x faster (~1.64E9 against 6.8E8)
 #endif
 
+// Choose whether to inline all HelAmps functions
+// This optimization can gain almost a factor 4 in C++, similar to -flto (issue #229)
+// By default, do not inline, but allow this macros to be set from outside with e.g. -DMGONGPU_INLINE_HELAMPS
+//#undef MGONGPU_INLINE_HELAMPS // default
+////#define MGONGPU_INLINE_HELAMPS 1
+
 // Complex type in cuda: thrust or cucomplex (CHOOSE ONLY ONE)
 #ifdef __CUDACC__
 #define MGONGPU_CXTYPE_THRUST 1 // default (~6.8E8)
 //#define MGONGPU_CXTYPE_CUCOMPLEX 1 // ~5% slower (6.5E8 against 6.8E8)
 #endif
-
-// Inline all HelAmps functions? (CHOOSE ONLY ONE)
-// This optimization can gain almost a factor 4 in C++, similar to -flto (issue #229)
-#undef MGONGPU_INLINE_HELAMPS
-//#define MGONGPU_INLINE_HELAMPS 1
 
 // Cuda nsight compute (ncu) debug: add dummy lines to ease SASS program flow navigation
 #ifdef __CUDACC__


### PR DESCRIPTION
…t aggressive inlining

```
On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
=========================================================================
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 9.2.0)] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 7.212939e+08                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 1.400295e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     0.849224 sec
     2,808,114,769      cycles                    #    2.588 GHz
     3,905,267,544      instructions              #    1.39  insn per cycle
       1.153374486 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 122
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 9.2.0)] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=2, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 1.391700e+09                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 3.261830e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
TOTAL       :     0.720050 sec
     2,519,873,643      cycles                    #    2.646 GHz
     3,695,253,338      instructions              #    1.47  insn per cycle
       1.015517484 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 48
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 9.2.0)] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 6.941261e+08                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 1.363094e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     0.811018 sec
     2,783,800,176      cycles                    #    2.651 GHz
     3,912,304,707      instructions              #    1.41  insn per cycle
       1.114209528 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 122
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CUDA [nvcc 11.4.48 (gcc 9.2.0)] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=2, zero=0)
EvtsPerSec[MatrixElems] (3) = ( 1.400312e+09                 )  sec^-1
EvtsPerSec[MECalcOnly] (3a) = ( 3.286396e+09                 )  sec^-1
MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
TOTAL       :     0.719431 sec
     2,506,452,444      cycles                    #    2.650 GHz
     3,694,417,124      instructions              #    1.47  insn per cycle
       1.011940239 seconds time elapsed
==PROF== Profiling "sigmaKin": launch__registers_per_thread 48
==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
=========================================================================
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.318427e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     7.235546 sec
    19,380,832,165      cycles                    #    2.672 GHz
    48,764,608,415      instructions              #    2.52  insn per cycle
       7.259182766 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  614) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 2.544157e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     4.928514 sec
    13,203,952,070      cycles                    #    2.669 GHz
    30,124,460,635      instructions              #    2.28  insn per cycle
       4.952199188 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4: 3274) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 4.599620e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.760575 sec
     9,551,000,139      cycles                    #    2.526 GHz
    16,746,784,852      instructions              #    1.75  insn per cycle
       3.784228078 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2746) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 4.942522e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.677088 sec
     9,365,149,286      cycles                    #    2.533 GHz
    16,683,540,674      instructions              #    1.78  insn per cycle
       3.700388180 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2572) (512y:   95) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 3.565285e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     4.173321 sec
     9,265,156,681      cycles                    #    2.210 GHz
    13,546,257,966      instructions              #    1.46  insn per cycle
       4.196664662 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1127) (512y:  205) (512z: 2045)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.208675e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
TOTAL       :     7.188579 sec
    19,265,327,616      cycles                    #    2.675 GHz
    47,812,080,167      instructions              #    2.48  insn per cycle
       7.205965330 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  578) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 4.552358e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
TOTAL       :     3.421159 sec
     9,158,720,466      cycles                    #    2.670 GHz
    19,803,984,519      instructions              #    2.16  insn per cycle
       3.437778429 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4: 3719) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 8.207503e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     2.769972 sec
     7,128,288,127      cycles                    #    2.560 GHz
    12,588,338,030      instructions              #    1.77  insn per cycle
       2.787861806 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3077) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 8.800518e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     2.708221 sec
     6,983,261,447      cycles                    #    2.566 GHz
    12,606,892,504      instructions              #    1.81  insn per cycle
       2.725243928 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2917) (512y:   81) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 7.041160e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
TOTAL       :     2.853162 sec
     6,673,968,987      cycles                    #    2.328 GHz
    11,013,378,592      instructions              #    1.65  insn per cycle
       2.870540890 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1559) (512y:  179) (512z: 2157)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 4.582173e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.828452 sec
    10,262,895,056      cycles                    #    2.668 GHz
    19,157,780,486      instructions              #    1.87  insn per cycle
       3.852100162 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  163) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 6.081384e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.487487 sec
     9,357,104,554      cycles                    #    2.669 GHz
    15,705,773,236      instructions              #    1.68  insn per cycle
       3.510681352 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  498) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.025374e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     2.995537 sec
     7,808,268,058      cycles                    #    2.590 GHz
    12,047,204,424      instructions              #    1.54  insn per cycle
       3.018613142 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  524) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.082475e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     2.992733 sec
     7,810,632,531      cycles                    #    2.593 GHz
    11,755,925,333      instructions              #    1.51  insn per cycle
       3.016263244 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  433) (512y:   15) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 7.769076e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
TOTAL       :     3.205406 sec
     7,722,855,175      cycles                    #    2.395 GHz
    10,916,378,460      instructions              #    1.41  insn per cycle
       3.228568931 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  130) (512y:   15) (512z:  318)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 4.914368e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
TOTAL       :     3.262435 sec
     8,752,968,444      cycles                    #    2.672 GHz
    18,407,763,149      instructions              #    2.10  insn per cycle
       3.278912088 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  180) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.229611e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
TOTAL       :     2.507796 sec
     6,732,048,884      cycles                    #    2.670 GHz
    12,382,744,726      instructions              #    1.84  insn per cycle
       2.524398017 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  585) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 2.039683e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     2.283740 sec
     6,006,965,123      cycles                    #    2.617 GHz
    10,164,472,517      instructions              #    1.69  insn per cycle
       2.300369327 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  588) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 2.238065e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
TOTAL       :     2.264588 sec
     5,969,249,872      cycles                    #    2.621 GHz
    10,046,255,732      instructions              #    1.68  insn per cycle
       2.281963503 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  499) (512y:   12) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=5, zero=0)
Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
OMP threads / `nproc --all` = 1 / 4
EvtsPerSec[MECalcOnly] (3a) = ( 1.669172e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
TOTAL       :     2.333696 sec
     5,849,649,158      cycles                    #    2.492 GHz
     9,622,400,849      instructions              #    1.64  insn per cycle
       2.350369337 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  198) (512y:   12) (512z:  343)
=========================================================================
```