### PR TITLE
WIP fix to prevent the cudacpp plugin from modifying the global environment (issue #341)

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -16,13 +16,14 @@ logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.model_handling')
 #------------------------------------------------------------------------------------
 
 # AV - modify export_cpp.get_mg5_info_lines (replace '# ' by '//')
-import madgraph.iolibs.export_cpp as export_cpp
+###import madgraph.iolibs.export_cpp as export_cpp
+import madgraph.iolibs.export_cpp as export_cudacpp # workaround for #341
 
 def PLUGIN_get_mg5_info_lines():
     return DEFAULT_get_mg5_info_lines().replace('# ','//')
 
-DEFAULT_get_mg5_info_lines = export_cpp.get_mg5_info_lines
-export_cpp.get_mg5_info_lines = PLUGIN_get_mg5_info_lines
+DEFAULT_get_mg5_info_lines = export_cudacpp.get_mg5_info_lines
+export_cudacpp.get_mg5_info_lines = PLUGIN_get_mg5_info_lines
 
 #------------------------------------------------------------------------------------
 
@@ -586,7 +587,7 @@ class PLUGIN_ALOHAWriter(aloha_writers.ALOHAWriterForGPU):
 
 #------------------------------------------------------------------------------------
 
-class PLUGIN_UFOModelConverter(export_cpp.UFOModelConverterGPU):
+class PLUGIN_UFOModelConverter(export_cudacpp.UFOModelConverterGPU):
     # Class structure information
     #  - object
     #  - UFOModelConverterCPP(object) [in madgraph/iolibs/export_cpp.py]
@@ -717,7 +718,7 @@ class PLUGIN_UFOModelConverter(export_cpp.UFOModelConverterGPU):
     def super_generate_parameters_class_files(self):
         """Create the content of the Parameters_model.h and .cc files"""
         replace_dict = self.default_replace_dict
-        replace_dict['info_lines'] = export_cpp.get_mg5_info_lines()
+        replace_dict['info_lines'] = export_cudacpp.get_mg5_info_lines()
         replace_dict['model_name'] = self.model_name
         replace_dict['independent_parameters'] = \
                                    "// Model parameters independent of aS\n" + \
@@ -819,7 +820,7 @@ class PLUGIN_UFOModelConverter(export_cpp.UFOModelConverterGPU):
                                      'HelAmps_%s.%s' % (self.model_name, self.cc_ext))
         replace_dict = {}
         replace_dict['output_name'] = self.output_name
-        replace_dict['info_lines'] = export_cpp.get_mg5_info_lines()
+        replace_dict['info_lines'] = export_cudacpp.get_mg5_info_lines()
         replace_dict['namespace'] = self.namespace
         replace_dict['model_name'] = self.model_name
         # Read in the template .h and .cc files, stripped of compiler commands and namespaces
@@ -863,7 +864,7 @@ class PLUGIN_UFOModelConverter(export_cpp.UFOModelConverterGPU):
 import madgraph.iolibs.files as files
 import madgraph.various.misc as misc
 
-class PLUGIN_OneProcessExporter(export_cpp.OneProcessExporterGPU):
+class PLUGIN_OneProcessExporter(export_cudacpp.OneProcessExporterGPU):
     # Class structure information
     #  - object
     #  - OneProcessExporterCPP(object) [in madgraph/iolibs/export_cpp.py]
@@ -909,7 +910,7 @@ class PLUGIN_OneProcessExporter(export_cpp.OneProcessExporterGPU):
     # AV - replace export_cpp.OneProcessExporterGPU method (fix gCPPProcess.cu)
     def get_process_function_definitions(self, write=True):
         """The complete class definition for the process"""
