### PR TITLE
WIP: a few fixes to use CXX=nvcc

### DIFF
--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -326,7 +326,7 @@ $(cu_main): $(BUILDDIR)/gcheck_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
 	$(NVCC) $< -o $@ $(cu_objects) $(CUARCHFLAGS) $(LIBFLAGS) $(CULIBFLAGS)
 
 $(cxx_main): $(BUILDDIR)/check_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects)
-	$(CXX) $< -o $@ $(cxx_objects) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+	$(CXX) $< -o $@ $(cxx_objects) $(OMPFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 
 $(BUILDDIR)/runTest.o: $(GTESTLIBS)
 $(testmain): $(GTESTLIBS)

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -37,6 +37,14 @@ OMPFLAGS ?= -fopenmp
 $(info OMPFLAGS=$(OMPFLAGS))
 CXXFLAGS += $(OMPFLAGS)
 
+# Set special CXXFLAGS and LIBFLAGS if nvcc is used as CXX
+# Forward unknown options (e.g. -Wall) to the host compiler
+# Forward unknown options (e.g. -Wl,--start-group) to the host linker
+ifneq ($(shell $(CXX) --version | grep ^nvcc),)
+CXXFLAGS += --forward-unknown-to-host-compiler
+LIBFLAGS += --forward-unknown-to-host-linker
+endif
+
 # Assuming uname is available, detect if architecture is PowerPC
 UNAME_P := $(shell uname -p)
 

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -326,7 +326,7 @@ $(cu_main): $(BUILDDIR)/gcheck_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
 	$(NVCC) $< -o $@ $(cu_objects) $(CUARCHFLAGS) $(LIBFLAGS) $(CULIBFLAGS)
 
 $(cxx_main): $(BUILDDIR)/check_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects)
-	$(CXX) $< -o $@ $(cxx_objects) $(CPPFLAGS) $(CXXFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+	$(CXX) $< -o $@ $(cxx_objects) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 
 $(BUILDDIR)/runTest.o: $(GTESTLIBS)
 $(testmain): $(GTESTLIBS)
@@ -347,13 +347,13 @@ $(testmain): cxx_objects += $(BUILDDIR)/testxxx.o # Comment out this line to ski
 ifeq ($(NVCC),)
 # Link only runTest.o
 $(testmain): $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(GTESTLIBS)
-	$(CXX) -o $@ $(cxx_objects) $(CPPFLAGS) $(CXXFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+	$(CXX) -o $@ $(cxx_objects) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
 else
 # Link both runTest.o and runTest_cu.o
 # (todo? avoid multiple targets and '&', this needs the latest make 4.3, see https://stackoverflow.com/a/60232515)
 $(testmain) $(BUILDDIR)/runTest_cu.o &: runTest.cc $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(cu_objects) $(GTESTLIBS)
 	$(NVCC) -o $(BUILDDIR)/runTest_cu.o -c -x cu runTest.cc $(CPPFLAGS) $(CUFLAGS)
-	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) $(CPPFLAGS) $(CUFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lgomp
+	$(NVCC) -o $@ $(cxx_objects) $(cu_objects) -ldl $(LIBFLAGS) $(CULIBFLAGS) -lcuda -lgomp
 endif
 
 $(GTESTLIBS):

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -27,6 +27,19 @@ TESTDIR  = ../../../../../test
 GTESTLIBDIR = $(TESTDIR)/googletest/build/lib/
 GTESTLIBS   = $(GTESTLIBDIR)/libgtest.a $(GTESTLIBDIR)/libgtest_main.a
 
+# Set special CXXFLAGS and LIBFLAGS if nvcc is used as CXX
+# Forward unknown options (e.g. -Wall) to the host compiler
+# Forward unknown options (e.g. -Wl,--start-group) to the host linker
+# Use -pthread unless nvcc is used as CXX
+# Disable OpenMP if nvcc is used as CXX
+ifneq ($(shell $(CXX) --version | grep ^nvcc),)
+CXXFLAGS += --forward-unknown-to-host-compiler
+LIBFLAGS += --forward-unknown-to-host-linker
+override OMPFLAGS =
+else
+LIBFLAGS += -pthread
+endif
+
 # OpenMP flags
 ifneq ($(shell $(CXX) --version | grep ^Intel),)
 override OMPFLAGS =
@@ -36,17 +49,6 @@ endif
 OMPFLAGS ?= -fopenmp
 $(info OMPFLAGS=$(OMPFLAGS))
 CXXFLAGS += $(OMPFLAGS)
-
-# Set special CXXFLAGS and LIBFLAGS if nvcc is used as CXX
-# Forward unknown options (e.g. -Wall) to the host compiler
-# Forward unknown options (e.g. -Wl,--start-group) to the host linker
-# Use -pthread unless nvcc is used as CXX
-ifneq ($(shell $(CXX) --version | grep ^nvcc),)
-CXXFLAGS += --forward-unknown-to-host-compiler
-LIBFLAGS += --forward-unknown-to-host-linker
-else
-LIBFLAGS += -pthread
-endif
 
 # Assuming uname is available, detect if architecture is PowerPC
 UNAME_P := $(shell uname -p)

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -40,9 +40,12 @@ CXXFLAGS += $(OMPFLAGS)
 # Set special CXXFLAGS and LIBFLAGS if nvcc is used as CXX
 # Forward unknown options (e.g. -Wall) to the host compiler
 # Forward unknown options (e.g. -Wl,--start-group) to the host linker
+# Use -pthread unless nvcc is used as CXX
 ifneq ($(shell $(CXX) --version | grep ^nvcc),)
 CXXFLAGS += --forward-unknown-to-host-compiler
 LIBFLAGS += --forward-unknown-to-host-linker
+else
+LIBFLAGS += -pthread
 endif
 
 # Assuming uname is available, detect if architecture is PowerPC
@@ -334,7 +337,7 @@ $(cu_main): $(BUILDDIR)/gcheck_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cu_objects)
 	$(NVCC) $< -o $@ $(cu_objects) $(CUARCHFLAGS) $(LIBFLAGS) $(CULIBFLAGS)
 
 $(cxx_main): $(BUILDDIR)/check_sa.o $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects)
