### PR TITLE
Fix unsigned int warnings for xcode

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/Bridge.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/CrossSectionKernels.cc
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/CrossSectionKernels.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/RandomNumberKernels.cc
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/RandomNumberKernels.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/check_sa.cc
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/read_slha.cc
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/read_slha.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -224,13 +224,22 @@ if ! python3 --version >& /dev/null; then echo "ERROR! python3 is not installed"
 mg5amc270=2.7.0_gpu
 mg5amc311=3.1.1_lo_vectorization
 mg5amcBrn=${mg5amc311}
+if [ "${OUTBCK}" == "alpaka" ]; then
+  revno_patches=370
+else
+  revno_patches=$(cat $SCRDIR/MG5aMC_patches/${mg5amcBrn}/revision.BZR)
+fi
 if [ "$MG5AMC_HOME" == "" ]; then
   echo "ERROR! MG5AMC_HOME is not defined"
-  echo "To download MG5AMC please run 'bzr branch lp:~maddevelopers/mg5amcnlo/${mg5amcBrn}'"
+  echo -e "To download MG5AMC please run\n  bzr branch lp:~maddevelopers/mg5amcnlo/${mg5amcBrn} -r ${revno_patches}"
   exit 1
 fi
 echo -e "\nDefault MG5AMC_HOME=$MG5AMC_HOME on $(hostname)\n"
-if [ ! -d $MG5AMC_HOME ]; then echo "ERROR! Directory $MG5AMC_HOME does not exist"; exit 1; fi
+if [ ! -d $MG5AMC_HOME ]; then
+  echo "ERROR! Directory $MG5AMC_HOME does not exist"
+  echo -e "To download MG5AMC please run\n  bzr branch lp:~maddevelopers/mg5amcnlo/${mg5amcBrn} -r ${revno_patches}"
+  exit 1
+fi
 if [ "$(basename ${MG5AMC_HOME})" != "${mg5amcBrn}" ]; then
   echo "ERROR! MG5AMC_HOME basename is not ${mg5amcBrn}"
   exit 1
@@ -270,11 +279,6 @@ if bzr --version >& /dev/null; then
   echo -e "Using $(bzr --version | head -1)"
   echo -e "Retrieving bzr information about MG5AMC_HOME"
   if bzr info ${MG5AMC_HOME} > /dev/null; then
-    if [ "${OUTBCK}" == "alpaka" ]; then
-      revno_patches=370
-    else
-      revno_patches=$(cat $SCRDIR/MG5aMC_patches/${mg5amcBrn}/revision.BZR)
-    fi
     echo -e "MG5AMC patches in this plugin refer to bzr revno '${revno_patches}'"
     echo -e "Revert MG5AMC_HOME to bzr revno '${revno_patches}'"
     bzr revert ${MG5AMC_HOME} -r ${revno_patches}

--- a/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
@@ -1,5 +1,4 @@
 Running MG5 in debug mode
-('WARNING: loading of madgraph too slow!!!', 1.3925747871398926)
 ************************************************************
 *                                                          *
 *                     W E L C O M E to                     *
