### PR TITLE
Improved fixes for rambo 2-to-1

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/rambo.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/CODEGEN/syncManu.sh
+++ b/epochX/cudacpp/CODEGEN/syncManu.sh
@@ -8,7 +8,7 @@ ggttggg=0
 
 function usage()
 {
-  echo "Usage: $0 <processes [-eemumu] [-ggtt] [-ggttgg]>"
+  echo "Usage: $0 <processes [-eemumu] [-ggtt] [-ggttg] [-ggttgg] [-ggttggg]>"
   exit 1
 }
 

--- a/epochX/cudacpp/CODEGEN/syncManu.sh
+++ b/epochX/cudacpp/CODEGEN/syncManu.sh
@@ -33,15 +33,19 @@ while [ "$1" != "" ]; do
   fi
 done
 
-# Check that at least one process has been selected
+# Select processes
 processes=
 if [ "${ggtt}" == "1" ]; then processes="gg_tt $processes"; fi
 if [ "${ggttg}" == "1" ]; then processes="gg_ttg $processes"; fi
 if [ "${ggttgg}" == "1" ]; then processes="gg_ttgg $processes"; fi
 if [ "${ggttggg}" == "1" ]; then processes="gg_ttggg $processes"; fi
 if [ "${eemumu}" == "1" ]; then processes="ee_mumu $processes"; fi
-if [ "${processes}" == "" ]; then usage; fi
 
+# Optional hack to hardcode additional processes
+###processes="heft_gg_h $processes"
+
+# Check that at least one process has been selected
+if [ "${processes}" == "" ]; then usage; fi
 echo "processes: ${processes}"
 
 cd $(dirname $0)

