### PR TITLE
[CI] Move to configuration matrix for CI.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,87 +9,52 @@ on:
 jobs:
   debug_builds:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
     steps:
     - uses: actions/checkout@v2
     - name: make epoch1
-      run: make -C epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
-    - name: make epoch2
-      run: make -C epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum debug
-  epoch1_eemumu:
+      run: make -C ${{ matrix.folder }} debug
+  CPU:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
+    strategy:
+      matrix:
+        folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
+        precision: [ d , f ]
     steps:
     - uses: actions/checkout@v2
     - name: make info
-      run: make info
+      run: make -C ${{ matrix.folder }} info
     - name: make
-      run: make
+      run: make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }}
     - name: make check
-      run: make check
-  epoch1_eemumu_float:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
+      run: make -C ${{ matrix.folder }} check
+  CPU_MAC:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
+        precision: [ d ]
     steps:
     - uses: actions/checkout@v2
     - name: make info
-      run: make info
+      run: make -C ${{ matrix.folder }} info
     - name: make
-      run: make FPTYPE=f
+      run: make AVX=none OMPFLAGS= FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }}
     - name: make check
-      run: make check
-  epoch2_eemumu:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
-    steps:
-    - uses: actions/checkout@v2
-    - name: make info
-      run: make info
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-  epoch1_eemumu_GPU:
+      run: make -C ${{ matrix.folder }} check
+  GPU:
     runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
+    strategy:
+      matrix:
+        folder: [ epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
+        precision: [ d , f ]
     steps:
     - uses: actions/checkout@v2
     - name: make info
-      run: source /opt/rh/gcc-toolset-9/enable; make info
+      run: source /opt/rh/gcc-toolset-10/enable; make -C ${{ matrix.folder }} info
     - name: make
-      run: source /opt/rh/gcc-toolset-9/enable; make
+      run: source /opt/rh/gcc-toolset-10/enable; make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }}
     - name: make check
-      run: source /opt/rh/gcc-toolset-9/enable; make check
-  epoch1_eemumu_GPU_float:
-    runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
-    steps:
-    - uses: actions/checkout@v2
-    - name: make info
-      run: source /opt/rh/gcc-toolset-9/enable; make info
-    - name: make
-      run: source /opt/rh/gcc-toolset-9/enable; make FPTYPE=f
-    - name: make check
-      run: source /opt/rh/gcc-toolset-9/enable; make check
-  epoch2_eemumu_GPU:
-    runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
-    steps:
-    - uses: actions/checkout@v2
-    - name: make info
-      run: source /opt/rh/gcc-toolset-9/enable; make info
-    - name: make
-      run: source /opt/rh/gcc-toolset-9/enable; make
-    - name: make check
-      run: source /opt/rh/gcc-toolset-9/enable; make check
+      run: source /opt/rh/gcc-toolset-10/enable; make -C ${{ matrix.folder }} check


### PR DESCRIPTION
- Add workflows for gg_ttgg and epochX.
- Add Mac OS to list of OS where CI jobs should run.
- Override all AVX autoconfiguration attempts, since they don't work on
  OS X.