-	$(CXX) $< -o $@ $(cxx_objects) $(OMPFLAGS) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+	$(CXX) $< -o $@ $(cxx_objects) $(OMPFLAGS) -ldl $(LIBFLAGS) $(CULIBFLAGS)
 
 $(BUILDDIR)/runTest.o: $(GTESTLIBS)
 $(testmain): $(GTESTLIBS)
@@ -355,7 +358,7 @@ $(testmain): cxx_objects += $(BUILDDIR)/testxxx.o # Comment out this line to ski
 ifeq ($(NVCC),)
 # Link only runTest.o
 $(testmain): $(LIBDIR)/lib$(MODELLIB).a $(cxx_objects) $(GTESTLIBS)
-	$(CXX) -o $@ $(cxx_objects) -ldl -pthread $(LIBFLAGS) $(CULIBFLAGS)
+	$(CXX) -o $@ $(cxx_objects) -ldl $(LIBFLAGS) $(CULIBFLAGS)
 else
 # Link both runTest.o and runTest_cu.o
 # (todo? avoid multiple targets and '&', this needs the latest make 4.3, see https://stackoverflow.com/a/60232515)

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Makefile
@@ -32,8 +32,8 @@ ifneq ($(shell $(CXX) --version | grep ^Intel),)
 override OMPFLAGS =
 else ifeq ($(shell $(CXX) --version | grep GCC | cut -d' ' -f3 | cut -d'.' -f1),9) # disable OMP on gcc9 (issue #269)
 override OMPFLAGS =
-OMPFLAGS ?= -fopenmp
 endif
+OMPFLAGS ?= -fopenmp
 $(info OMPFLAGS=$(OMPFLAGS))
 CXXFLAGS += $(OMPFLAGS)
 