-        replace_dict = super(export_cpp.OneProcessExporterGPU,self).get_process_function_definitions(write=False) # defines replace_dict['initProc_lines']
+        replace_dict = super(export_cudacpp.OneProcessExporterGPU,self).get_process_function_definitions(write=False) # defines replace_dict['initProc_lines']
         replace_dict['hardcoded_initProc_lines'] = replace_dict['initProc_lines'].replace( 'm_pars->', 'Parameters_%s::' % self.model_name )
         replace_dict['ncouplings'] = len(self.couplings2order)
         replace_dict['ncouplingstimes2'] = 2 * replace_dict['ncouplings']
@@ -1058,7 +1059,7 @@ class PLUGIN_OneProcessExporter(export_cpp.OneProcessExporterGPU):
         if self.matrix_elements[0].get('has_mirror_process'):
             self.matrix_elements[0].set('has_mirror_process', False)
             self.nprocesses/=2
-        super(export_cpp.OneProcessExporterGPU, self).generate_process_files()
+        super(export_cudacpp.OneProcessExporterGPU, self).generate_process_files()
         self.edit_CMakeLists()
         self.edit_check_sa()
         self.edit_mgonGPU()
@@ -1142,7 +1143,7 @@ class PLUGIN_OneProcessExporter(export_cpp.OneProcessExporterGPU):
     # AV - replace the export_cpp.OneProcessExporterGPU method (replace HelAmps.cu by HelAmps.cc)
     def super_write_process_cc_file(self, writer):
         """Write the class member definition (.cc) file for the process described by matrix_element"""
-        replace_dict = super(export_cpp.OneProcessExporterGPU, self).write_process_cc_file(False)
+        replace_dict = super(export_cudacpp.OneProcessExporterGPU, self).write_process_cc_file(False)
         ###replace_dict['hel_amps_def'] = "\n#include \"../../src/HelAmps_%s.cu\"" % self.model_name
         replace_dict['hel_amps_h'] = "#include \"HelAmps_%s.h\"" % self.model_name # AV
         if writer:

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -1241,7 +1241,7 @@ class PLUGIN_OneProcessExporter(export_cudacpp.OneProcessExporterGPU):
 import madgraph.core.helas_objects as helas_objects
 import madgraph.iolibs.helas_call_writers as helas_call_writers
 
-# AV - define a custom HelasCallWriter
+# AV - define a custom HelasCallWriter (NB: enable it via PLUGIN_ProcessExporter.aloha_exporter in output.py - this fixes #341)
 class PLUGIN_GPUFOHelasCallWriter(helas_call_writers.GPUFOHelasCallWriter):
     """ A Custom HelasCallWriter """
     # Class structure information
@@ -1606,9 +1606,5 @@ class PLUGIN_GPUFOHelasCallWriter(helas_call_writers.GPUFOHelasCallWriter):
             self.add_wavefunction(argument.get_call_key(), call_function)
         else:
             self.add_amplitude(argument.get_call_key(), call_function)
-
-# AV - use the custom HelasCallWriter
-DEFAULT_GPUFOHelasCallWriter = helas_call_writers.GPUFOHelasCallWriter
-helas_call_writers.GPUFOHelasCallWriter = PLUGIN_GPUFOHelasCallWriter
 
 #------------------------------------------------------------------------------------

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.model_handling')
 
 ###import madgraph.iolibs.export_cpp as export_cpp # first copy
 ######import madgraph.iolibs.export_cpp as export_cudacpp # this is not enough to define a second copy: id(export_cpp)==id(export_cudacpp)
-import madgraph.iolibs.export_cudacpp as export_cudacpp # second copy loaded in the plugin's output.py
+import PLUGIN.CUDACPP_SA_OUTPUT.export_cudacpp as export_cudacpp # second copy loaded in the plugin's output.py
 ###print('id(export_cpp)=%s'%id(export_cpp))
 ###print('id(export_cudacpp)=%s'%id(export_cudacpp))
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -68,29 +68,6 @@ export_cudacpp.writers.CPPWriter = PLUGIN_FileWriter # WITHOUT FORMATTING
 import aloha
 import aloha.aloha_writers as aloha_writers
 
