### PR TITLE
Tests on an AMD EPYC node

### DIFF
--- a/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
+++ b/epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/throughput12.sh
@@ -120,10 +120,10 @@ for helinl in $inl; do
       exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_${fptype}_inl${helinl}/check.exe"
       exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_${fptype}_inl${helinl}/check.exe"
     fi
-    if [ "${cpp}" == "1" ]; then 
+    if [ "${cpp}" == "1" ] && [ "$(grep -m1 -c avx512vl /proc/cpuinfo)" == "1" ]; then 
       exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_${fptype}_inl${helinl}/check.exe"
     fi
-    if [ "${avxall}" == "1" ]; then 
+    if [ "${avxall}" == "1" ] && [ "$(grep -m1 -c avx512vl /proc/cpuinfo)" == "1" ]; then 
       exes="$exes ../../../../../epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_${fptype}_inl${helinl}/check.exe"
     fi
   done
@@ -166,8 +166,8 @@ for helinl in $inl; do
     make AVX=none; echo
     if [ "${avxall}" == "1" ]; then make AVX=sse4; echo; fi
     if [ "${avxall}" == "1" ]; then make AVX=avx2; echo; fi
-    if [ "${cpp}" == "1" ]; then make AVX=512y; echo; fi # always take 512y as the C++ reference, even if for clang avx2 is faster
-    if [ "${avxall}" == "1" ]; then make AVX=512z; echo; fi
+    if [ "${cpp}" == "1" ] && [ "$(grep -m1 -c avx512vl /proc/cpuinfo)" == "1" ]; then make AVX=512y; echo; fi # always take 512y as the C++ reference, even if for clang avx2 is faster (but skip it if not supported!)
+    if [ "${avxall}" == "1" ] && [ "$(grep -m1 -c avx512vl /proc/cpuinfo)" == "1" ]; then make AVX=512z; echo; fi
   done
 done
 popd >& /dev/null
@@ -276,7 +276,7 @@ unamep=$(uname -p)
 if [ "${unamep}" == "ppc64le" ]; then 
   cpuTxt=$(cat /proc/cpuinfo | grep ^machine | awk '{print substr($0,index($0,"Power"))", "}')$(cat /proc/cpuinfo | grep ^cpu | head -1 | awk '{print substr($0,index($0,"POWER"))}')
 else
-  cpuTxt=$(cat /proc/cpuinfo | grep '^model name' | head -1 | awk '{i0=index($0,"Intel"); i1=index($0," @"); if (i1>0) {print substr($0,i0,i1-i0)} else {print substr($0,i0)}}')
+  cpuTxt=$(cat /proc/cpuinfo | grep '^model name' | head -1 | awk '{i0=index($0,"Intel"); if (i0==0) i0=index($0,"AMD"); i1=index($0," @"); if (i1>0) {print substr($0,i0,i1-i0)} else {print substr($0,i0)}}')
 fi
 echo -e "On $HOSTNAME [CPU: $cpuTxt] [GPU: $gpuTxt]:"
 


### PR DESCRIPTION
Minor patches for AMD (only in the throughput script essentially)

Interesting performance, even in inline mode.
This AMD does not yet have AVX512 (it is a zen3 not a zen4?)