--- a/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/CPPProcess.cc
@@ -355,7 +355,10 @@ namespace Proc
   {
     std::stringstream out;
     // CUDA version (NVCC)
-#ifdef __CUDACC__
+    // [Use __CUDACC_VER_MAJOR__ instead of __CUDACC__ here!]
+    // [This tests if 'nvcc' was used even to build a .cc file, even if not necessarily 'nvcc -x cu' for a .cu file]
+    // [Check 'nvcc --compiler-options -dM -E dummy.c | grep CUDA': see https://stackoverflow.com/a/53713712]
+#ifdef __CUDACC_VER_MAJOR__
 #if defined __CUDACC_VER_MAJOR__ && defined __CUDACC_VER_MINOR__ && defined __CUDACC_VER_BUILD__
     out << "nvcc " << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__ << "." << __CUDACC_VER_BUILD__;
 #else
@@ -381,7 +384,7 @@ namespace Proc
     std::array<char, 128> tchainbuf;
     while ( fgets( tchainbuf.data(), tchainbuf.size(), tchainpipe.get() ) != nullptr ) tchainout += tchainbuf.data();
     tchainout.pop_back(); // remove trailing newline
-#if defined __CUDACC__ or defined __INTEL_LLVM_COMPILER
+#if defined __CUDACC_VER_MAJOR__ or defined __INTEL_LLVM_COMPILER
     out << ", gcc " << tchainout;
 #else
     out << " (gcc " << tchainout << ")";
@@ -397,7 +400,7 @@ namespace Proc
     out << "gcc UNKNOWKN";
 #endif
 #endif
-#if defined __CUDACC__ or defined __INTEL_LLVM_COMPILER
+#if defined __CUDACC_VER_MAJOR__ or defined __INTEL_LLVM_COMPILER
     out << ")";
 #endif
     return out.str();

--- a/epochX/cudacpp/ee_mumu/src/Makefile
+++ b/epochX/cudacpp/ee_mumu/src/Makefile
@@ -16,6 +16,14 @@ RANLIB = ranlib
 # OpenMP flags
 CXXFLAGS += $(OMPFLAGS)
 
+# Set special CXXFLAGS and LIBFLAGS if nvcc is used as CXX
+# Forward unknown options (e.g. -Wall) to the host compiler
+# Forward unknown options (e.g. -Wl,--start-group) to the host linker
+ifneq ($(shell $(CXX) --version | grep ^nvcc),)
+CXXFLAGS += --forward-unknown-to-host-compiler
+LIBFLAGS += --forward-unknown-to-host-linker
+endif
+
 # Assuming uname is available, detect if architecture is PowerPC
 UNAME_P := $(shell uname -p)
 

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -33,11 +33,7 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.sse4_d_inl0_hrd0 for tag=sse4_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make -C ../../src 
-AVX=sse4
-make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
-make[2]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
-make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[1]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=avx2
@@ -49,11 +45,7 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.avx2_d_inl0_hrd0 for tag=avx2_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make -C ../../src 
-AVX=avx2
-make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
-make[2]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
-make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[1]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512y
@@ -77,106 +69,102 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.512z_d_inl0_hrd0 for tag=512z_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make -C ../../src 
-AVX=512z
-make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
-make[2]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
-make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2021-12-18_00:03:52
+DATE: 2021-12-13_08:16:59
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[MatrixElems] (3) = ( 5.899969e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.114759e+09                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.967191e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.119611e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.440811 sec
-       417,758,985      cycles:u                  #    0.838 GHz                    
-       728,679,580      instructions:u            #    1.74  insn per cycle         
-       0.513521163 seconds time elapsed
+TOTAL       :     1.154408 sec
+       768,297,528      cycles:u                  #    0.653 GHz                    
+     1,461,311,470      instructions:u            #    1.90  insn per cycle         
+       1.457486286 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 130
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[MatrixElems] (3) = ( 1.334955e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.334955e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.338109e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.338109e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     7.169677 sec
-    18,826,439,553      cycles:u                  #    2.619 GHz                    
-    47,746,323,343      instructions:u            #    2.54  insn per cycle         
-       7.192809681 seconds time elapsed
+TOTAL       :     7.155692 sec
+    18,790,361,499      cycles:u                  #    2.619 GHz                    
+    47,746,061,718      instructions:u            #    2.54  insn per cycle         
+       7.179553704 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  558) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 2.546531e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.546531e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.537806e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.537806e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.963172 sec
-    12,937,765,999      cycles:u                  #    2.596 GHz                    
-    29,530,019,781      instructions:u            #    2.28  insn per cycle         
-       4.986777529 seconds time elapsed
+TOTAL       :     4.960751 sec
+    12,941,509,106      cycles:u                  #    2.598 GHz                    
+    29,529,759,484      instructions:u            #    2.28  insn per cycle         
+       4.984771479 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 3342) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.497046e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.497046e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.488644e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.488644e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.807441 sec
-     9,309,421,603      cycles:u                  #    2.432 GHz                    
-    16,453,098,615      instructions:u            #    1.77  insn per cycle         
-       3.830962787 seconds time elapsed
+TOTAL       :     3.798423 sec
+     9,277,413,988      cycles:u                  #    2.430 GHz                    
+    16,452,837,480      instructions:u            #    1.77  insn per cycle         
+       3.821538870 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2883) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.944135e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.944135e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.959774e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.959774e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.689639 sec
-     9,041,602,846      cycles:u                  #    2.438 GHz                    
-    16,339,853,228      instructions:u            #    1.81  insn per cycle         
-       3.712749486 seconds time elapsed
+TOTAL       :     3.681487 sec
+     9,038,054,633      cycles:u                  #    2.442 GHz                    
+    16,339,591,722      instructions:u            #    1.81  insn per cycle         
+       3.704883055 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2780) (512y:   52) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 3.684344e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.684344e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.705715e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.705715e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.142344 sec
-     8,883,880,982      cycles:u                  #    2.137 GHz                    
-    13,282,168,344      instructions:u            #    1.50  insn per cycle         
-       4.165759174 seconds time elapsed
+TOTAL       :     4.129527 sec
+     8,872,138,866      cycles:u                  #    2.139 GHz                    
+    13,281,907,204      instructions:u            #    1.50  insn per cycle         
+       4.153320738 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1384) (512y:   84) (512z: 2214)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -1,6 +1,6 @@
 
 /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=512y
 FPTYPE=d
 HELINL=0