-# AV - replace aloha_writers.Declaration_list.is_used (disable caching to be on the safe side)
-# (NB class Declaration_list(set) is a set of (type, name) pairs!)
-def PLUGIN_Declaration_list_is_used(self, var):
-    ###if hasattr(self, 'var_name'): return var in self.var_name # AV why was this needed? disable caching to be on the safe side
-    self.var_name = [name for type,name in self]
-    return var in self.var_name
-
-DEFAULT_Declaration_list_is_used = aloha_writers.Declaration_list.is_used
-aloha_writers.Declaration_list.is_used = PLUGIN_Declaration_list_is_used
-
-#------------------------------------------------------------------------------------
-
-# AV - decorate aloha_writers.Declaration_list.add (add optional debug printout)
-def PLUGIN_Declaration_list_add(self, obj):
-    #print( 'ADDING ', obj) # FOR DEBUGGING
-    #assert( obj[1] != 'P3' ) # FOR DEBUGGING (check MG5_debug to see where OM3, TMP3, P3 etc were added)
-    return DEFAULT_Declaration_list_add(self, obj)
-
-DEFAULT_Declaration_list_add = aloha_writers.Declaration_list.add
-aloha_writers.Declaration_list.add = PLUGIN_Declaration_list_add
-
-#------------------------------------------------------------------------------------
-
 class PLUGIN_ALOHAWriter(aloha_writers.ALOHAWriterForGPU):
     # Class structure information
     #  - object

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -37,7 +37,7 @@ import importlib.util
 SPEC_WRITERS = importlib.util.find_spec('madgraph.iolibs.file_writers')
 writers = importlib.util.module_from_spec(SPEC_WRITERS)
 SPEC_WRITERS.loader.exec_module(writers)
-###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.writers'] = writers # allow other files to simply import PLUGIN.CUDACPP_SA_OUTPUT.writers (not needed)
+###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.writers'] = writers # may now simply import PLUGIN.CUDACPP_SA_OUTPUT.writers (not needed)
 del SPEC_WRITERS
 
 DEFAULT_writers = export_cudacpp.writers
@@ -66,7 +66,19 @@ export_cudacpp.writers.CPPWriter = PLUGIN_FileWriter # WITHOUT FORMATTING
 #------------------------------------------------------------------------------------
 
 import aloha
-import aloha.aloha_writers as aloha_writers
+
+# AV - load a second copy of the writers module and use that within the export_cudacpp module
+###import aloha.aloha_writers as aloha_writers # first copy
+SPEC_ALOHAWRITERS = importlib.util.find_spec('aloha.aloha_writers')
+aloha_writers = importlib.util.module_from_spec(SPEC_ALOHAWRITERS)
+SPEC_ALOHAWRITERS.loader.exec_module(aloha_writers)
+###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.aloha_writers'] = aloha_writers # may now simply import PLUGIN.CUDACPP_SA_OUTPUT.aloha_writers (not needed)
+del SPEC_ALOHAWRITERS
+
+DEFAULT_aloha_writers = export_cudacpp.aloha_writers
+export_cudacpp.aloha_writers = aloha_writers
+
+#------------------------------------------------------------------------------------
 
 # AV - replace aloha_writers.Declaration_list.is_used (disable caching to be on the safe side)
 # (NB class Declaration_list(set) is a set of (type, name) pairs!)
@@ -75,8 +87,8 @@ def PLUGIN_Declaration_list_is_used(self, var):
     self.var_name = [name for type,name in self]
     return var in self.var_name
 
-DEFAULT_Declaration_list_is_used = aloha_writers.Declaration_list.is_used
-aloha_writers.Declaration_list.is_used = PLUGIN_Declaration_list_is_used
+DEFAULT_Declaration_list_is_used = export_cudacpp.aloha_writers.Declaration_list.is_used
+export_cudacpp.aloha_writers.Declaration_list.is_used = PLUGIN_Declaration_list_is_used
 
 #------------------------------------------------------------------------------------
 