--- a/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006927013397216797 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068035125732421875 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 [1;32mDEBUG:  True [1;30m[misc.py at line 2192][0m [0m
@@ -92,7 +92,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1056][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1063][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1075][0m [0m
-Generated helas calls for 1 subprocesses (2 diagrams) in 0.008 s
+Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 170][0m [0m
 ALOHA: aloha creates routines (starting by FFV1)
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -120,6 +120,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/2.7.0_gpu/CODEGEN_cudacpp_ee_mumu/src/. and 
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 179][0m [0m
 quit
 
-real	0m4.224s
-user	0m0.970s
-sys	0m0.122s
+real	0m4.337s
+user	0m0.945s
+sys	0m0.120s

--- a/epochX/cudacpp/ee_mumu.auto/src/rambo.h
+++ b/epochX/cudacpp/ee_mumu.auto/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/ee_mumu/src/rambo.h
+++ b/epochX/cudacpp/ee_mumu/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068836212158203125 [0m
+[1;32mDEBUG: model prefixing  takes 0.006848573684692383 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 [1;32mDEBUG:  True [1;30m[misc.py at line 2192][0m [0m
@@ -117,6 +117,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/2.7.0_gpu/CODEGEN_cudacpp_gg_tt/src/. and /d
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 179][0m [0m
 quit
 
-real	0m3.830s
-user	0m0.788s
-sys	0m0.138s
+real	0m3.963s
+user	0m0.790s
+sys	0m0.136s

--- a/epochX/cudacpp/gg_tt.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_tt.auto/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_tt/src/rambo.h
+++ b/epochX/cudacpp/gg_tt/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006867647171020508 [0m
+[1;32mDEBUG: model prefixing  takes 0.00685572624206543 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 [1;32mDEBUG:  True [1;30m[misc.py at line 2192][0m [0m
@@ -129,6 +129,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/2.7.0_gpu/CODEGEN_cudacpp_gg_ttg/src/. and /
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 179][0m [0m
 quit
 
-real	0m4.035s
-user	0m1.098s
-sys	0m0.151s
+real	0m4.085s
+user	0m1.112s
+sys	0m0.131s

--- a/epochX/cudacpp/gg_ttg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttg.auto/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttg/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006813764572143555 [0m
+[1;32mDEBUG: model prefixing  takes 0.006865024566650391 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 [1;32mDEBUG:  True [1;30m[misc.py at line 2192][0m [0m
@@ -67,7 +67,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.209 s
+1 processes with 123 diagrams generated in 0.210 s
 Total: 1 processes with 123 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttgg
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
@@ -101,7 +101,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1056][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1063][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1075][0m [0m
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.565 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.560 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 170][0m [0m
 ALOHA: aloha creates routines (starting by VVV1)
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -137,6 +137,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/2.7.0_gpu/CODEGEN_cudacpp_gg_ttgg/src/. and 
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 179][0m [0m
 quit
 
-real	0m4.891s
-user	0m2.000s
-sys	0m0.144s
+real	0m4.963s
+user	0m2.002s
+sys	0m0.138s

--- a/epochX/cudacpp/gg_ttgg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttgg.auto/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttgg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttgg/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068590641021728516 [0m
+[1;32mDEBUG: model prefixing  takes 0.006861686706542969 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 [1;32mDEBUG:  True [1;30m[misc.py at line 2192][0m [0m
@@ -67,7 +67,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.472 s
+1 processes with 1240 diagrams generated in 2.483 s
 Total: 1 processes with 1240 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttggg
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
@@ -103,7 +103,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1056][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1063][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1075][0m [0m
-Generated helas calls for 1 subprocesses (1240 diagrams) in 8.912 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.945 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 170][0m [0m
 ALOHA: aloha creates routines (starting by VVV1)
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -139,6 +139,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/2.7.0_gpu/CODEGEN_cudacpp_gg_ttggg/src/. and
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 179][0m [0m
 quit
 
-real	0m20.352s
-user	0m17.140s
-sys	0m0.204s
+real	0m20.788s
+user	0m17.123s
+sys	0m0.226s

--- a/epochX/cudacpp/gg_ttggg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttggg.auto/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/gg_ttggg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttggg/src/rambo.h
@@ -88,10 +88,13 @@ namespace mg5amcCpu
         first = false;
       }
       const int iparf = 0;
-      M_ACCESS::kernelAccessIp4Ipar( momenta, 0, iparf+npari ) = energy;
-      for ( int i4 = 1; i4 < np4; i4++ )
+      for ( int i4 = 0; i4 < np4; i4++ )
       {
         M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) = 0;
+        for ( int ipari = 0; ipari < npari; ipari++ )
+        {
+          M_ACCESS::kernelAccessIp4Ipar( momenta, i4, iparf+npari ) += M_ACCESS::kernelAccessIp4Ipar( momenta, i4, ipari );
+        }
       }
       wt = 1;
       return;

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-02-01_15:18:40
+DATE: 2022-02-01_16:28:27
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.55 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.224855e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.583774e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.348259e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.628998e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.542610e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.319274e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     1.158090 sec
-       709,091,350      cycles:u                  #    0.629 GHz                    
-     1,325,258,654      instructions:u            #    1.87  insn per cycle         
-       1.463008152 seconds time elapsed
+TOTAL       :     1.217332 sec
+       700,149,106      cycles:u                  #    0.628 GHz                    
+     1,309,405,971      instructions:u            #    1.87  insn per cycle         
+       1.532294921 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 128
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -93,14 +93,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.093065e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.671958e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.671958e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.092105e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.666585e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.666585e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.254684 sec
-    16,479,718,707      cycles:u                  #    2.635 GHz                    
-    40,384,994,832      instructions:u            #    2.45  insn per cycle         
-       6.270950207 seconds time elapsed
+TOTAL       :     6.244628 sec
+    16,469,161,935      cycles:u                  #    2.634 GHz                    
+    40,384,995,346      instructions:u            #    2.45  insn per cycle         
+       6.259642598 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  280) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -111,14 +111,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.538724e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.134745e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.134745e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.541297e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.128398e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.128398e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.582501 sec
-    12,027,349,349      cycles:u                  #    2.623 GHz                    
-    26,019,096,378      instructions:u            #    2.16  insn per cycle         
-       4.598627492 seconds time elapsed
+TOTAL       :     4.564077 sec
+    12,004,362,135      cycles:u                  #    2.623 GHz                    
+    26,019,096,213      instructions:u            #    2.17  insn per cycle         
+       4.579406546 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1271) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -129,14 +129,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.008864e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.524289e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.524289e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.010949e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.512264e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.512264e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.636804 sec
-     9,020,449,608      cycles:u                  #    2.484 GHz                    
-    15,411,596,684      instructions:u            #    1.71  insn per cycle         
-       3.653484956 seconds time elapsed
+TOTAL       :     3.608807 sec
+     9,010,726,683      cycles:u                  #    2.489 GHz                    
+    15,411,596,581      instructions:u            #    1.71  insn per cycle         
+       3.623991026 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1047) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -147,14 +147,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.023285e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.827499e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.827499e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.061930e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.838522e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.838522e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.611075 sec
-     8,990,085,950      cycles:u                  #    2.493 GHz                    
-    15,336,099,621      instructions:u            #    1.71  insn per cycle         
-       3.627344489 seconds time elapsed
+TOTAL       :     3.531417 sec
+     8,825,974,390      cycles:u                  #    2.491 GHz                    
+    15,336,100,252      instructions:u            #    1.74  insn per cycle         
+       3.546862543 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1021) (512y:    1) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -165,14 +165,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.900314e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.731016e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.731016e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.906057e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.738852e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.738852e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.797664 sec
-     8,510,477,302      cycles:u                  #    2.234 GHz                    
-    12,459,303,296      instructions:u            #    1.46  insn per cycle         
-       3.814294424 seconds time elapsed
+TOTAL       :     3.784770 sec
+     8,479,130,750      cycles:u                  #    2.233 GHz                    
+    12,459,303,871      instructions:u            #    1.47  insn per cycle         
+       3.800059931 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  241) (512y:    2) (512z:  787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-02-01_15:19:14
+DATE: 2022-02-01_16:29:00
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.55 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.521017e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.577142e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.580525e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.450465e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.496117e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.499081e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.821249 sec
-       586,693,705      cycles:u                  #    0.586 GHz                    
-     1,028,458,545      instructions:u            #    1.75  insn per cycle         
-       1.110342855 seconds time elapsed
+TOTAL       :     0.727897 sec
+       587,346,418      cycles:u                  #    0.858 GHz                    
+     1,033,032,451      instructions:u            #    1.76  insn per cycle         
+       1.016650451 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,28 +91,28 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.55 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.137380e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.191459e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.193709e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.140775e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.192591e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.194673e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.661841 sec
-     2,001,728,215      cycles:u                  #    0.686 GHz                    
-     4,165,634,552      instructions:u            #    2.08  insn per cycle         
-       2.981437352 seconds time elapsed
+TOTAL       :     2.655732 sec
+     1,974,439,860      cycles:u                  #    0.679 GHz                    
+     4,249,627,309      instructions:u            #    2.15  insn per cycle         
+       2.971802017 seconds time elapsed
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.798782e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.800764e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.800764e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.800591e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.802575e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.802575e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.128257 sec
-    24,382,677,839      cycles:u                  #    2.670 GHz                    
-    75,705,520,649      instructions:u            #    3.10  insn per cycle         
-       9.135156555 seconds time elapsed
+TOTAL       :     9.123445 sec
+    24,354,545,890      cycles:u                  #    2.669 GHz                    
+    75,705,520,593      instructions:u            #    3.11  insn per cycle         
+       9.130288313 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1282) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -123,14 +123,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.372368e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.379440e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.379440e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.369682e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.376667e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.376667e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.875311 sec
-    13,011,692,004      cycles:u                  #    2.667 GHz                    
-    39,848,520,692      instructions:u            #    3.06  insn per cycle         
-       4.882298970 seconds time elapsed
+TOTAL       :     4.877975 sec
+    13,023,997,175      cycles:u                  #    2.668 GHz                    
+    39,848,521,092      instructions:u            #    3.06  insn per cycle         
+       4.884720035 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7945) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -141,14 +141,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.786112e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.813712e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.813712e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.785607e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.813555e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.813555e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.427637 sec
-     5,509,084,797      cycles:u                  #    2.266 GHz                    
-    13,741,984,229      instructions:u            #    2.49  insn per cycle         
-       2.434817132 seconds time elapsed
+TOTAL       :     2.427938 sec
+     5,511,430,660      cycles:u                  #    2.266 GHz                    
+    13,741,984,526      instructions:u            #    2.49  insn per cycle         
+       2.435070677 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6822) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -159,14 +159,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.480828e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.514284e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.514284e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.482798e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.517567e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.517567e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.203554 sec
-     5,000,439,729      cycles:u                  #    2.265 GHz                    
-    12,642,003,587      instructions:u            #    2.53  insn per cycle         
-       2.210651960 seconds time elapsed
+TOTAL       :     2.202826 sec
+     4,999,928,227      cycles:u                  #    2.266 GHz                    
+    12,642,003,537      instructions:u            #    2.53  insn per cycle         
+       2.210208780 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6607) (512y:   57) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -177,14 +177,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.518154e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.543785e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.543785e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.522085e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.547484e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.547484e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.527295 sec
-     3,988,619,853      cycles:u                  #    1.576 GHz                    
-     6,403,111,919      instructions:u            #    1.61  insn per cycle         
-       2.534182925 seconds time elapsed
+TOTAL       :     2.525817 sec
+     3,985,584,506      cycles:u                  #    1.576 GHz                    
+     6,403,111,386      instructions:u            #    1.61  insn per cycle         
+       2.532663180 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1752) (512y:   73) (512z: 5663)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe


### PR DESCRIPTION
This is a followup to PR #365 - I realised there was a better way to get the four momentum o fth efinal particle, just add those of the initial particles, this is more generic, the previous one had buggy physics