@@ -9,7 +9,7 @@ RNDGEN=curdev
 Building in BUILDDIR=build.512y_d_inl0_hrd0 for tag=512y_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 
 make USEBUILDDIR=1 AVX=none
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=none
 FPTYPE=d
 HELINL=0
@@ -17,15 +17,11 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.none_d_inl0_hrd0 for tag=none_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make -C ../../src 
-AVX=none
-make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
-make[2]: Nothing to be done for `all.none_d_inl0_hrd0_curdev'.
-make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[1]: Nothing to be done for `all.none_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=sse4
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=sse4
 FPTYPE=d
 HELINL=0
@@ -37,7 +33,7 @@ make[1]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=avx2
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=avx2
 FPTYPE=d
 HELINL=0
@@ -49,7 +45,7 @@ make[1]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512y
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=512y
 FPTYPE=d
 HELINL=0
@@ -61,7 +57,7 @@ make[1]: Nothing to be done for `all.512y_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512z
-OMPFLAGS=
+OMPFLAGS=-fopenmp
 AVX=512z
 FPTYPE=d
 HELINL=0
@@ -72,20 +68,20 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2021-12-13_08:16:59
+DATE: 2021-12-17_23:29:00
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[MatrixElems] (3) = ( 5.967191e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.119611e+09                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.763429e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.154140e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     1.154408 sec
-       768,297,528      cycles:u                  #    0.653 GHz                    
-     1,461,311,470      instructions:u            #    1.90  insn per cycle         
-       1.457486286 seconds time elapsed
+TOTAL       :     0.469549 sec
+       432,177,162      cycles:u                  #    0.860 GHz                    
+       746,617,630      instructions:u            #    1.73  insn per cycle         
+       0.543507724 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 130
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -94,14 +90,15 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[MatrixElems] (3) = ( 1.338109e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.338109e+06                 )  sec^-1
+OMP threads / `nproc --all` = 1 / 4
+EvtsPerSec[MatrixElems] (3) = ( 1.321836e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.321836e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     7.155692 sec
-    18,790,361,499      cycles:u                  #    2.619 GHz                    
-    47,746,061,718      instructions:u            #    2.54  insn per cycle         
-       7.179553704 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:  558) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     7.229896 sec
+    18,957,854,749      cycles:u                  #    2.618 GHz                    
+    47,840,630,008      instructions:u            #    2.52  insn per cycle         
+       7.254970412 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:  567) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -110,14 +107,15 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 2.537806e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.537806e+06                 )  sec^-1
+OMP threads / `nproc --all` = 1 / 4
+EvtsPerSec[MatrixElems] (3) = ( 2.554806e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.554806e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.960751 sec
-    12,941,509,106      cycles:u                  #    2.598 GHz                    
-    29,529,759,484      instructions:u            #    2.28  insn per cycle         
-       4.984771479 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4: 3342) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     4.963151 sec
+    12,943,339,285      cycles:u                  #    2.597 GHz                    
+    29,580,281,590      instructions:u            #    2.29  insn per cycle         
+       4.988039584 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4: 3301) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -126,14 +124,15 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.488644e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.488644e+06                 )  sec^-1
+OMP threads / `nproc --all` = 1 / 4
+EvtsPerSec[MatrixElems] (3) = ( 4.493872e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.493872e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.798423 sec
-     9,277,413,988      cycles:u                  #    2.430 GHz                    
-    16,452,837,480      instructions:u            #    1.77  insn per cycle         
-       3.821538870 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2883) (512y:    0) (512z:    0)
+TOTAL       :     3.804344 sec
+     9,289,034,464      cycles:u                  #    2.431 GHz                    
+    16,471,903,753      instructions:u            #    1.77  insn per cycle         
+       3.828911952 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2840) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -142,14 +141,15 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.959774e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.959774e+06                 )  sec^-1
+OMP threads / `nproc --all` = 1 / 4
+EvtsPerSec[MatrixElems] (3) = ( 4.966791e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.966791e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.681487 sec
-     9,038,054,633      cycles:u                  #    2.442 GHz                    
-    16,339,591,722      instructions:u            #    1.81  insn per cycle         
-       3.704883055 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2780) (512y:   52) (512z:    0)
+TOTAL       :     3.684029 sec
+     9,039,190,431      cycles:u                  #    2.439 GHz                    
+    16,346,074,676      instructions:u            #    1.81  insn per cycle         
+       3.708979933 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2737) (512y:   52) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -158,14 +158,15 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 3.705715e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.705715e+06                 )  sec^-1
+OMP threads / `nproc --all` = 1 / 4
+EvtsPerSec[MatrixElems] (3) = ( 3.666678e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.666678e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.129527 sec
-     8,872,138,866      cycles:u                  #    2.139 GHz                    
-    13,281,907,204      instructions:u            #    1.50  insn per cycle         
-       4.153320738 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1384) (512y:   84) (512z: 2214)
+TOTAL       :     4.222871 sec
+     9,066,048,801      cycles:u                  #    2.142 GHz                    
+    13,272,668,357      instructions:u            #    1.46  insn per cycle         
+       4.248157524 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1387) (512y:   84) (512z: 2156)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -17,7 +17,11 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.none_d_inl0_hrd0 for tag=none_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make[1]: Nothing to be done for `all.none_d_inl0_hrd0_curdev'.
+make -C ../../src 
+AVX=none
+make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[2]: Nothing to be done for `all.none_d_inl0_hrd0_curdev'.
+make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=sse4
@@ -29,7 +33,11 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.sse4_d_inl0_hrd0 for tag=sse4_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make[1]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
+make -C ../../src 
+AVX=sse4
+make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[2]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
+make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=avx2
@@ -41,7 +49,11 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.avx2_d_inl0_hrd0 for tag=avx2_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make[1]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
+make -C ../../src 
+AVX=avx2
+make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[2]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
+make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512y
@@ -65,102 +77,106 @@ HRDCOD=0
 RNDGEN=curdev
 Building in BUILDDIR=build.512z_d_inl0_hrd0 for tag=512z_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
-make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
+make -C ../../src 
+AVX=512z
+make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
+make[2]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
+make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/src'
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2021-12-17_23:39:30
+DATE: 2021-12-18_00:03:52
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[MatrixElems] (3) = ( 5.786057e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.118316e+09                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.899969e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.114759e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.448723 sec
-       424,348,387      cycles:u                  #    0.858 GHz                    
-       744,158,302      instructions:u            #    1.75  insn per cycle         
-       0.522257756 seconds time elapsed
+TOTAL       :     0.440811 sec
+       417,758,985      cycles:u                  #    0.838 GHz                    
+       728,679,580      instructions:u            #    1.74  insn per cycle         
+       0.513521163 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 130
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[MatrixElems] (3) = ( 1.335956e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.335956e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.334955e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.334955e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     7.170825 sec
-    18,833,561,317      cycles:u                  #    2.619 GHz                    
-    47,746,315,548      instructions:u            #    2.54  insn per cycle         
-       7.194017827 seconds time elapsed
+TOTAL       :     7.169677 sec
+    18,826,439,553      cycles:u                  #    2.619 GHz                    
+    47,746,323,343      instructions:u            #    2.54  insn per cycle         
+       7.192809681 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  558) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 2.548479e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.548479e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.546531e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.546531e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.964392 sec
-    12,946,751,206      cycles:u                  #    2.597 GHz                    
-    29,530,012,910      instructions:u            #    2.28  insn per cycle         
-       4.987539523 seconds time elapsed
+TOTAL       :     4.963172 sec
+    12,937,765,999      cycles:u                  #    2.596 GHz                    
+    29,530,019,781      instructions:u            #    2.28  insn per cycle         
+       4.986777529 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 3342) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.504376e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.504376e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.497046e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.497046e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.814698 sec
-     9,295,910,200      cycles:u                  #    2.429 GHz                    
-    16,453,090,595      instructions:u            #    1.77  insn per cycle         
-       3.839278563 seconds time elapsed
+TOTAL       :     3.807441 sec
+     9,309,421,603      cycles:u                  #    2.432 GHz                    
+    16,453,098,615      instructions:u            #    1.77  insn per cycle         
+       3.830962787 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2883) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 4.933053e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.933053e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.944135e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.944135e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.693001 sec
-     9,029,087,329      cycles:u                  #    2.436 GHz                    
-    16,339,844,897      instructions:u            #    1.81  insn per cycle         
-       3.716701418 seconds time elapsed
+TOTAL       :     3.689639 sec
+     9,041,602,846      cycles:u                  #    2.438 GHz                    
+    16,339,853,228      instructions:u            #    1.81  insn per cycle         
+       3.712749486 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2780) (512y:   52) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[MatrixElems] (3) = ( 3.683836e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.683836e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.684344e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.684344e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.144971 sec
-     8,894,374,562      cycles:u                  #    2.137 GHz                    
-    13,282,160,616      instructions:u            #    1.49  insn per cycle         
-       4.168782513 seconds time elapsed
+TOTAL       :     4.142344 sec
+     8,883,880,982      cycles:u                  #    2.137 GHz                    
+    13,282,168,344      instructions:u            #    1.50  insn per cycle         
+       4.165759174 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1384) (512y:   84) (512z: 2214)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -1,6 +1,6 @@
 
 /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=512y
 FPTYPE=d
 HELINL=0
@@ -9,7 +9,7 @@ RNDGEN=curdev
 Building in BUILDDIR=build.512y_d_inl0_hrd0 for tag=512y_d_inl0_hrd0_curdev (USEBUILDDIR is set = 1)
 
 make USEBUILDDIR=1 AVX=none
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=none
 FPTYPE=d
 HELINL=0
@@ -21,7 +21,7 @@ make[1]: Nothing to be done for `all.none_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=sse4
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=sse4
 FPTYPE=d
 HELINL=0