@@ -86,8 +98,8 @@ def PLUGIN_Declaration_list_add(self, obj):
     #assert( obj[1] != 'P3' ) # FOR DEBUGGING (check MG5_debug to see where OM3, TMP3, P3 etc were added)
     return DEFAULT_Declaration_list_add(self, obj)
 
-DEFAULT_Declaration_list_add = aloha_writers.Declaration_list.add
-aloha_writers.Declaration_list.add = PLUGIN_Declaration_list_add
+DEFAULT_Declaration_list_add = export_cudacpp.aloha_writers.Declaration_list.add
+export_cudacpp.aloha_writers.Declaration_list.add = PLUGIN_Declaration_list_add
 
 #------------------------------------------------------------------------------------
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -15,10 +15,13 @@ logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.model_handling')
 
 #------------------------------------------------------------------------------------
 
-# AV - modify export_cpp.get_mg5_info_lines (replace '# ' by '//')
-###import madgraph.iolibs.export_cpp as export_cpp
-import madgraph.iolibs.export_cpp as export_cudacpp # workaround for #341
+###import madgraph.iolibs.export_cpp as export_cpp # first copy
+######import madgraph.iolibs.export_cpp as export_cudacpp # this is not enough to define a second copy: id(export_cpp)==id(export_cudacpp)
+import madgraph.iolibs.export_cudacpp as export_cudacpp # second copy loaded in the plugin's output.py
+###print('id(export_cpp)=%s'%id(export_cpp))
+###print('id(export_cudacpp)=%s'%id(export_cudacpp))
 
+# AV - modify export_cpp.get_mg5_info_lines (replace '# ' by '//')
 def PLUGIN_get_mg5_info_lines():
     return DEFAULT_get_mg5_info_lines().replace('# ','//')
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -37,7 +37,7 @@ import importlib.util
 SPEC_WRITERS = importlib.util.find_spec('madgraph.iolibs.file_writers')
 writers = importlib.util.module_from_spec(SPEC_WRITERS)
 SPEC_WRITERS.loader.exec_module(writers)
-###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.writers'] = writers # may now simply import PLUGIN.CUDACPP_SA_OUTPUT.writers (not needed)
+###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.writers'] = writers # allow other files to simply import PLUGIN.CUDACPP_SA_OUTPUT.writers (not needed)
 del SPEC_WRITERS
 
 DEFAULT_writers = export_cudacpp.writers
@@ -66,19 +66,7 @@ export_cudacpp.writers.CPPWriter = PLUGIN_FileWriter # WITHOUT FORMATTING
 #------------------------------------------------------------------------------------
 
 import aloha
-
-# AV - load a second copy of the writers module and use that within the export_cudacpp module
-###import aloha.aloha_writers as aloha_writers # first copy
-SPEC_ALOHAWRITERS = importlib.util.find_spec('aloha.aloha_writers')
-aloha_writers = importlib.util.module_from_spec(SPEC_ALOHAWRITERS)
-SPEC_ALOHAWRITERS.loader.exec_module(aloha_writers)
-###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.aloha_writers'] = aloha_writers # may now simply import PLUGIN.CUDACPP_SA_OUTPUT.aloha_writers (not needed)
-del SPEC_ALOHAWRITERS
-
-DEFAULT_aloha_writers = export_cudacpp.aloha_writers
-export_cudacpp.aloha_writers = aloha_writers
-
-#------------------------------------------------------------------------------------
+import aloha.aloha_writers as aloha_writers
 
 # AV - replace aloha_writers.Declaration_list.is_used (disable caching to be on the safe side)
 # (NB class Declaration_list(set) is a set of (type, name) pairs!)
@@ -87,8 +75,8 @@ def PLUGIN_Declaration_list_is_used(self, var):
     self.var_name = [name for type,name in self]
     return var in self.var_name
 