```
On b7s01p3272.cern.ch [CPU: AMD EPYC 7302 16-Core Processor] [GPU: none]:
=========================================================================
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 1.790062e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     5.262333 sec
    18,640,514,529      cycles                    #    3.271 GHz                      (60.00%)
     1,432,917,809      stalled-cycles-frontend   #    7.69% frontend cycles idle     (60.11%)
     1,003,671,602      stalled-cycles-backend    #    5.38% backend cycles idle      (60.13%)
    48,606,388,470      instructions              #    2.61  insn per cycle
                                                  #    0.03  stalled cycles per insn  (60.14%)
       5.267442975 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  614) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 3.400763e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     3.684801 sec
    13,394,877,121      cycles                    #    3.248 GHz                      (59.95%)
     1,443,046,459      stalled-cycles-frontend   #   10.77% frontend cycles idle     (59.36%)
       894,839,605      stalled-cycles-backend    #    6.68% backend cycles idle      (59.33%)
    30,509,899,644      instructions              #    2.28  insn per cycle
                                                  #    0.05  stalled cycles per insn  (59.24%)
       3.690049746 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4: 3274) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 7.041320e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     2.590213 sec
     9,868,103,807      cycles                    #    3.266 GHz                      (60.15%)
     1,380,923,621      stalled-cycles-frontend   #   13.99% frontend cycles idle     (60.34%)
       833,710,896      stalled-cycles-backend    #    8.45% backend cycles idle      (60.43%)
    16,683,521,360      instructions              #    1.69  insn per cycle
                                                  #    0.08  stalled cycles per insn  (60.34%)
       2.597024209 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2746) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 1.529296e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371779e-02 +- 3.268970e-06 )  GeV^0
TOTAL       :     5.380939 sec
    18,311,633,178      cycles                    #    3.261 GHz                      (59.94%)
       945,832,161      stalled-cycles-frontend   #    5.17% frontend cycles idle     (60.08%)
       847,106,138      stalled-cycles-backend    #    4.63% backend cycles idle      (60.11%)
    46,706,082,317      instructions              #    2.55  insn per cycle
                                                  #    0.02  stalled cycles per insn  (60.11%)
       5.386563442 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  578) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 5.934684e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371780e-02 +- 3.268970e-06 )  GeV^0
TOTAL       :     2.362167 sec
     8,475,411,126      cycles                    #    3.267 GHz                      (59.95%)
       926,585,890      stalled-cycles-frontend   #   10.93% frontend cycles idle     (60.01%)
       681,317,029      stalled-cycles-backend    #    8.04% backend cycles idle      (60.11%)
    18,786,518,201      instructions              #    2.22  insn per cycle
                                                  #    0.05  stalled cycles per insn  (60.19%)
       2.368856108 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4: 3719) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=0]
FP precision                = FLOAT (NaN/abnormal=4, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 1.147558e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371787e-02 +- 3.269413e-06 )  GeV^0
TOTAL       :     1.810575 sec
     6,641,203,529      cycles                    #    3.251 GHz                      (59.72%)
       940,209,521      stalled-cycles-frontend   #   14.16% frontend cycles idle     (60.14%)
       652,548,851      stalled-cycles-backend    #    9.83% backend cycles idle      (60.20%)
    11,491,557,470      instructions              #    1.73  insn per cycle
                                                  #    0.08  stalled cycles per insn  (60.24%)
       1.816615491 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3077) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 5.227925e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     2.929974 sec
    11,004,676,798      cycles                    #    3.266 GHz                      (60.10%)
     1,386,171,583      stalled-cycles-frontend   #   12.60% frontend cycles idle     (60.11%)
       965,136,809      stalled-cycles-backend    #    8.77% backend cycles idle      (60.01%)
    18,906,467,688      instructions              #    1.72  insn per cycle
                                                  #    0.07  stalled cycles per insn  (59.99%)
       2.936587747 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  163) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 7.589393e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     2.572034 sec
     9,814,496,112      cycles                    #    3.263 GHz                      (60.01%)
     1,386,091,393      stalled-cycles-frontend   #   14.12% frontend cycles idle     (60.14%)
       860,847,649      stalled-cycles-backend    #    8.77% backend cycles idle      (60.19%)
    15,703,812,468      instructions              #    1.60  insn per cycle
                                                  #    0.09  stalled cycles per insn  (60.26%)
       2.577875993 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  498) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 1.514028e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.372113e-02 +- 3.270608e-06 )  GeV^0
TOTAL       :     2.107620 sec
     8,265,179,278      cycles                    #    3.255 GHz                      (60.44%)
     1,354,383,415      stalled-cycles-frontend   #   16.39% frontend cycles idle     (60.35%)
       825,027,663      stalled-cycles-backend    #    9.98% backend cycles idle      (60.31%)
    12,014,744,785      instructions              #    1.45  insn per cycle
                                                  #    0.11  stalled cycles per insn  (59.88%)
       2.112479856 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  524) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 5.783732e+06                 )  sec^-1
MeanMatrixElemValue         = ( 1.371779e-02 +- 3.268970e-06 )  GeV^0
TOTAL       :     2.345963 sec
     8,413,201,674      cycles                    #    3.256 GHz                      (60.10%)
       902,628,888      stalled-cycles-frontend   #   10.73% frontend cycles idle     (60.15%)
       810,114,213      stalled-cycles-backend    #    9.63% backend cycles idle      (60.21%)
    17,318,842,828      instructions              #    2.06  insn per cycle
                                                  #    0.05  stalled cycles per insn  (60.17%)
       2.352630849 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  180) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=6, zero=0)
Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 1.694465e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371780e-02 +- 3.268970e-06 )  GeV^0
TOTAL       :     1.653767 sec
     6,134,059,591      cycles                    #    3.252 GHz                      (60.03%)
       909,830,650      stalled-cycles-frontend   #   14.83% frontend cycles idle     (60.11%)
       664,626,397      stalled-cycles-backend    #   10.84% backend cycles idle      (60.21%)
    11,372,767,439      instructions              #    1.85  insn per cycle
                                                  #    0.08  stalled cycles per insn  (60.31%)
       1.659193081 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:  585) (avx2:    0) (512y:    0) (512z:    0)
-------------------------------------------------------------------------
Process                     = EPOCH1_EEMUMU_CPP [gcc 9.2.0] [inlineHel=1]
FP precision                = FLOAT (NaN/abnormal=4, zero=0)
Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
Random number generation    = COMMON RANDOM (C++ code)
OMP threads / `nproc --all` = 1 / 64
EvtsPerSec[MECalcOnly] (3a) = ( 3.275830e+07                 )  sec^-1
MeanMatrixElemValue         = ( 1.371787e-02 +- 3.269413e-06 )  GeV^0
TOTAL       :     1.444105 sec
     5,451,930,107      cycles                    #    3.256 GHz                      (59.91%)
       934,593,213      stalled-cycles-frontend   #   17.14% frontend cycles idle     (59.88%)
       654,715,858      stalled-cycles-backend    #   12.01% backend cycles idle      (59.93%)
     9,123,578,136      instructions              #    1.67  insn per cycle
                                                  #    0.10  stalled cycles per insn  (59.94%)
       1.450689691 seconds time elapsed
=Symbols in CPPProcess.o= (~sse4:    0) (avx2:  588) (512y:    0) (512z:    0)
=========================================================================
```