@@ -33,7 +33,7 @@ make[1]: Nothing to be done for `all.sse4_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=avx2
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=avx2
 FPTYPE=d
 HELINL=0
@@ -45,7 +45,7 @@ make[1]: Nothing to be done for `all.avx2_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512y
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=512y
 FPTYPE=d
 HELINL=0
@@ -57,7 +57,7 @@ make[1]: Nothing to be done for `all.512y_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
 make USEBUILDDIR=1 AVX=512z
-OMPFLAGS=-fopenmp
+OMPFLAGS=
 AVX=512z
 FPTYPE=d
 HELINL=0
@@ -68,20 +68,20 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_curdev'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2021-12-17_23:29:00
+DATE: 2021-12-17_23:39:30
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.1.105 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[MatrixElems] (3) = ( 5.763429e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.154140e+09                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.786057e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.118316e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.469549 sec
-       432,177,162      cycles:u                  #    0.860 GHz                    
-       746,617,630      instructions:u            #    1.73  insn per cycle         
-       0.543507724 seconds time elapsed
+TOTAL       :     0.448723 sec
+       424,348,387      cycles:u                  #    0.858 GHz                    
+       744,158,302      instructions:u            #    1.75  insn per cycle         
+       0.522257756 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 130
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -90,15 +90,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-OMP threads / `nproc --all` = 1 / 4
-EvtsPerSec[MatrixElems] (3) = ( 1.321836e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.321836e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.335956e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.335956e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     7.229896 sec
-    18,957,854,749      cycles:u                  #    2.618 GHz                    
-    47,840,630,008      instructions:u            #    2.52  insn per cycle         
-       7.254970412 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:  567) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     7.170825 sec
+    18,833,561,317      cycles:u                  #    2.619 GHz                    
+    47,746,315,548      instructions:u            #    2.54  insn per cycle         
+       7.194017827 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:  558) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -107,15 +106,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-OMP threads / `nproc --all` = 1 / 4
-EvtsPerSec[MatrixElems] (3) = ( 2.554806e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.554806e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.548479e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.548479e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.963151 sec
-    12,943,339,285      cycles:u                  #    2.597 GHz                    
-    29,580,281,590      instructions:u            #    2.29  insn per cycle         
-       4.988039584 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4: 3301) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     4.964392 sec
+    12,946,751,206      cycles:u                  #    2.597 GHz                    
+    29,530,012,910      instructions:u            #    2.28  insn per cycle         
+       4.987539523 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4: 3342) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -124,15 +122,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-OMP threads / `nproc --all` = 1 / 4
-EvtsPerSec[MatrixElems] (3) = ( 4.493872e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.493872e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.504376e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.504376e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.804344 sec
-     9,289,034,464      cycles:u                  #    2.431 GHz                    
-    16,471,903,753      instructions:u            #    1.77  insn per cycle         
-       3.828911952 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2840) (512y:    0) (512z:    0)
+TOTAL       :     3.814698 sec
+     9,295,910,200      cycles:u                  #    2.429 GHz                    
+    16,453,090,595      instructions:u            #    1.77  insn per cycle         
+       3.839278563 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2883) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -141,15 +138,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-OMP threads / `nproc --all` = 1 / 4
-EvtsPerSec[MatrixElems] (3) = ( 4.966791e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.966791e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.933053e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.933053e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.684029 sec
-     9,039,190,431      cycles:u                  #    2.439 GHz                    
-    16,346,074,676      instructions:u            #    1.81  insn per cycle         
-       3.708979933 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2737) (512y:   52) (512z:    0)
+TOTAL       :     3.693001 sec
+     9,029,087,329      cycles:u                  #    2.436 GHz                    
+    16,339,844,897      instructions:u            #    1.81  insn per cycle         
+       3.716701418 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2780) (512y:   52) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.
@@ -158,15 +154,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-OMP threads / `nproc --all` = 1 / 4
-EvtsPerSec[MatrixElems] (3) = ( 3.666678e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.666678e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.683836e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.683836e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.222871 sec
-     9,066,048,801      cycles:u                  #    2.142 GHz                    
-    13,272,668,357      instructions:u            #    1.46  insn per cycle         
-       4.248157524 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1387) (512y:   84) (512z: 2156)
+TOTAL       :     4.144971 sec
+     8,894,374,562      cycles:u                  #    2.137 GHz                    
+    13,282,160,616      instructions:u            #    1.49  insn per cycle         
+       4.168782513 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1384) (512y:   84) (512z: 2214)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 3 tests.


### PR DESCRIPTION
This is a WIP PR related to #318.

I managed to build the code using 'export CXX=nvcc' and get good SIMD performance from the underlying gcc102.
So there should be no problem whatsoever building the SIMD C++ kernels using nvcc.

This is WIP because I still need to backport to code generation.