-DEFAULT_Declaration_list_is_used = export_cudacpp.aloha_writers.Declaration_list.is_used
-export_cudacpp.aloha_writers.Declaration_list.is_used = PLUGIN_Declaration_list_is_used
+DEFAULT_Declaration_list_is_used = aloha_writers.Declaration_list.is_used
+aloha_writers.Declaration_list.is_used = PLUGIN_Declaration_list_is_used
 
 #------------------------------------------------------------------------------------
 
@@ -98,8 +86,8 @@ def PLUGIN_Declaration_list_add(self, obj):
     #assert( obj[1] != 'P3' ) # FOR DEBUGGING (check MG5_debug to see where OM3, TMP3, P3 etc were added)
     return DEFAULT_Declaration_list_add(self, obj)
 
-DEFAULT_Declaration_list_add = export_cudacpp.aloha_writers.Declaration_list.add
-export_cudacpp.aloha_writers.Declaration_list.add = PLUGIN_Declaration_list_add
+DEFAULT_Declaration_list_add = aloha_writers.Declaration_list.add
+aloha_writers.Declaration_list.add = PLUGIN_Declaration_list_add
 
 #------------------------------------------------------------------------------------
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -1,8 +1,19 @@
 import os
 pjoin = os.path.join
 
-###import madgraph.iolibs.export_cpp as export_cpp
-import madgraph.iolibs.export_cpp as export_cudacpp # workaround for #341
+# AV - workaround for #341, load a separate copy of the export_cpp module as export_cudacpp
+# See https://stackoverflow.com/a/11285504
+import madgraph.iolibs.export_cpp as export_cpp # first copy
+###import madgraph.iolibs.export_cpp as export_cudacpp # this is not enough to define a second copy: id(export_cpp)==id(export_cudacpp)
+import sys
+import importlib.util
+SPEC_EXPORTCPP = importlib.util.find_spec('madgraph.iolibs.export_cpp')
+export_cudacpp = importlib.util.module_from_spec(SPEC_EXPORTCPP)
+SPEC_EXPORTCPP.loader.exec_module(export_cudacpp)
+sys.modules['madgraph.iolibs.export_cudacpp'] = export_cudacpp # allow model_handling to simply import madgraph.iolibs.export_cudacpp
+del SPEC_EXPORTCPP
+print('id(export_cpp)=%s'%id(export_cpp))
+print('id(export_cudacpp)=%s'%id(export_cudacpp))
 
 # AV - use template files from PLUGINDIR instead of MG5DIR
 ###from madgraph import MG5DIR

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -10,7 +10,7 @@ import importlib.util
 SPEC_EXPORTCPP = importlib.util.find_spec('madgraph.iolibs.export_cpp')
 export_cudacpp = importlib.util.module_from_spec(SPEC_EXPORTCPP)
 SPEC_EXPORTCPP.loader.exec_module(export_cudacpp)
-sys.modules['madgraph.iolibs.export_cudacpp'] = export_cudacpp # allow model_handling to simply import madgraph.iolibs.export_cudacpp
+sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.export_cudacpp'] = export_cudacpp # allow model_handling to simply import PLUGIN.CUDACPP_SA_OUTPUT.export_cudacpp
 del SPEC_EXPORTCPP
 ###print('id(export_cpp)=%s'%id(export_cpp))
 ###print('id(export_cudacpp)=%s'%id(export_cudacpp))

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -1,7 +1,8 @@
 import os
 pjoin = os.path.join
 
-import madgraph.iolibs.export_cpp as export_cpp
+###import madgraph.iolibs.export_cpp as export_cpp
+import madgraph.iolibs.export_cpp as export_cudacpp # workaround for #341
 
 # AV - use template files from PLUGINDIR instead of MG5DIR
 ###from madgraph import MG5DIR
@@ -19,7 +20,7 @@ import madgraph.various.misc as misc
 
 #------------------------------------------------------------------------------------
 
