### PR TITLE
Disable fail-fast in the github CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: make epoch1
@@ -22,6 +23,7 @@ jobs:
       matrix:
         folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/ ]
         precision: [ d , f ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: make info
@@ -38,6 +40,7 @@ jobs:
       matrix:
         folder: [ epoch1/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum, epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/ ]
         precision: [ d ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: make info
@@ -52,6 +55,7 @@ jobs:
       matrix:
         folder: [ epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum , epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/ , epoch2/cuda/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum ]
         precision: [ d , f ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: make info


### PR DESCRIPTION
Do not cancel jobs in a matrix if another job failed
See https://github.community/t/error-the-operation-was-canceled-in-ci/166506/4
See https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails

This is important for the 'shared' PR #367, where I was getting several uncorrelated failures from different sources and I want to see them all 