@@ -13,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           996         *
+*         BZR 3.1.1_lo_vectorization           990         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -51,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006873607635498047 [0m
+[1;32mDEBUG: model prefixing  takes 0.006872653961181641 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -102,7 +101,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 4 routines in  0.321 s
+ALOHA: aloha creates 4 routines in  0.320 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -128,6 +127,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mu
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m3.005s
-user	0m0.948s
-sys	0m0.123s
+real	0m1.046s
+user	0m0.921s
+sys	0m0.106s

--- a/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
@@ -1,4 +1,5 @@
 Running MG5 in debug mode
+('WARNING: loading of madgraph too slow!!!', 1.3925747871398926)
 ************************************************************
 *                                                          *
 *                     W E L C O M E to                     *
@@ -12,7 +13,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           990         *
+*         BZR 3.1.1_lo_vectorization           996         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +51,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006872653961181641 [0m
+[1;32mDEBUG: model prefixing  takes 0.006873607635498047 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -101,7 +102,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 4 routines in  0.320 s
+ALOHA: aloha creates 4 routines in  0.321 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -127,6 +128,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mu
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m1.046s
-user	0m0.921s
-sys	0m0.106s
+real	0m3.005s
+user	0m0.948s
+sys	0m0.123s

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/P1_Sigma_sm_epem_mupmum/check_sa.cc
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/P1_Sigma_sm_epem_mupmum/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/ee_mumu.auto/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/ee_mumu.auto/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/ee_mumu.auto/src/read_slha.cc
+++ b/epochX/cudacpp/ee_mumu.auto/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/ee_mumu.auto/src/read_slha.h
+++ b/epochX/cudacpp/ee_mumu.auto/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/ee_mumu/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/ee_mumu/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/ee_mumu/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check_sa.cc
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/ee_mumu/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/ee_mumu/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/ee_mumu/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/ee_mumu/src/read_slha.cc
+++ b/epochX/cudacpp/ee_mumu/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/ee_mumu/src/read_slha.h
+++ b/epochX/cudacpp/ee_mumu/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
@@ -1,4 +1,5 @@
 Running MG5 in debug mode
+('WARNING: loading of madgraph too slow!!!', 1.1827144622802734)
 ************************************************************
 *                                                          *
 *                     W E L C O M E to                     *
@@ -12,7 +13,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           996         *
+*         BZR 3.1.1_lo_vectorization           990         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +51,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006899356842041016 [0m
+[1;32mDEBUG: model prefixing  takes 0.006821870803833008 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -104,7 +105,7 @@ Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.162 s
+ALOHA: aloha creates 2 routines in  0.171 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -122,6 +123,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m0.909s
-user	0m0.789s
-sys	0m0.100s
+real	0m2.018s
+user	0m1.709s
+sys	0m0.192s

--- a/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
@@ -1,5 +1,4 @@
 Running MG5 in debug mode
-('WARNING: loading of madgraph too slow!!!', 1.1827144622802734)
 ************************************************************
 *                                                          *
 *                     W E L C O M E to                     *
@@ -13,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           990         *
+*         BZR 3.1.1_lo_vectorization           996         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -51,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006821870803833008 [0m
+[1;32mDEBUG: model prefixing  takes 0.006899356842041016 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -105,7 +104,7 @@ Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.171 s
+ALOHA: aloha creates 2 routines in  0.162 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -123,6 +122,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m2.018s
-user	0m1.709s
-sys	0m0.192s
+real	0m0.909s
+user	0m0.789s
+sys	0m0.100s

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/P1_Sigma_sm_gg_ttx/check_sa.cc
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/P1_Sigma_sm_gg_ttx/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_tt.auto/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_tt.auto/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_tt.auto/src/read_slha.cc
+++ b/epochX/cudacpp/gg_tt.auto/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_tt.auto/src/read_slha.h
+++ b/epochX/cudacpp/gg_tt.auto/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_tt/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_tt/SubProcesses/Bridge.h
@@ -135,7 +135,7 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 

--- a/epochX/cudacpp/gg_tt/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_tt/SubProcesses/CrossSectionKernels.cc
@@ -82,7 +82,7 @@ namespace mg5amcCpu
 
   void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/check_sa.cc
+++ b/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/check_sa.cc
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_tt/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_tt/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_tt/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_tt/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           990         *
+*         BZR 3.1.1_lo_vectorization           996         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068662166595458984 [0m
+[1;32mDEBUG: model prefixing  takes 0.006898403167724609 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -109,7 +109,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.391 s
+ALOHA: aloha creates 5 routines in  0.390 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -137,6 +137,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m1.225s
-user	0m1.083s
-sys	0m0.124s
+real	0m1.226s
+user	0m1.096s
+sys	0m0.112s

--- a/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           996         *
+*         BZR 3.1.1_lo_vectorization           990         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006898403167724609 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068662166595458984 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -109,7 +109,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.390 s
+ALOHA: aloha creates 5 routines in  0.391 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -137,6 +137,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m1.226s
-user	0m1.096s
-sys	0m0.112s
+real	0m1.225s
+user	0m1.083s
+sys	0m0.124s

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/P1_Sigma_sm_gg_ttxg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/P1_Sigma_sm_gg_ttxg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttg.auto/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttg.auto/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttg.auto/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttg.auto/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttg.auto/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttg.auto/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_ttg/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttg/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttg/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttg/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttg/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttg/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttg/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttg/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttg/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttg/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           990         *
+*         BZR 3.1.1_lo_vectorization           996         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069921016693115234 [0m
+[1;32mDEBUG: model prefixing  takes 0.006911516189575195 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.210 s
+1 processes with 123 diagrams generated in 0.208 s
 Total: 1 processes with 123 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttgg
 [1;34mPlugin PLUGIN.CUDACPP_SA_OUTPUT has marked as NOT being validated with this version. 
@@ -103,7 +103,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1100][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1107][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1119][0m [0m
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.572 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.574 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 203][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -145,6 +145,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m2.118s
-user	0m1.977s
-sys	0m0.124s
+real	0m2.121s
+user	0m1.960s
+sys	0m0.144s

--- a/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           996         *
+*         BZR 3.1.1_lo_vectorization           990         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006911516189575195 [0m
+[1;32mDEBUG: model prefixing  takes 0.0069921016693115234 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.208 s
+1 processes with 123 diagrams generated in 0.210 s
 Total: 1 processes with 123 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttgg
 [1;34mPlugin PLUGIN.CUDACPP_SA_OUTPUT has marked as NOT being validated with this version. 
@@ -103,7 +103,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1100][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1107][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1119][0m [0m
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.574 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.572 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 203][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -145,6 +145,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m2.121s
-user	0m1.960s
-sys	0m0.144s
+real	0m2.118s
+user	0m1.977s
+sys	0m0.124s

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttgg.auto/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttgg.auto/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttgg.auto/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttgg.auto/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttgg.auto/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttgg.auto/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttgg/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttgg/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttgg/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttgg/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttgg/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttgg/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           996         *
+*         BZR 3.1.1_lo_vectorization           990         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.00687098503112793 [0m
+[1;32mDEBUG: model prefixing  takes 0.006894826889038086 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.470 s
+1 processes with 1240 diagrams generated in 2.500 s
 Total: 1 processes with 1240 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttggg
 [1;34mPlugin PLUGIN.CUDACPP_SA_OUTPUT has marked as NOT being validated with this version. 
@@ -105,7 +105,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1100][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1107][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1119][0m [0m
-Generated helas calls for 1 subprocesses (1240 diagrams) in 8.913 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 9.066 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 203][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -113,7 +113,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.385 s
+ALOHA: aloha creates 5 routines in  0.383 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -147,6 +147,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m17.304s
-user	0m17.096s
-sys	0m0.190s
+real	0m17.543s
+user	0m17.343s
+sys	0m0.182s

--- a/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
@@ -12,7 +12,7 @@ Running MG5 in debug mode
 *                 *                       *                *
 *                                                          *
 *         VERSION 3.3.1_lo_vect         2022-01-30         *
-*         BZR 3.1.1_lo_vectorization           990         *
+*         BZR 3.1.1_lo_vectorization           996         *
 *                                                          *
 *    The MadGraph5_aMC@NLO Development Team - Find us at   *
 *    https://server06.fynu.ucl.ac.be/projects/madgraph     *
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006894826889038086 [0m
+[1;32mDEBUG: model prefixing  takes 0.00687098503112793 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.500 s
+1 processes with 1240 diagrams generated in 2.470 s
 Total: 1 processes with 1240 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttggg
 [1;34mPlugin PLUGIN.CUDACPP_SA_OUTPUT has marked as NOT being validated with this version. 
@@ -105,7 +105,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1100][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1107][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1119][0m [0m
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.066 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.913 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 203][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -113,7 +113,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.383 s
+ALOHA: aloha creates 5 routines in  0.385 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -147,6 +147,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 212][0m [0m
 quit
 
-real	0m17.543s
-user	0m17.343s
-sys	0m0.182s
+real	0m17.304s
+user	0m17.096s
+sys	0m0.190s

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/P1_Sigma_sm_gg_ttxggg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/P1_Sigma_sm_gg_ttxggg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttggg.auto/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttggg.auto/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttggg.auto/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttggg.auto/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttggg.auto/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttggg.auto/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/Bridge.h
@@ -65,7 +65,7 @@ namespace mg5amcCpu
      * @param nparF (NEXTERNAL, nexternal.inc) number of external particles in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      * @param np4F number of momenta components, usually 4, in Fortran arrays (KEPT FOR SANITY CHECKS ONLY)
      */
-    Bridge( int nevtF, int nparF, int np4F );
+    Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F );
 
     /**
      * Destructor
@@ -108,7 +108,7 @@ namespace mg5amcCpu
     void cpu_sequence( const FORTRANFPTYPE* momenta, FORTRANFPTYPE* mes, const bool goodHelOnly = false );
 
   private:
-    int m_nevt;                // number of events
+    unsigned int m_nevt;       // number of events
     bool m_goodHelsCalculated; // have the good helicities been calculated?
 
 #ifdef __CUDACC__
@@ -135,15 +135,15 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
 
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
 #endif // __CUDACC__
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt );
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt );
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt );
 
   //--------------------------------------------------------------------------
   //
@@ -151,7 +151,7 @@ namespace mg5amcCpu
   //
 
   template<typename FORTRANFPTYPE>
-  Bridge<FORTRANFPTYPE>::Bridge( int nevtF, int nparF, int np4F )
+  Bridge<FORTRANFPTYPE>::Bridge( unsigned int nevtF, unsigned int nparF, unsigned int np4F )
     : m_nevt( nevtF )
     , m_goodHelsCalculated( false )
 #ifdef __CUDACC__
@@ -267,7 +267,7 @@ namespace mg5amcCpu
 
 #ifdef __CUDACC__
   template<typename Tin, typename Tout>
-  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  __global__ void dev_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = true; // default: use old implementation
     if constexpr( oldImplementation )
@@ -318,25 +318,25 @@ namespace mg5amcCpu
 #endif
 
   template<typename Tin, typename Tout, bool F2C>
-  void hst_transposeMomenta( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomenta( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool oldImplementation = false; // default: use new implementation
     if constexpr( oldImplementation )
     {
       // SR initial implementation
-      constexpr int part = mgOnGpu::npar;
-      constexpr int mome = mgOnGpu::np4;
-      constexpr int strd = MemoryAccessMomenta::neppM;
-      int arrlen = nevt * part * mome;
-      for( int pos = 0; pos < arrlen; ++pos )
+      constexpr unsigned int part = mgOnGpu::npar;
+      constexpr unsigned int mome = mgOnGpu::np4;
+      constexpr unsigned int strd = MemoryAccessMomenta::neppM;
+      unsigned int arrlen = nevt * part * mome;
+      for( unsigned int pos = 0; pos < arrlen; ++pos )
       {
-        int page_i = pos / ( strd * mome * part );
-        int rest_1 = pos % ( strd * mome * part );
-        int part_i = rest_1 / ( strd * mome );
-        int rest_2 = rest_1 % ( strd * mome );
-        int mome_i = rest_2 / strd;
-        int strd_i = rest_2 % strd;
-        int inpos =
+        unsigned int page_i = pos / ( strd * mome * part );
+        unsigned int rest_1 = pos % ( strd * mome * part );
+        unsigned int part_i = rest_1 / ( strd * mome );
+        unsigned int rest_2 = rest_1 % ( strd * mome );
+        unsigned int mome_i = rest_2 / strd;
+        unsigned int strd_i = rest_2 % strd;
+        unsigned int inpos =
           ( page_i * strd + strd_i ) // event number
             * ( part * mome )        // event size (pos of event)
           + part_i * mome            // particle inside event
@@ -353,25 +353,25 @@ namespace mg5amcCpu
       // [NB! this is not a transposition, it is an AOS to AOSOA conversion: if neppM=1, a memcpy is enough]
       // F-style: AOS[nevtF][nparF][np4F]
       // C-style: AOSOA[npagM][npar][np4][neppM] with nevt=npagM*neppM
-      constexpr int npar = mgOnGpu::npar;
-      constexpr int np4 = mgOnGpu::np4;
-      constexpr int neppM = MemoryAccessMomenta::neppM;
+      constexpr unsigned int npar = mgOnGpu::npar;
+      constexpr unsigned int np4 = mgOnGpu::np4;
+      constexpr unsigned int neppM = MemoryAccessMomenta::neppM;
       if constexpr( neppM == 1 && std::is_same_v<Tin, Tout> )
       {
         memcpy( out, in, nevt * npar * np4 * sizeof( Tin ) );
       }
       else
       {
-        const int npagM = nevt / neppM;
+        const unsigned int npagM = nevt / neppM;
         assert( nevt % neppM == 0 ); // number of events is not a multiple of neppM???
-        for( int ipagM = 0; ipagM < npagM; ipagM++ )
-          for( int ip4 = 0; ip4 < np4; ip4++ )
-            for( int ipar = 0; ipar < npar; ipar++ )
-              for( int ieppM = 0; ieppM < neppM; ieppM++ )
+        for( unsigned int ipagM = 0; ipagM < npagM; ipagM++ )
+          for( unsigned int ip4 = 0; ip4 < np4; ip4++ )
+            for( unsigned int ipar = 0; ipar < npar; ipar++ )
+              for( unsigned int ieppM = 0; ieppM < neppM; ieppM++ )
               {
-                int ievt = ipagM * neppM + ieppM;
-                int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
-                int fpos = ievt * npar * np4 + ipar * np4 + ip4;
+                unsigned int ievt = ipagM * neppM + ieppM;
+                unsigned int cpos = ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM;
+                unsigned int fpos = ievt * npar * np4 + ipar * np4 + ip4;
                 if constexpr( F2C )
                   out[cpos] = in[fpos]; // F2C (Fortran to C)
                 else
@@ -382,14 +382,14 @@ namespace mg5amcCpu
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaF2C( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = true;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );
   }
 
   template<typename Tin, typename Tout>
-  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const int nevt )
+  void hst_transposeMomentaC2F( const Tin* in, Tout* out, const unsigned int nevt )
   {
     constexpr bool F2C = false;
     hst_transposeMomenta<Tin, Tout, F2C>( in, out, nevt );

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/CrossSectionKernels.cc
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/CrossSectionKernels.cc
@@ -80,9 +80,9 @@ namespace mg5amcCpu
 {
   //--------------------------------------------------------------------------
 
-  void flagAbnormalMEs( fptype* hstMEs, int nevt )
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt )
   {
-    for( int ievt = 0; ievt < nevt; ievt++ )
+    for( unsigned int ievt = 0; ievt < nevt; ievt++ )
     {
       if( fp_is_abnormal( hstMEs[ievt] ) )
       {

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/CrossSectionKernels.h
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/CrossSectionKernels.h
@@ -18,7 +18,7 @@ namespace mg5amcCpu
 
   // Helper function for Bridge.h: must be compiled without fast math
   // Iterate through all output MEs and replace any NaN/abnormal ones by sqrt(-1)
-  void flagAbnormalMEs( fptype* hstMEs, int nevt );
+  void flagAbnormalMEs( fptype* hstMEs, unsigned int nevt );
 
   //--------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/check_sa.cc
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/check_sa.cc
@@ -81,12 +81,12 @@ main( int argc, char** argv )
   bool debug = false;
   bool perf = false;
   bool json = false;
-  int niter = 0;
-  int gpublocks = 1;
-  int gputhreads = 32;
-  int jsondate = 0;
-  int jsonrun = 0;
-  int numvec[5] = { 0, 0, 0, 0, 0 };
+  unsigned int niter = 0;
+  unsigned int gpublocks = 1;
+  unsigned int gputhreads = 32;
+  unsigned int jsondate = 0;
+  unsigned int jsonrun = 0;
+  unsigned int numvec[5] = { 0, 0, 0, 0, 0 };
   int nnum = 0;
   // Random number mode
   enum class RandomNumberMode
@@ -174,7 +174,7 @@ main( int argc, char** argv )
     }
     else if( is_number( argv[argn] ) && nnum < 5 )
     {
-      numvec[nnum++] = atoi( argv[argn] );
+      numvec[nnum++] = strtoul( argv[argn], NULL, 0 );
     }
     else
     {
@@ -262,8 +262,8 @@ main( int argc, char** argv )
   if( !MatrixElementKernelHost::hostSupportsSIMD() ) return 1;
 #endif
 
-  const int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
-  const int nevt = ndim;                   // number of events in one iteration == number of GPU threads
+  const unsigned int ndim = gpublocks * gputhreads; // number of threads in one GPU grid
+  const unsigned int nevt = ndim;                   // number of events in one iteration == number of GPU threads
 
   if( verbose )
     std::cout << "# iterations: " << niter << std::endl;
@@ -414,7 +414,7 @@ main( int argc, char** argv )
   // *** START MAIN LOOP ON #ITERATIONS ***
   // **************************************
 
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned long int iiter = 0; iiter < niter; ++iiter )
   {
     //std::cout << "Iteration #" << iiter+1 << " of " << niter << std::endl;
 
@@ -571,7 +571,7 @@ main( int argc, char** argv )
       if( perf ) std::cout << "Wave function time: " << wavetime << std::endl;
     }
 
-    for( int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
+    for( unsigned int ievt = 0; ievt < nevt; ++ievt ) // Loop over all events in this iteration
     {
       if( verbose )
       {
@@ -616,7 +616,7 @@ main( int argc, char** argv )
   //double sqsgtim = 0;
   double mingtim = genrtimes[0];
   double maxgtim = genrtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumgtim += genrtimes[iiter];
     //sqsgtim += genrtimes[iiter]*genrtimes[iiter];
@@ -628,7 +628,7 @@ main( int argc, char** argv )
   //double sqsrtim = 0;
   double minrtim = rambtimes[0];
   double maxrtim = rambtimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumrtim += rambtimes[iiter];
     //sqsrtim += rambtimes[iiter]*rambtimes[iiter];
@@ -640,7 +640,7 @@ main( int argc, char** argv )
   //double sqswtim = 0;
   double minwtim = wavetimes[0];
   double maxwtim = wavetimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumwtim += wavetimes[iiter];
     //sqswtim += wavetimes[iiter]*wavetimes[iiter];
@@ -654,7 +654,7 @@ main( int argc, char** argv )
   //double sqsw3atim = 0;
   double minw3atim = wv3atimes[0];
   double maxw3atim = wv3atimes[0];
-  for( int iiter = 0; iiter < niter; ++iiter )
+  for( unsigned int iiter = 0; iiter < niter; ++iiter )
   {
     sumw3atim += wv3atimes[iiter];
     //sqsw3atim += wv3atimes[iiter]*wv3atimes[iiter];
@@ -664,7 +664,7 @@ main( int argc, char** argv )
   double meanw3atim = sumw3atim / niter;
   //double stdw3atim = std::sqrt( sqsw3atim / niter - meanw3atim * meanw3atim );
 
-  const int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
+  const unsigned int nevtALL = hstStats.nevtALL; // total number of ALL events in all iterations
   if( nevtALL != niter * nevt )
     std::cout << "ERROR! nevtALL mismatch " << nevtALL << " != " << niter * nevt << std::endl; // SANITY CHECK
   int nabn = hstStats.nevtABN;

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/RandomNumberKernels.cc
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/RandomNumberKernels.cc
@@ -75,7 +75,7 @@ namespace mg5amcCpu
 
   //--------------------------------------------------------------------------
 
-  void CurandRandomNumberKernel::seedGenerator( const int seed )
+  void CurandRandomNumberKernel::seedGenerator( const unsigned int seed )
   {
     if( m_isOnDevice )
     {

--- a/epochX/cudacpp/gg_ttggg/SubProcesses/RandomNumberKernels.h
+++ b/epochX/cudacpp/gg_ttggg/SubProcesses/RandomNumberKernels.h
@@ -28,7 +28,7 @@ namespace mg5amcCpu
     virtual ~IRandomNumberKernel(){}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -57,7 +57,7 @@ namespace mg5amcCpu
     virtual ~RandomNumberKernelBase() {}
 
     // Seed the random number generator
-    virtual void seedGenerator( const int seed ) = 0;
+    virtual void seedGenerator( const unsigned int seed ) = 0;
 
     // Generate the random number array
     virtual void generateRnarray() = 0;
@@ -85,7 +85,7 @@ namespace mg5amcCpu
     ~CommonRandomNumberKernel() {}
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final { m_seed = seed; };
+    void seedGenerator( const unsigned int seed ) override final { m_seed = seed; };
 
     // Generate the random number array
     void generateRnarray() override final;
@@ -96,7 +96,7 @@ namespace mg5amcCpu
   private:
 
     // The generator seed
-    int m_seed;
+    unsigned int m_seed;
   };
 
   //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace mg5amcCpu
     ~CurandRandomNumberKernel();
 
     // Seed the random number generator
-    void seedGenerator( const int seed ) override final;
+    void seedGenerator( const unsigned int seed ) override final;
 
     // Generate the random number array
     void generateRnarray() override final;

--- a/epochX/cudacpp/gg_ttggg/src/read_slha.cc
+++ b/epochX/cudacpp/gg_ttggg/src/read_slha.cc
@@ -110,8 +110,8 @@ SLHAReader::read_slha_file( std::string file_name, bool verbose )
         while( line[0] == ' ' )
           line = line.substr( 1 );
         // Now find end of block name
-        int space_pos = line.find( ' ' );
-        if( space_pos != ( (int)line.npos ) )
+        size_t space_pos = line.find( ' ' );
+        if( space_pos != std::string::npos )
           line = line.substr( 0, space_pos );
         block = line;
         continue;

--- a/epochX/cudacpp/gg_ttggg/src/read_slha.h
+++ b/epochX/cudacpp/gg_ttggg/src/read_slha.h
@@ -15,7 +15,7 @@ public:
   double get_entry( std::vector<int> indices, double def_val = 0 );
   void set_name( std::string name ) { _name = name; }
   std::string get_name() { return _name; }
-  int get_indices() { return _indices; }
+  unsigned int get_indices() { return _indices; }
 private:
   std::string _name;
   std::map<std::vector<int>, double> _entries;

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-04-18_19:12:00
+DATE: 2022-03-02_20:42:21
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.325757e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.345253e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.327342e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.650391e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.543701e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.328033e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.763633 sec
-       435,001,888      cycles:u                  #    0.431 GHz                    
-       771,534,440      instructions:u            #    1.77  insn per cycle         
-       1.067958238 seconds time elapsed
+TOTAL       :     0.513662 sec
+       413,968,051      cycles:u                  #    0.931 GHz                    
+       751,994,111      instructions:u            #    1.82  insn per cycle         
+       0.732801350 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 128
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.089886e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.660493e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.660493e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.082769e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.634916e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.634916e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.248796 sec
-    16,543,867,962      cycles:u                  #    2.642 GHz                    
-    40,584,564,773      instructions:u            #    2.45  insn per cycle         
-       6.264375547 seconds time elapsed
+TOTAL       :     6.270509 sec
+    16,617,081,523      cycles:u                  #    2.648 GHz                    
+    40,586,917,676      instructions:u            #    2.44  insn per cycle         
+       6.318167103 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  280) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868164916E-002
-Relative difference = 1.0277102699700292e-08
+Avg ME (F77/C++)    = 1.2828039868165201E-002
+Relative difference = 1.0277080522138477e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.542389e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.111620e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.111620e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.546202e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.098641e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.098641e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.542522 sec
-    11,981,941,136      cycles:u                  #    2.632 GHz                    
-    26,055,085,303      instructions:u            #    2.17  insn per cycle         
-       4.557613725 seconds time elapsed
+TOTAL       :     4.517435 sec
+    11,951,541,790      cycles:u                  #    2.641 GHz                    
+    26,063,732,111      instructions:u            #    2.18  insn per cycle         
+       4.637719681 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1267) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868164916E-002
-Relative difference = 1.0277102699700292e-08
+Avg ME (F77/C++)    = 1.2828039868165201E-002
+Relative difference = 1.0277080522138477e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.009267e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.454978e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.454978e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.012668e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.420060e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.420060e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.600609 sec
-     9,019,047,765      cycles:u                  #    2.496 GHz                    
-    15,491,626,366      instructions:u            #    1.72  insn per cycle         
-       3.615905411 seconds time elapsed
+TOTAL       :     3.578034 sec
+     8,982,829,582      cycles:u                  #    2.505 GHz                    
+    15,500,272,859      instructions:u            #    1.73  insn per cycle         
+       3.717096111 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1044) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165088E-002
-Relative difference = 1.0277089312025782e-08
+Avg ME (F77/C++)    = 1.2828039868165201E-002
+Relative difference = 1.0277080522138477e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.073044e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.899945e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.899945e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.073252e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.890733e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.890733e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.504899 sec
-     8,792,720,287      cycles:u                  #    2.500 GHz                    
-    15,372,091,454      instructions:u            #    1.75  insn per cycle         
-       3.522120902 seconds time elapsed
+TOTAL       :     3.483272 sec
+     8,768,552,952      cycles:u                  #    2.512 GHz                    
+    15,380,735,835      instructions:u            #    1.75  insn per cycle         
+       3.550889508 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1018) (512y:    1) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165088E-002
-Relative difference = 1.0277089312025782e-08
+Avg ME (F77/C++)    = 1.2828039868165201E-002
+Relative difference = 1.0277080522138477e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -199,23 +199,25 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.921597e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.813776e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.813776e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.918396e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.772420e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.772420e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.743690 sec
-     8,429,688,933      cycles:u                  #    2.244 GHz                    
-    12,454,395,807      instructions:u            #    1.48  insn per cycle         
-       3.759742841 seconds time elapsed
+TOTAL       :     3.730114 sec
+     8,413,652,592      cycles:u                  #    2.251 GHz                    
+    12,463,041,181      instructions:u            #    1.48  insn per cycle         
+       3.822048507 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  238) (512y:    2) (512z:  787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165088E-002
-Relative difference = 1.0277089312025782e-08
+Avg ME (F77/C++)    = 1.2828039868165201E-002
+Relative difference = 1.0277080522138477e-08
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-03-02_20:42:21
+DATE: 2022-04-18_19:12:00
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 12 OMP=
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.650391e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.543701e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.328033e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.325757e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.345253e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.327342e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.513662 sec
-       413,968,051      cycles:u                  #    0.931 GHz                    
-       751,994,111      instructions:u            #    1.82  insn per cycle         
-       0.732801350 seconds time elapsed
+TOTAL       :     0.763633 sec
+       435,001,888      cycles:u                  #    0.431 GHz                    
+       771,534,440      instructions:u            #    1.77  insn per cycle         
+       1.067958238 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 128
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.082769e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.634916e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.634916e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.089886e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.660493e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.660493e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.270509 sec
-    16,617,081,523      cycles:u                  #    2.648 GHz                    
-    40,586,917,676      instructions:u            #    2.44  insn per cycle         
-       6.318167103 seconds time elapsed
+TOTAL       :     6.248796 sec
+    16,543,867,962      cycles:u                  #    2.642 GHz                    
+    40,584,564,773      instructions:u            #    2.45  insn per cycle         
+       6.264375547 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  280) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165201E-002
-Relative difference = 1.0277080522138477e-08
+Avg ME (F77/C++)    = 1.2828039868164916E-002
+Relative difference = 1.0277102699700292e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.546202e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.098641e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.098641e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.542389e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.111620e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.111620e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.517435 sec
-    11,951,541,790      cycles:u                  #    2.641 GHz                    
-    26,063,732,111      instructions:u            #    2.18  insn per cycle         
-       4.637719681 seconds time elapsed
+TOTAL       :     4.542522 sec
+    11,981,941,136      cycles:u                  #    2.632 GHz                    
+    26,055,085,303      instructions:u            #    2.17  insn per cycle         
+       4.557613725 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1267) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165201E-002
-Relative difference = 1.0277080522138477e-08
+Avg ME (F77/C++)    = 1.2828039868164916E-002
+Relative difference = 1.0277102699700292e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.012668e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.420060e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.420060e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.009267e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.454978e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.454978e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.578034 sec
-     8,982,829,582      cycles:u                  #    2.505 GHz                    
-    15,500,272,859      instructions:u            #    1.73  insn per cycle         
-       3.717096111 seconds time elapsed
+TOTAL       :     3.600609 sec
+     9,019,047,765      cycles:u                  #    2.496 GHz                    
+    15,491,626,366      instructions:u            #    1.72  insn per cycle         
+       3.615905411 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1044) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165201E-002
-Relative difference = 1.0277080522138477e-08
+Avg ME (F77/C++)    = 1.2828039868165088E-002
+Relative difference = 1.0277089312025782e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.073252e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.890733e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.890733e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.073044e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.899945e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.899945e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.483272 sec
-     8,768,552,952      cycles:u                  #    2.512 GHz                    
-    15,380,735,835      instructions:u            #    1.75  insn per cycle         
-       3.550889508 seconds time elapsed
+TOTAL       :     3.504899 sec
+     8,792,720,287      cycles:u                  #    2.500 GHz                    
+    15,372,091,454      instructions:u            #    1.75  insn per cycle         
+       3.522120902 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1018) (512y:    1) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165201E-002
-Relative difference = 1.0277080522138477e-08
+Avg ME (F77/C++)    = 1.2828039868165088E-002
+Relative difference = 1.0277089312025782e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe -p 2048 256 12 OMP=
@@ -199,25 +199,23 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.918396e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.772420e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.772420e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.921597e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.813776e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.813776e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.730114 sec
-     8,413,652,592      cycles:u                  #    2.251 GHz                    
-    12,463,041,181      instructions:u            #    1.48  insn per cycle         
-       3.822048507 seconds time elapsed
+TOTAL       :     3.743690 sec
+     8,429,688,933      cycles:u                  #    2.244 GHz                    
+    12,454,395,807      instructions:u            #    1.48  insn per cycle         
+       3.759742841 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  238) (512y:    2) (512z:  787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.282804e-02
-Avg ME (F77/C++)    = 1.2828039868165201E-002
-Relative difference = 1.0277080522138477e-08
+Avg ME (F77/C++)    = 1.2828039868165088E-002
+Relative difference = 1.0277089312025782e-08
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-04-14_13:55:55
+DATE: 2022-03-02_20:44:01
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.998459e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.292230e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.421736e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.783311e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.286976e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.423520e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.579130 sec
-       126,907,785      cycles:u                  #    0.156 GHz                    
-       149,382,612      instructions:u            #    1.18  insn per cycle         
-       0.874559337 seconds time elapsed
+TOTAL       :     0.192238 sec
+       121,032,856      cycles:u                  #    0.477 GHz                    
+       148,693,174      instructions:u            #    1.23  insn per cycle         
+       0.470459066 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 170
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.876022e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.995895e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.995895e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.880869e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.998415e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.998415e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.887522 sec
-     7,585,832,305      cycles:u                  #    2.617 GHz                    
-    22,040,673,948      instructions:u            #    2.91  insn per cycle         
-       2.904398753 seconds time elapsed
+TOTAL       :     2.868103 sec
+     7,569,490,302      cycles:u                  #    2.632 GHz                    
+    22,043,027,778      instructions:u            #    2.91  insn per cycle         
+       2.930334332 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  449) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358985919
-Relative difference = 1.7946576886544025e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.867906e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.163648e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.163648e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.875237e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.171967e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.171967e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.920225 sec
-     5,004,927,499      cycles:u                  #    2.591 GHz                    
-    12,983,449,990      instructions:u            #    2.59  insn per cycle         
-       1.934430881 seconds time elapsed
+TOTAL       :     1.904920 sec
+     4,986,509,471      cycles:u                  #    2.606 GHz                    
+    12,986,329,320      instructions:u            #    2.60  insn per cycle         
+       1.967185501 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2360) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358985928
-Relative difference = 1.7946576842765667e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.802120e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.648656e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.648656e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.784499e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.627868e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.627868e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.183223 sec
-     2,667,626,510      cycles:u                  #    2.233 GHz                    
-     5,527,264,356      instructions:u            #    2.07  insn per cycle         
-       1.197223654 seconds time elapsed
+TOTAL       :     1.176503 sec
+     2,668,866,456      cycles:u                  #    2.253 GHz                    
+     5,530,142,603      instructions:u            #    2.07  insn per cycle         
+       1.233542634 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2177) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.087289e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.060891e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.060891e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.158898e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.147894e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.147894e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.123142 sec
-     2,527,726,128      cycles:u                  #    2.228 GHz                    
-     5,351,099,993      instructions:u            #    2.12  insn per cycle         
-       1.137204424 seconds time elapsed
+TOTAL       :     1.096895 sec
+     2,489,998,374      cycles:u                  #    2.253 GHz                    
+     5,353,978,508      instructions:u            #    2.15  insn per cycle         
+       1.210113960 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2013) (512y:  115) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -199,23 +199,25 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.416682e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.822836e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.822836e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.420075e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.836944e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.836944e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.626037 sec
-     2,717,083,092      cycles:u                  #    1.660 GHz                    
-     3,543,690,537      instructions:u            #    1.30  insn per cycle         
-       1.639859629 seconds time elapsed
+TOTAL       :     1.614425 sec
+     2,714,080,080      cycles:u                  #    1.673 GHz                    
+     3,546,569,379      instructions:u            #    1.31  insn per cycle         
+       1.660243395 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1026) (512y:   83) (512z: 1568)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-03-02_20:44:01
+DATE: 2022-04-14_13:55:55
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.783311e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.286976e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.423520e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.998459e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.292230e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.421736e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.192238 sec
-       121,032,856      cycles:u                  #    0.477 GHz                    
-       148,693,174      instructions:u            #    1.23  insn per cycle         
-       0.470459066 seconds time elapsed
+TOTAL       :     0.579130 sec
+       126,907,785      cycles:u                  #    0.156 GHz                    
+       149,382,612      instructions:u            #    1.18  insn per cycle         
+       0.874559337 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 170
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.880869e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.998415e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.998415e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.876022e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.995895e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.995895e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.868103 sec
-     7,569,490,302      cycles:u                  #    2.632 GHz                    
-    22,043,027,778      instructions:u            #    2.91  insn per cycle         
-       2.930334332 seconds time elapsed
+TOTAL       :     2.887522 sec
+     7,585,832,305      cycles:u                  #    2.617 GHz                    
+    22,040,673,948      instructions:u            #    2.91  insn per cycle         
+       2.904398753 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  449) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358985919
+Relative difference = 1.7946576886544025e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.875237e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.171967e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.171967e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.867906e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.163648e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.163648e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.904920 sec
-     4,986,509,471      cycles:u                  #    2.606 GHz                    
-    12,986,329,320      instructions:u            #    2.60  insn per cycle         
-       1.967185501 seconds time elapsed
+TOTAL       :     1.920225 sec
+     5,004,927,499      cycles:u                  #    2.591 GHz                    
+    12,983,449,990      instructions:u            #    2.59  insn per cycle         
+       1.934430881 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2360) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358985928
+Relative difference = 1.7946576842765667e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.784499e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.627868e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.627868e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.802120e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.648656e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.648656e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.176503 sec
-     2,668,866,456      cycles:u                  #    2.253 GHz                    
-     5,530,142,603      instructions:u            #    2.07  insn per cycle         
-       1.233542634 seconds time elapsed
+TOTAL       :     1.183223 sec
+     2,667,626,510      cycles:u                  #    2.233 GHz                    
+     5,527,264,356      instructions:u            #    2.07  insn per cycle         
+       1.197223654 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2177) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.158898e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.147894e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.147894e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.087289e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.060891e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.060891e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.096895 sec
-     2,489,998,374      cycles:u                  #    2.253 GHz                    
-     5,353,978,508      instructions:u            #    2.15  insn per cycle         
-       1.210113960 seconds time elapsed
+TOTAL       :     1.123142 sec
+     2,527,726,128      cycles:u                  #    2.228 GHz                    
+     5,351,099,993      instructions:u            #    2.12  insn per cycle         
+       1.137204424 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2013) (512y:  115) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -199,25 +199,23 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.420075e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.836944e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.836944e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.416682e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.822836e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.822836e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.614425 sec
-     2,714,080,080      cycles:u                  #    1.673 GHz                    
-     3,546,569,379      instructions:u            #    1.31  insn per cycle         
-       1.660243395 seconds time elapsed
+TOTAL       :     1.626037 sec
+     2,717,083,092      cycles:u                  #    1.660 GHz                    
+     3,543,690,537      instructions:u            #    1.30  insn per cycle         
+       1.639859629 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1026) (512y:   83) (512z: 1568)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-04-18_19:12:59
+DATE: 2022-03-02_20:44:01
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.509592e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.272921e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.421547e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.783311e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.286976e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.423520e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.577209 sec
-       128,996,211      cycles:u                  #    0.158 GHz                    
-       150,383,174      instructions:u            #    1.17  insn per cycle         
-       0.875440528 seconds time elapsed
+TOTAL       :     0.192238 sec
+       121,032,856      cycles:u                  #    0.477 GHz                    
+       148,693,174      instructions:u            #    1.23  insn per cycle         
+       0.470459066 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 170
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.877092e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.995195e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.995195e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.880869e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.998415e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.998415e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.889049 sec
-     7,588,158,014      cycles:u                  #    2.615 GHz                    
-    22,040,674,008      instructions:u            #    2.90  insn per cycle         
-       2.905073904 seconds time elapsed
+TOTAL       :     2.868103 sec
+     7,569,490,302      cycles:u                  #    2.632 GHz                    
+    22,043,027,778      instructions:u            #    2.91  insn per cycle         
+       2.930334332 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  449) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358985919
-Relative difference = 1.7946576886544025e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.838847e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.138122e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.138122e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.875237e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.171967e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.171967e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.941198 sec
-     5,051,842,791      cycles:u                  #    2.585 GHz                    
-    12,983,449,870      instructions:u            #    2.57  insn per cycle         
-       1.956675768 seconds time elapsed
+TOTAL       :     1.904920 sec
+     4,986,509,471      cycles:u                  #    2.606 GHz                    
+    12,986,329,320      instructions:u            #    2.60  insn per cycle         
+       1.967185501 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2360) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358985928
-Relative difference = 1.7946576842765667e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.791102e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.660053e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.660053e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.784499e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.627868e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.627868e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.189151 sec
-     2,667,634,896      cycles:u                  #    2.219 GHz                    
-     5,527,264,818      instructions:u            #    2.07  insn per cycle         
-       1.205178750 seconds time elapsed
+TOTAL       :     1.176503 sec
+     2,668,866,456      cycles:u                  #    2.253 GHz                    
+     5,530,142,603      instructions:u            #    2.07  insn per cycle         
+       1.233542634 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2177) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.119508e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.113932e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.113932e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.158898e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.147894e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.147894e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.119007 sec
-     2,514,607,443      cycles:u                  #    2.221 GHz                    
-     5,351,099,831      instructions:u            #    2.13  insn per cycle         
-       1.135003361 seconds time elapsed
+TOTAL       :     1.096895 sec
+     2,489,998,374      cycles:u                  #    2.253 GHz                    
+     5,353,978,508      instructions:u            #    2.15  insn per cycle         
+       1.210113960 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2013) (512y:  115) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -199,23 +199,25 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.439378e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.853003e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.853003e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.420075e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.836944e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.836944e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.618317 sec
-     2,702,416,707      cycles:u                  #    1.657 GHz                    
-     3,543,690,451      instructions:u            #    1.31  insn per cycle         
-       1.633856140 seconds time elapsed
+TOTAL       :     1.614425 sec
+     2,714,080,080      cycles:u                  #    1.673 GHz                    
+     3,546,569,379      instructions:u            #    1.31  insn per cycle         
+       1.660243395 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1026) (512y:   83) (512z: 1568)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358986465
-Relative difference = 1.7946574194174922e-07
+Avg ME (F77/C++)    = 2.0288066358987087
+Relative difference = 1.7946571129689766e-07
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
@@ -68,22 +68,22 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-03-02_20:44:01
+DATE: 2022-04-18_19:12:59
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.783311e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.286976e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.423520e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.509592e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.272921e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.421547e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.192238 sec
-       121,032,856      cycles:u                  #    0.477 GHz                    
-       148,693,174      instructions:u            #    1.23  insn per cycle         
-       0.470459066 seconds time elapsed
+TOTAL       :     0.577209 sec
+       128,996,211      cycles:u                  #    0.158 GHz                    
+       150,383,174      instructions:u            #    1.17  insn per cycle         
+       0.875440528 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 170
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,24 +99,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.880869e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.998415e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.998415e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.877092e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.995195e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.995195e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.868103 sec
-     7,569,490,302      cycles:u                  #    2.632 GHz                    
-    22,043,027,778      instructions:u            #    2.91  insn per cycle         
-       2.930334332 seconds time elapsed
+TOTAL       :     2.889049 sec
+     7,588,158,014      cycles:u                  #    2.615 GHz                    
+    22,040,674,008      instructions:u            #    2.90  insn per cycle         
+       2.905073904 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  449) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358985919
+Relative difference = 1.7946576886544025e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -124,24 +124,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.875237e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.171967e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.171967e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.838847e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.138122e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.138122e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.904920 sec
-     4,986,509,471      cycles:u                  #    2.606 GHz                    
-    12,986,329,320      instructions:u            #    2.60  insn per cycle         
-       1.967185501 seconds time elapsed
+TOTAL       :     1.941198 sec
+     5,051,842,791      cycles:u                  #    2.585 GHz                    
+    12,983,449,870      instructions:u            #    2.57  insn per cycle         
+       1.956675768 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2360) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358985928
+Relative difference = 1.7946576842765667e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -149,24 +149,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.784499e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.627868e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.627868e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.791102e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.660053e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.660053e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.176503 sec
-     2,668,866,456      cycles:u                  #    2.253 GHz                    
-     5,530,142,603      instructions:u            #    2.07  insn per cycle         
-       1.233542634 seconds time elapsed
+TOTAL       :     1.189151 sec
+     2,667,634,896      cycles:u                  #    2.219 GHz                    
+     5,527,264,818      instructions:u            #    2.07  insn per cycle         
+       1.205178750 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2177) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -174,24 +174,24 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.158898e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.147894e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.147894e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.119508e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.113932e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.113932e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.096895 sec
-     2,489,998,374      cycles:u                  #    2.253 GHz                    
-     5,353,978,508      instructions:u            #    2.15  insn per cycle         
-       1.210113960 seconds time elapsed
+TOTAL       :     1.119007 sec
+     2,514,607,443      cycles:u                  #    2.221 GHz                    
+     5,351,099,831      instructions:u            #    2.13  insn per cycle         
+       1.135003361 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2013) (512y:  115) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe -p 2048 256 1 OMP=
@@ -199,25 +199,23 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.420075e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.836944e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.836944e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.439378e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.853003e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.853003e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.614425 sec
-     2,714,080,080      cycles:u                  #    1.673 GHz                    
-     3,546,569,379      instructions:u            #    1.31  insn per cycle         
-       1.660243395 seconds time elapsed
+TOTAL       :     1.618317 sec
+     2,702,416,707      cycles:u                  #    1.657 GHz                    
+     3,543,690,451      instructions:u            #    1.31  insn per cycle         
+       1.633856140 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1026) (512y:   83) (512z: 1568)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 2.028807e+00
-Avg ME (F77/C++)    = 2.0288066358987087
-Relative difference = 1.7946571129689766e-07
+Avg ME (F77/C++)    = 2.0288066358986465
+Relative difference = 1.7946574194174922e-07
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-03-02_22:15:06
+DATE: 2022-04-18_19:16:23
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 8.884329e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.122004e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.142852e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.818345e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.113734e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.133206e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.202382 sec
-        94,563,161      cycles:u                  #    0.493 GHz                    
-        89,904,458      instructions:u            #    0.95  insn per cycle         
-       0.252128833 seconds time elapsed
+TOTAL       :     0.616313 sec
+        96,306,123      cycles:u                  #    0.130 GHz                    
+        89,837,353      instructions:u            #    0.93  insn per cycle         
+       0.924336734 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.150746e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.426221e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.442531e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.140008e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.423325e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.441338e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.734461e+02 +- 4.775415e+02 )  GeV^-2
-TOTAL       :     0.276354 sec
-       182,799,600      cycles:u                  #    0.528 GHz                    
-       285,563,716      instructions:u            #    1.56  insn per cycle         
-       0.352869456 seconds time elapsed
+TOTAL       :     0.647787 sec
+       186,858,869      cycles:u                  #    0.208 GHz                    
+       288,759,263      instructions:u            #    1.55  insn per cycle         
+       0.959314230 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.444930e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.474432e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.474432e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.446744e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.475963e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.475963e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.681342 sec
-     1,804,067,404      cycles:u                  #    2.636 GHz                    
-     5,728,310,505      instructions:u            #    3.18  insn per cycle         
-       0.688457745 seconds time elapsed
+TOTAL       :     0.675437 sec
+     1,802,070,246      cycles:u                  #    2.651 GHz                    
+     5,725,940,306      instructions:u            #    3.18  insn per cycle         
+       0.682525348 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  713) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787944412
-Relative difference = 2.2730207216187906e-07
+Avg ME (F77/C++)    = 1.4131216787958192
+Relative difference = 2.2730109700982697e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.403870e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.498913e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.498913e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.401912e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.498710e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.498710e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.381299 sec
-     1,008,612,859      cycles:u                  #    2.616 GHz                    
-     2,995,457,153      instructions:u            #    2.97  insn per cycle         
-       0.388252431 seconds time elapsed
+TOTAL       :     0.378085 sec
+     1,006,907,472      cycles:u                  #    2.633 GHz                    
+     2,993,087,861      instructions:u            #    2.97  insn per cycle         
+       0.385076184 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4237) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787944412
-Relative difference = 2.2730207216187906e-07
+Avg ME (F77/C++)    = 1.4131216787958190
+Relative difference = 2.2730109716695749e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.477066e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.836452e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.836452e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.431176e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.800866e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.800866e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.202323 sec
-       456,303,954      cycles:u                  #    2.209 GHz                    
-     1,064,622,815      instructions:u            #    2.33  insn per cycle         
-       0.209416914 seconds time elapsed
+TOTAL       :     0.200358 sec
+       455,714,103      cycles:u                  #    2.225 GHz                    
+     1,062,237,161      instructions:u            #    2.33  insn per cycle         
+       0.207588644 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3582) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787944412
-Relative difference = 2.2730207216187906e-07
+Avg ME (F77/C++)    = 1.4131216787942236
+Relative difference = 2.2730222614979577e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 9.382412e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.813856e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.813856e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.387916e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.822077e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.822077e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.184437 sec
-       414,437,290      cycles:u                  #    2.192 GHz                    
-     1,006,126,068      instructions:u            #    2.43  insn per cycle         
-       0.191759500 seconds time elapsed
+TOTAL       :     0.180222 sec
+       411,452,798      cycles:u                  #    2.226 GHz                    
+     1,003,740,256      instructions:u            #    2.44  insn per cycle         
+       0.187220714 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3421) (512y:   70) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787944412
-Relative difference = 2.2730207216187906e-07
+Avg ME (F77/C++)    = 1.4131216787942236
+Relative difference = 2.2730222614979577e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -212,25 +212,23 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.968373e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.203025e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.203025e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.991395e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.225386e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.225386e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.245146 sec
-       392,781,640      cycles:u                  #    1.571 GHz                    
-       558,073,754      instructions:u            #    1.42  insn per cycle         
-       0.252616903 seconds time elapsed
+TOTAL       :     0.240370 sec
+       389,324,348      cycles:u                  #    1.589 GHz                    
+       555,687,827      instructions:u            #    1.43  insn per cycle         
+       0.247481153 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1240) (512y:   69) (512z: 2828)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787944412
-Relative difference = 2.2730207216187906e-07
+Avg ME (F77/C++)    = 1.4131216787942236
+Relative difference = 2.2730222614979577e-07
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-04-18_19:16:23
+DATE: 2022-03-02_22:15:06
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 8.818345e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.113734e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.133206e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.884329e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.122004e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.142852e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.616313 sec
-        96,306,123      cycles:u                  #    0.130 GHz                    
-        89,837,353      instructions:u            #    0.93  insn per cycle         
-       0.924336734 seconds time elapsed
+TOTAL       :     0.202382 sec
+        94,563,161      cycles:u                  #    0.493 GHz                    
+        89,904,458      instructions:u            #    0.95  insn per cycle         
+       0.252128833 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.140008e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.423325e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.441338e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.150746e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.426221e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.442531e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.734461e+02 +- 4.775415e+02 )  GeV^-2
-TOTAL       :     0.647787 sec
-       186,858,869      cycles:u                  #    0.208 GHz                    
-       288,759,263      instructions:u            #    1.55  insn per cycle         
-       0.959314230 seconds time elapsed
+TOTAL       :     0.276354 sec
+       182,799,600      cycles:u                  #    0.528 GHz                    
+       285,563,716      instructions:u            #    1.56  insn per cycle         
+       0.352869456 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.446744e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.475963e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.475963e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.444930e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.474432e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.474432e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.675437 sec
-     1,802,070,246      cycles:u                  #    2.651 GHz                    
-     5,725,940,306      instructions:u            #    3.18  insn per cycle         
-       0.682525348 seconds time elapsed
+TOTAL       :     0.681342 sec
+     1,804,067,404      cycles:u                  #    2.636 GHz                    
+     5,728,310,505      instructions:u            #    3.18  insn per cycle         
+       0.688457745 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  713) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787958192
-Relative difference = 2.2730109700982697e-07
+Avg ME (F77/C++)    = 1.4131216787944412
+Relative difference = 2.2730207216187906e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.401912e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.498710e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.498710e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.403870e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.498913e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.498913e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.378085 sec
-     1,006,907,472      cycles:u                  #    2.633 GHz                    
-     2,993,087,861      instructions:u            #    2.97  insn per cycle         
-       0.385076184 seconds time elapsed
+TOTAL       :     0.381299 sec
+     1,008,612,859      cycles:u                  #    2.616 GHz                    
+     2,995,457,153      instructions:u            #    2.97  insn per cycle         
+       0.388252431 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4237) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787958190
-Relative difference = 2.2730109716695749e-07
+Avg ME (F77/C++)    = 1.4131216787944412
+Relative difference = 2.2730207216187906e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.431176e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.800866e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.800866e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.477066e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.836452e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.836452e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.200358 sec
-       455,714,103      cycles:u                  #    2.225 GHz                    
-     1,062,237,161      instructions:u            #    2.33  insn per cycle         
-       0.207588644 seconds time elapsed
+TOTAL       :     0.202323 sec
+       456,303,954      cycles:u                  #    2.209 GHz                    
+     1,064,622,815      instructions:u            #    2.33  insn per cycle         
+       0.209416914 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3582) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787942236
-Relative difference = 2.2730222614979577e-07
+Avg ME (F77/C++)    = 1.4131216787944412
+Relative difference = 2.2730207216187906e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 9.387916e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.822077e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.822077e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.382412e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.813856e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.813856e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.180222 sec
-       411,452,798      cycles:u                  #    2.226 GHz                    
-     1,003,740,256      instructions:u            #    2.44  insn per cycle         
-       0.187220714 seconds time elapsed
+TOTAL       :     0.184437 sec
+       414,437,290      cycles:u                  #    2.192 GHz                    
+     1,006,126,068      instructions:u            #    2.43  insn per cycle         
+       0.191759500 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3421) (512y:   70) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787942236
-Relative difference = 2.2730222614979577e-07
+Avg ME (F77/C++)    = 1.4131216787944412
+Relative difference = 2.2730207216187906e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -212,23 +212,25 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.991395e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.225386e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.225386e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.968373e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.203025e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.203025e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.240370 sec
-       389,324,348      cycles:u                  #    1.589 GHz                    
-       555,687,827      instructions:u            #    1.43  insn per cycle         
-       0.247481153 seconds time elapsed
+TOTAL       :     0.245146 sec
+       392,781,640      cycles:u                  #    1.571 GHz                    
+       558,073,754      instructions:u            #    1.42  insn per cycle         
+       0.252616903 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1240) (512y:   69) (512z: 2828)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 1.413122e+00
-Avg ME (F77/C++)    = 1.4131216787942236
-Relative difference = 2.2730222614979577e-07
+Avg ME (F77/C++)    = 1.4131216787944412
+Relative difference = 2.2730207216187906e-07
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-03-02_20:45:04
+DATE: 2022-04-18_19:20:18
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.448381e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.492028e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.495404e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.439031e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.494543e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.498261e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.203547 sec
-       160,556,197      cycles:u                  #    0.643 GHz                    
-       234,164,869      instructions:u            #    1.46  insn per cycle         
-       0.510651371 seconds time elapsed
+TOTAL       :     0.689999 sec
+       168,855,613      cycles:u                  #    0.205 GHz                    
+       236,002,182      instructions:u            #    1.40  insn per cycle         
+       1.011439799 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.141580e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.192307e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.194436e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.134896e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.191286e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.193684e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.251792 sec
-     2,018,066,532      cycles:u                  #    0.868 GHz                    
-     4,060,131,840      instructions:u            #    2.01  insn per cycle         
-       2.330274883 seconds time elapsed
+TOTAL       :     2.621292 sec
+     1,923,502,259      cycles:u                  #    0.668 GHz                    
+     4,150,776,089      instructions:u            #    2.16  insn per cycle         
+       2.937413813 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.795381e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.797351e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.797351e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.791930e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.793883e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.793883e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.146190 sec
-    24,408,471,737      cycles:u                  #    2.667 GHz                    
-    75,802,803,874      instructions:u            #    3.11  insn per cycle         
-       9.189273129 seconds time elapsed
+TOTAL       :     9.158772 sec
+    24,452,249,830      cycles:u                  #    2.669 GHz                    
+    75,800,433,874      instructions:u            #    3.10  insn per cycle         
+       9.165851836 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1234) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603003670E-004
-Relative difference = 9.099641544231038e-09
+Avg ME (F77/C++)    = 6.6266750602986669E-004
+Relative difference = 9.099385000941009e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.322167e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.328838e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.328838e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.336537e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.343380e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.343380e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.946382 sec
-    13,185,710,971      cycles:u                  #    2.663 GHz                    
-    39,954,200,268      instructions:u            #    3.03  insn per cycle         
-       5.047701273 seconds time elapsed
+TOTAL       :     4.921410 sec
+    13,146,694,081      cycles:u                  #    2.669 GHz                    
+    39,951,810,946      instructions:u            #    3.04  insn per cycle         
+       4.928307588 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7957) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603003670E-004
-Relative difference = 9.099641544231038e-09
+Avg ME (F77/C++)    = 6.6266750602986659E-004
+Relative difference = 9.099384837329216e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.791437e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.819283e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.819283e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.756611e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.783893e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.783893e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.429143 sec
-     5,511,865,684      cycles:u                  #    2.265 GHz                    
-    13,780,488,133      instructions:u            #    2.50  insn per cycle         
-       2.607078173 seconds time elapsed
+TOTAL       :     2.433924 sec
+     5,533,699,067      cycles:u                  #    2.269 GHz                    
+    13,778,099,120      instructions:u            #    2.49  insn per cycle         
+       2.441436437 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6819) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603003670E-004
-Relative difference = 9.099641544231038e-09
+Avg ME (F77/C++)    = 6.6266750603002878E-004
+Relative difference = 9.099629600570215e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.459552e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.492443e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.492443e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.409800e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.442666e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.442666e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.208541 sec
-     5,017,577,651      cycles:u                  #    2.267 GHz                    
-    12,680,180,504      instructions:u            #    2.53  insn per cycle         
-       2.274128563 seconds time elapsed
+TOTAL       :     2.219939 sec
+     5,046,540,619      cycles:u                  #    2.269 GHz                    
+    12,677,791,553      instructions:u            #    2.51  insn per cycle         
+       2.227172320 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6604) (512y:   57) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603003670E-004
-Relative difference = 9.099641544231038e-09
+Avg ME (F77/C++)    = 6.6266750603002878E-004
+Relative difference = 9.099629600570215e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -212,25 +212,23 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.513080e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.538311e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.538311e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.519212e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.544084e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.544084e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.529753 sec
-     3,990,412,420      cycles:u                  #    1.575 GHz                    
-     6,424,103,333      instructions:u            #    1.61  insn per cycle         
-       2.629224079 seconds time elapsed
+TOTAL       :     2.521933 sec
+     3,986,652,612      cycles:u                  #    1.578 GHz                    
+     6,421,716,308      instructions:u            #    1.61  insn per cycle         
+       2.528931245 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1749) (512y:   73) (512z: 5663)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603003670E-004
-Relative difference = 9.099641544231038e-09
+Avg ME (F77/C++)    = 6.6266750603002878E-004
+Relative difference = 9.099629600570215e-09
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-04-18_19:20:18
+DATE: 2022-03-02_20:45:04
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.439031e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.494543e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.498261e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.448381e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.492028e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.495404e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.689999 sec
-       168,855,613      cycles:u                  #    0.205 GHz                    
-       236,002,182      instructions:u            #    1.40  insn per cycle         
-       1.011439799 seconds time elapsed
+TOTAL       :     0.203547 sec
+       160,556,197      cycles:u                  #    0.643 GHz                    
+       234,164,869      instructions:u            #    1.46  insn per cycle         
+       0.510651371 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.134896e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.191286e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.193684e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.141580e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.192307e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.194436e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.621292 sec
-     1,923,502,259      cycles:u                  #    0.668 GHz                    
-     4,150,776,089      instructions:u            #    2.16  insn per cycle         
-       2.937413813 seconds time elapsed
+TOTAL       :     2.251792 sec
+     2,018,066,532      cycles:u                  #    0.868 GHz                    
+     4,060,131,840      instructions:u            #    2.01  insn per cycle         
+       2.330274883 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.791930e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.793883e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.793883e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.795381e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.797351e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.797351e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.158772 sec
-    24,452,249,830      cycles:u                  #    2.669 GHz                    
-    75,800,433,874      instructions:u            #    3.10  insn per cycle         
-       9.165851836 seconds time elapsed
+TOTAL       :     9.146190 sec
+    24,408,471,737      cycles:u                  #    2.667 GHz                    
+    75,802,803,874      instructions:u            #    3.11  insn per cycle         
+       9.189273129 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1234) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750602986669E-004
-Relative difference = 9.099385000941009e-09
+Avg ME (F77/C++)    = 6.6266750603003670E-004
+Relative difference = 9.099641544231038e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.336537e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.343380e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.343380e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.322167e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.328838e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.328838e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.921410 sec
-    13,146,694,081      cycles:u                  #    2.669 GHz                    
-    39,951,810,946      instructions:u            #    3.04  insn per cycle         
-       4.928307588 seconds time elapsed
+TOTAL       :     4.946382 sec
+    13,185,710,971      cycles:u                  #    2.663 GHz                    
+    39,954,200,268      instructions:u            #    3.03  insn per cycle         
+       5.047701273 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7957) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750602986659E-004
-Relative difference = 9.099384837329216e-09
+Avg ME (F77/C++)    = 6.6266750603003670E-004
+Relative difference = 9.099641544231038e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.756611e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.783893e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.783893e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.791437e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.819283e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.819283e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.433924 sec
-     5,533,699,067      cycles:u                  #    2.269 GHz                    
-    13,778,099,120      instructions:u            #    2.49  insn per cycle         
-       2.441436437 seconds time elapsed
+TOTAL       :     2.429143 sec
+     5,511,865,684      cycles:u                  #    2.265 GHz                    
+    13,780,488,133      instructions:u            #    2.50  insn per cycle         
+       2.607078173 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6819) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603002878E-004
-Relative difference = 9.099629600570215e-09
+Avg ME (F77/C++)    = 6.6266750603003670E-004
+Relative difference = 9.099641544231038e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.409800e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.442666e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.442666e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.459552e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.492443e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.492443e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.219939 sec
-     5,046,540,619      cycles:u                  #    2.269 GHz                    
-    12,677,791,553      instructions:u            #    2.51  insn per cycle         
-       2.227172320 seconds time elapsed
+TOTAL       :     2.208541 sec
+     5,017,577,651      cycles:u                  #    2.267 GHz                    
+    12,680,180,504      instructions:u            #    2.53  insn per cycle         
+       2.274128563 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6604) (512y:   57) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603002878E-004
-Relative difference = 9.099629600570215e-09
+Avg ME (F77/C++)    = 6.6266750603003670E-004
+Relative difference = 9.099641544231038e-09
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
@@ -212,23 +212,25 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.519212e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.544084e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.544084e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.513080e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.538311e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.538311e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.521933 sec
-     3,986,652,612      cycles:u                  #    1.578 GHz                    
-     6,421,716,308      instructions:u            #    1.61  insn per cycle         
-       2.528931245 seconds time elapsed
+TOTAL       :     2.529753 sec
+     3,990,412,420      cycles:u                  #    1.575 GHz                    
+     6,424,103,333      instructions:u            #    1.61  insn per cycle         
+       2.629224079 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1749) (512y:   73) (512z: 5663)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 6.626675e-04
-Avg ME (F77/C++)    = 6.6266750603002878E-004
-Relative difference = 9.099629600570215e-09
+Avg ME (F77/C++)    = 6.6266750603003670E-004
+Relative difference = 9.099641544231038e-09
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-04-18_19:55:45
+DATE: 2022-03-03_00:40:13
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe -p 1 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.853307e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.854020e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.854239e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.850344e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.850939e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.851233e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.780709 sec
-     1,133,113,564      cycles:u                  #    0.572 GHz                    
-     2,376,935,410      instructions:u            #    2.10  insn per cycle         
-       2.196039508 seconds time elapsed
+TOTAL       :     1.519137 sec
+     1,240,540,962      cycles:u                  #    0.875 GHz                    
+     2,538,404,158      instructions:u            #    2.05  insn per cycle         
+       1.773924836 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.222977e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.223400e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.223442e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.218943e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.219420e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.219458e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856249e-04 +- 8.329951e-05 )  GeV^-6
-TOTAL       :     3.242303 sec
-     2,570,996,452      cycles:u                  #    0.719 GHz                    
-     5,559,457,864      instructions:u            #    2.16  insn per cycle         
-       3.634161411 seconds time elapsed
+TOTAL       :     2.923202 sec
+     2,623,210,949      cycles:u                  #    0.879 GHz                    
+     5,669,746,807      instructions:u            #    2.16  insn per cycle         
+       2.987413652 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.219187e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.219697e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.219697e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.016970e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.017442e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.017442e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     3.770181 sec
-    10,046,408,436      cycles:u                  #    2.662 GHz                    
-    28,668,619,367      instructions:u            #    2.85  insn per cycle         
-       3.777322489 seconds time elapsed
+TOTAL       :     3.890593 sec
+    10,337,069,750      cycles:u                  #    2.658 GHz                    
+    28,670,989,343      instructions:u            #    2.77  insn per cycle         
+       3.962849544 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631421586209E-003
-Relative difference = 1.4399800904805474e-08
+Avg ME (F77/C++)    = 9.8722631420503186E-003
+Relative difference = 1.4388830547142576e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.297431e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.297594e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.297594e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.303340e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.303514e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.303514e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     2.098824 sec
-     5,588,204,882      cycles:u                  #    2.658 GHz                    
-    15,094,629,930      instructions:u            #    2.70  insn per cycle         
-       2.105857822 seconds time elapsed
+TOTAL       :     2.092670 sec
+     5,564,868,671      cycles:u                  #    2.654 GHz                    
+    15,096,999,560      instructions:u            #    2.71  insn per cycle         
+       2.163061036 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:66501) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631421586174E-003
-Relative difference = 1.4399800553371668e-08
+Avg ME (F77/C++)    = 9.8722631420503186E-003
+Relative difference = 1.4388830547142576e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.591119e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.591768e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.591768e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.582720e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.583393e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.583393e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.052200 sec
-     2,386,079,529      cycles:u                  #    2.258 GHz                    
-     5,270,047,457      instructions:u            #    2.21  insn per cycle         
-       1.059604488 seconds time elapsed
+TOTAL       :     1.059318 sec
+     2,395,389,422      cycles:u                  #    2.251 GHz                    
+     5,272,417,521      instructions:u            #    2.20  insn per cycle         
+       1.167034390 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:57213) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631421502022E-003
-Relative difference = 1.4398948150677173e-08
+Avg ME (F77/C++)    = 9.8722631420503186E-003
+Relative difference = 1.4388830547142576e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.817419e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.818152e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.818152e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.845911e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.846735e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.846735e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.967927 sec
-     2,193,739,256      cycles:u                  #    2.257 GHz                    
-     4,829,891,796      instructions:u            #    2.20  insn per cycle         
-       0.974725215 seconds time elapsed
+TOTAL       :     0.961917 sec
+     2,174,781,832      cycles:u                  #    2.250 GHz                    
+     4,832,261,415      instructions:u            #    2.22  insn per cycle         
+       1.140115499 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:57716) (512y:   51) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631421502022E-003
-Relative difference = 1.4398948150677173e-08
+Avg ME (F77/C++)    = 9.8722631420503186E-003
+Relative difference = 1.4388830547142576e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -212,23 +212,25 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.948108e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.948924e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.948924e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.944918e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.945733e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.945733e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.925672 sec
-     1,453,357,087      cycles:u                  #    1.563 GHz                    
-     2,413,449,281      instructions:u            #    1.66  insn per cycle         
-       0.932617743 seconds time elapsed
+TOTAL       :     0.930126 sec
+     1,457,417,419      cycles:u                  #    1.559 GHz                    
+     2,415,819,335      instructions:u            #    1.66  insn per cycle         
+       1.003260116 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6172) (512y:   49) (512z:52234)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631421502022E-003
-Relative difference = 1.4398948150677173e-08
+Avg ME (F77/C++)    = 9.8722631420503186E-003
+Relative difference = 1.4388830547142576e-08
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
@@ -68,37 +68,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-03-03_00:40:13
+DATE: 2022-04-18_19:55:45
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe -p 1 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.850344e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.850939e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.851233e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.853307e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.854020e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.854239e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.519137 sec
-     1,240,540,962      cycles:u                  #    0.875 GHz                    
-     2,538,404,158      instructions:u            #    2.05  insn per cycle         
-       1.773924836 seconds time elapsed
+TOTAL       :     1.780709 sec
+     1,133,113,564      cycles:u                  #    0.572 GHz                    
+     2,376,935,410      instructions:u            #    2.10  insn per cycle         
+       2.196039508 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.112 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodeCIPC=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.218943e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.219420e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.219458e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.222977e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.223400e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.223442e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856249e-04 +- 8.329951e-05 )  GeV^-6
-TOTAL       :     2.923202 sec
-     2,623,210,949      cycles:u                  #    0.879 GHz                    
-     5,669,746,807      instructions:u            #    2.16  insn per cycle         
-       2.987413652 seconds time elapsed
+TOTAL       :     3.242303 sec
+     2,570,996,452      cycles:u                  #    0.719 GHz                    
+     5,559,457,864      instructions:u            #    2.16  insn per cycle         
+       3.634161411 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,24 +112,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.016970e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.017442e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.017442e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.219187e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.219697e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.219697e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     3.890593 sec
-    10,337,069,750      cycles:u                  #    2.658 GHz                    
-    28,670,989,343      instructions:u            #    2.77  insn per cycle         
-       3.962849544 seconds time elapsed
+TOTAL       :     3.770181 sec
+    10,046,408,436      cycles:u                  #    2.662 GHz                    
+    28,668,619,367      instructions:u            #    2.85  insn per cycle         
+       3.777322489 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631420503186E-003
-Relative difference = 1.4388830547142576e-08
+Avg ME (F77/C++)    = 9.8722631421586209E-003
+Relative difference = 1.4399800904805474e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -137,24 +137,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.303340e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.303514e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.303514e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.297431e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.297594e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.297594e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     2.092670 sec
-     5,564,868,671      cycles:u                  #    2.654 GHz                    
-    15,096,999,560      instructions:u            #    2.71  insn per cycle         
-       2.163061036 seconds time elapsed
+TOTAL       :     2.098824 sec
+     5,588,204,882      cycles:u                  #    2.658 GHz                    
+    15,094,629,930      instructions:u            #    2.70  insn per cycle         
+       2.105857822 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:66501) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631420503186E-003
-Relative difference = 1.4388830547142576e-08
+Avg ME (F77/C++)    = 9.8722631421586174E-003
+Relative difference = 1.4399800553371668e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -162,24 +162,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.582720e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.583393e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.583393e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.591119e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.591768e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.591768e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.059318 sec
-     2,395,389,422      cycles:u                  #    2.251 GHz                    
-     5,272,417,521      instructions:u            #    2.20  insn per cycle         
-       1.167034390 seconds time elapsed
+TOTAL       :     1.052200 sec
+     2,386,079,529      cycles:u                  #    2.258 GHz                    
+     5,270,047,457      instructions:u            #    2.21  insn per cycle         
+       1.059604488 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:57213) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631420503186E-003
-Relative difference = 1.4388830547142576e-08
+Avg ME (F77/C++)    = 9.8722631421502022E-003
+Relative difference = 1.4398948150677173e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -187,24 +187,24 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.845911e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.846735e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.846735e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.817419e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.818152e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.818152e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.961917 sec
-     2,174,781,832      cycles:u                  #    2.250 GHz                    
-     4,832,261,415      instructions:u            #    2.22  insn per cycle         
-       1.140115499 seconds time elapsed
+TOTAL       :     0.967927 sec
+     2,193,739,256      cycles:u                  #    2.257 GHz                    
+     4,829,891,796      instructions:u            #    2.20  insn per cycle         
+       0.974725215 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:57716) (512y:   51) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631420503186E-003
-Relative difference = 1.4388830547142576e-08
+Avg ME (F77/C++)    = 9.8722631421502022E-003
+Relative difference = 1.4398948150677173e-08
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/check.exe -p 1 256 1 OMP=
@@ -212,25 +212,23 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.944918e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.945733e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.945733e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.948108e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.948924e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.948924e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.930126 sec
-     1,457,417,419      cycles:u                  #    1.559 GHz                    
-     2,415,819,335      instructions:u            #    1.66  insn per cycle         
-       1.003260116 seconds time elapsed
+TOTAL       :     0.925672 sec
+     1,453,357,087      cycles:u                  #    1.563 GHz                    
+     2,413,449,281      instructions:u            #    1.66  insn per cycle         
+       0.932617743 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6172) (512y:   49) (512z:52234)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/check.exe --common -p 2 64 2
-cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/fgcheck.exe 2 64 2
+cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/fcheck.exe 2 64 2
 Avg ME (C++/C++)    = 9.872263e-03
-Avg ME (F77/C++)    = 9.8722631420503186E-003
-Relative difference = 1.4388830547142576e-08
+Avg ME (F77/C++)    = 9.8722631421502022E-003
+Relative difference = 1.4398948150677173e-08
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED


### PR DESCRIPTION
Hi @roiser, this extends and replaces your #411 about fixing unsigned int warnings for xcode. The main differences are:
- it fixes a few build errors
- it fixes a few build warnings
- it backports the changes to code generation
- it regenerates all five main processes auto and manual eemumu and ggtt(g*)