-class PLUGIN_ProcessExporter(export_cpp.ProcessExporterGPU):
+class PLUGIN_ProcessExporter(export_cudacpp.ProcessExporterGPU):
     # Class structure information
     #  - object
     #  - VirtualExporter(object) [in madgraph/iolibs/export_v4.py]
@@ -54,7 +55,7 @@ class PLUGIN_ProcessExporter(export_cpp.ProcessExporterGPU):
     exporter = 'gpu'
 
     # AV - use a custom OneProcessExporter
-    ###oneprocessclass = export_cpp.OneProcessExporterGPU # responsible for P directory
+    ###oneprocessclass = export_cudacpp.OneProcessExporterGPU # responsible for P directory
     oneprocessclass = model_handling.PLUGIN_OneProcessExporter
 
     # Information to find the template file that we want to include from madgraph
@@ -110,7 +111,7 @@ class PLUGIN_ProcessExporter(export_cpp.ProcessExporterGPU):
     template_Sub_make = pjoin(PLUGINDIR, 'madgraph', 'iolibs', 'template_files','gpu','Makefile')
 
     # AV - use a custom UFOModelConverter (model/aloha exporter)
-    ###create_model_class =  export_cpp.UFOModelConverterGPU
+    ###create_model_class =  export_cudacpp.UFOModelConverterGPU
     import PLUGIN.CUDACPP_SA_OUTPUT.model_handling as model_handling
     create_model_class = model_handling.PLUGIN_UFOModelConverter
 
@@ -139,7 +140,7 @@ class PLUGIN_ProcessExporter(export_cpp.ProcessExporterGPU):
             # Copy files in various subdirectories
             for key in self.from_template:
                 for f in self.from_template[key]:
-                    export_cpp.cp(f, key) # NB this assumes directory key exists...
+                    export_cudacpp.cp(f, key) # NB this assumes directory key exists...
             # Copy src Makefile
             if self.template_src_make:
                 makefile = self.read_template_file(self.template_src_make) % {'model': self.get_model_name(model.get('name'))}

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -130,6 +130,7 @@ class PLUGIN_ProcessExporter(export_cudacpp.ProcessExporterGPU):
     # (OM: "typically not defined but useful for this tutorial - the class for writing helas routine")
     ###aloha_exporter = None
     ###aloha_exporter = model_handling.PLUGIN_UFOHelasCallWriter
+    aloha_exporter = model_handling.PLUGIN_GPUFOHelasCallWriter # this is one of the main fixes for issue #341!
 
     # AV (default from OM's tutorial) - add a debug printout
     def __init__(self, *args, **kwargs):

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -14,30 +14,8 @@ import PLUGIN.CUDACPP_SA_OUTPUT.model_handling as model_handling
 import logging
 logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.output')
 
-#------------------------------------------------------------------------------------
-
-# AV - modify misc.make_unique (remove a printout)
+# AV - used for various printouts
 import madgraph.various.misc as misc
-
-printordering = True
-def PLUGIN_make_unique(input, keepordering=None):
-    "remove duplicate in a list "
-    global printordering
-    if keepordering is None:
-        keepordering = misc.madgraph.ordering
-        if printordering:
-            printordering = False
-            misc.sprint('keepordering (default): %s'%keepordering) # AV - add a printout only in the first call
-    else:
-        misc.sprint('keepordering (argument): %s'%keepordering) # AV - add a printout at every call only if it is an argument
-    ###sprint(keepordering) # AV - remove the printout at every call
-    if not keepordering:
-        return list(set(input))
-    else:
-        return list(dict.fromkeys(input))
-
-DEFAULT_make_unique = misc.make_unique
-misc.make_unique = PLUGIN_make_unique
 
 #------------------------------------------------------------------------------------
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -19,25 +19,6 @@ import madgraph.various.misc as misc
 
 #------------------------------------------------------------------------------------
 
