### PR TITLE
Fix for hardcoded cIPC and cIPD

### DIFF
--- a/epochX/sycl/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/CPPProcess.h
+++ b/epochX/sycl/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/CPPProcess.h
@@ -65,6 +65,8 @@ namespace Proc
 
     ~CPPProcess();
     int * get_cHel_ptr();
+    fptype * get_cIPC_ptr();
+    fptype * get_cIPD_ptr();
 
     // Initialize process.
     virtual void initProc( std::string param_card_name );
@@ -127,7 +129,9 @@ SYCL_EXTERNAL
 void sigmaKin_getGoodHel(const fptype * allmomenta,  // input: momenta as AOSOA[npagM][npar][4][neppM] with nevt=npagM*neppM
 bool * isGoodHel,  // output: isGoodHel[ncomb] - device array
 sycl::nd_item<3> item_ct1,
-int *cHel
+int *cHel,
+const fptype *cIPC,
+const fptype *cIPD
 );
 #endif
 
@@ -145,6 +149,8 @@ void sigmaKin(const fptype * allmomenta,  // input: momenta as AOSOA[npagM][npar
 fptype * allMEs  // output: allMEs[nevt], final |M|^2 averaged over all helicities
 , sycl::nd_item<3> item_ct1,
 int *cHel,
+const fptype *cIPC,
+const fptype *cIPD,
 int *cNGoodHel,
 int *cGoodHel
 #ifndef SYCL_LANGUAGE_VERSION

--- a/epochX/sycl/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
+++ b/epochX/sycl/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
@@ -400,8 +400,12 @@ int main(int argc, char **argv)
   auto devWeights   = malloc_device<fptype>( nWeights, q_ct1 ); // (previously was: meDevPtr)
   auto devMEs       = malloc_device<fptype>( nMEs, q_ct1 ); // (previously was: meDevPtr)
   auto devcHel      = malloc_device<int   >( ncomb*npar, q_ct1 );
+  auto devcIPC      = malloc_device<fptype>( 6, q_ct1 );
+  auto devcIPD      = malloc_device<fptype>( 2, q_ct1 );
   //auto tmp_cHel = process.get_cHel();
   q_ct1.memcpy( devcHel, process.get_cHel_ptr(), ncomb*npar*sizeof(int) ).wait();
+  q_ct1.memcpy( devcIPC, process.get_cIPC_ptr(), 6*sizeof(fptype) ).wait();
+  q_ct1.memcpy( devcIPD, process.get_cIPD_ptr(), 2*sizeof(fptype) ).wait();
   auto devcNGoodHel = malloc_device<int   >( 1, q_ct1 ); 
   auto devcGoodHel  = malloc_device<int   >( ncomb, q_ct1 ); 
 
@@ -595,7 +599,7 @@ int main(int argc, char **argv)
                                     sycl::range<3>(1, 1, gputhreads),
                                 sycl::range<3>(1, 1, gputhreads)),
               [=](sycl::nd_item<3> item_ct1) {
-                    Proc::sigmaKin_getGoodHel(devMomenta, devIsGoodHel, item_ct1, devcHel);
+                    Proc::sigmaKin_getGoodHel(devMomenta, devIsGoodHel, item_ct1, devcHel, devcIPC, devcIPD);
               });
         });
       q_ct1.wait();
@@ -631,7 +635,7 @@ int main(int argc, char **argv)
                 Proc::sigmaKin(
                 devMomenta, devMEs, item_ct1,
 
-		devcHel,
+		devcHel, devcIPC, devcIPD,
 		devcNGoodHel, devcGoodHel);
               });
       });


### PR DESCRIPTION
Fix for Issue #260. The variables cIPC and cIPD following the same method as cHel. 