-# AV - modify madgraph.iolibs.files.cp (preserve symlinks)
-def PLUGIN_cp(path1, path2, log=True, error=False):
-    """ simple cp taking linux or mix entry"""
-    from madgraph.iolibs.files import format_path
-    path1 = format_path(path1)
-    path2 = format_path(path2)
-    try:
-        import shutil
-        ###shutil.copy(path1, path2)
-        shutil.copy(path1, path2, follow_symlinks=False) # AV
-    except:
-        from madgraph.iolibs.files import cp
-        cp(path1, path2, log=log, error=error)
-
-DEFAULT_cp = export_cpp.cp
-export_cpp.cp = PLUGIN_cp
-
-#------------------------------------------------------------------------------------
-
 class PLUGIN_ProcessExporter(export_cpp.ProcessExporterGPU):
     # Class structure information
     #  - object

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/output.py
@@ -3,8 +3,8 @@ pjoin = os.path.join
 
 # AV - workaround for #341, load a separate copy of the export_cpp module as export_cudacpp
 # See https://stackoverflow.com/a/11285504
-import madgraph.iolibs.export_cpp as export_cpp # first copy
-###import madgraph.iolibs.export_cpp as export_cudacpp # this is not enough to define a second copy: id(export_cpp)==id(export_cudacpp)
+###import madgraph.iolibs.export_cpp as export_cpp # first copy
+######import madgraph.iolibs.export_cpp as export_cudacpp # this is not enough to define a second copy: id(export_cpp)==id(export_cudacpp)
 import sys
 import importlib.util
 SPEC_EXPORTCPP = importlib.util.find_spec('madgraph.iolibs.export_cpp')
@@ -12,8 +12,8 @@ export_cudacpp = importlib.util.module_from_spec(SPEC_EXPORTCPP)
 SPEC_EXPORTCPP.loader.exec_module(export_cudacpp)
 sys.modules['madgraph.iolibs.export_cudacpp'] = export_cudacpp # allow model_handling to simply import madgraph.iolibs.export_cudacpp
 del SPEC_EXPORTCPP
-print('id(export_cpp)=%s'%id(export_cpp))
-print('id(export_cudacpp)=%s'%id(export_cudacpp))
+###print('id(export_cpp)=%s'%id(export_cpp))
+###print('id(export_cudacpp)=%s'%id(export_cudacpp))
 
 # AV - use template files from PLUGINDIR instead of MG5DIR
 ###from madgraph import MG5DIR

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -379,8 +379,8 @@ fi
 if [ "${SCRBCK}" == "cudacpp" ]; then
   if [ "${OUTBCK}" == "madcpp" ]; then
     echo -e "\nWARNING! 'madcpp' mode selected: do not copy the cudacpp plugin (workaround for #341)"
-  elif [ "${OUTBCK}" == "madgpu" ]; then
-    echo -e "\nWARNING! 'madgpu' mode selected: do not copy the cudacpp plugin (workaround for #341)"
+  #elif [ "${OUTBCK}" == "madgpu" ]; then
+  #  echo -e "\nWARNING! 'madgpu' mode selected: do not copy the cudacpp plugin (workaround for #341)"
   else # CURRENTLY FAILS WITH #341 FOR MADCPP AND MADGPU
     echo -e "\nINFO! '${OUTBCK}' mode selected: copy the cudacpp plugin\n"
     cp -dpr ${SCRDIR}/PLUGIN/${SCRBCK^^}_SA_OUTPUT ${MG5AMC_HOME}/PLUGIN/


### PR DESCRIPTION
This is a WIP fix for #341 

It includes several types of modifications
- some function redefinitions have been removed (they seem to be not really necessary?)
- as suggested by @oliviermattelaer, the modified HelasCallWriter is now set via the aloha_exporter hook (this seems to be the main change required to remove the bug for standalone_gpu, however now the standalone_cudacpp code is badly formatted: this is WIP, I still need to fix this)
- for some modules, like export_cpp, a second "deep copy" is made (actually this is not really a deep copy, it is a second loading of the module, as in https://stackoverflow.com/a/11285504)

Still some issues to sort out, but this issue seems possible to solve