### PR TITLE
Additional fixes for EFT gg->h in clang

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/rambo.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -788,12 +788,14 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
             dcoupcompute = [ '    %ss_sv = couplings_sv.%s;'%( name, name ) for name in self.coups_dep ]
             replace_dict['dcoupcompute'] = '\n'.join( dcoupcompute )
             # Special handling in EFT for fptype=float using SIMD
-            dcoupoutdcoup2 = [ '      fptype& %sr = cxreal( out.%s )[i];\n      fptype& %si = cximag( out.%s )[i];'%(name,name,name,name) for name in self.coups_dep ]
-            replace_dict['dcoupoutdcoup2'] = '\n' + '\n'.join( dcoupoutdcoup2 )
+            dcoupoutfptypev2 = [ '    fptype_v %sr_v;\n    fptype_v %si_v;'%(name,name) for name in self.coups_dep ]
+            replace_dict['dcoupoutfptypev2'] = '\n' + '\n'.join( dcoupoutfptypev2 )
             replace_dict['dcoupsetdpar2'] = replace_dict['dcoupsetdpar'].replace('fptype_sv','fptype')
             dcoupsetdcoup2 = [ '    ' + line.replace('constexpr cxsmpl<double> ','const cxtype ').replace('mdl_complexi', 'cI') for line in self.write_hardcoded_parameters(list(self.coups_dep.values())).split('\n') if line != '' ]
-            dcoupsetdcoup2 += [ '      %sr = cxreal( %s );\n      %si = cximag( %s );'%(name,name,name,name) for name in self.coups_dep ]
+            dcoupsetdcoup2 += [ '      %sr_v[i] = cxreal( %s );\n      %si_v[i] = cximag( %s );'%(name,name,name,name) for name in self.coups_dep ]
             replace_dict['dcoupsetdcoup2'] = '  ' + '\n'.join( dcoupsetdcoup2 )
+            dcoupoutdcoup2 = [ '    out.%s = cxtype_v( %sr_v, %si_v );'%(name,name,name) for name in self.coups_dep ]
+            replace_dict['dcoupoutdcoup2'] = '\n' + '\n'.join( dcoupoutdcoup2 )
         else:
             replace_dict['idcoup'] = '  // NB: there are no aS-dependent couplings in this physics process'
             replace_dict['dcoupdecl'] = '    // (none)'
@@ -803,9 +805,10 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
             replace_dict['dcoupkernelaccess'] = ''
             replace_dict['dcoupcompute'] = '    // NB: there are no aS-dependent couplings in this physics process'
             # Special handling in EFT for fptype=float using SIMD
-            replace_dict['dcoupoutdcoup2'] = ''
+            replace_dict['dcoupfptypev2'] = ''
             replace_dict['dcoupsetdpar2'] = '      // (none)'
             replace_dict['dcoupsetdcoup2'] = '      // (none)'
+            replace_dict['dcoupoutdcoup2'] = ''
         # Require HRDCOD=1 in EFT and special handling in EFT for fptype=float using SIMD
         if self.model_name == 'sm' :
             replace_dict['efterror'] = ''
@@ -818,15 +821,15 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
             replace_dict['eftspecial2'] = """#else
     // ** NB #439: special handling is necessary ONLY FOR VECTORS OF FLOATS (variable Gs are vector floats, fixed parameters are scalar doubles)
     // Use an explicit loop to avoid <<error: conversion of scalar ‘double’ to vector ‘fptype_sv’ {aka ‘__vector(8) float’} involves truncation>>
-    // Problems may come e.g. in EFTs from multiplying a vector float (related to aS-dependent G) by a scalar double (aS-independent parameters)
+    // Problems may come e.g. in EFTs from multiplying a vector float (related to aS-dependent G) by a scalar double (aS-independent parameters)%(dcoupoutfptypev2)s
     for( int i = 0; i < neppV; i++ )
     {
-      const fptype& G = G_sv[i];%(dcoupoutdcoup2)s
+      const fptype& G = G_sv[i];
       // Model parameters dependent on aS
 %(dcoupsetdpar2)s
       // Model couplings dependent on aS
 %(dcoupsetdcoup2)s
-    }
+    }%(dcoupoutdcoup2)s
 #endif""" % replace_dict
             replace_dict['eftspecial2'] += '\n    // End non-SM (e.g. EFT) implementation - special handling of vectors of floats (#439)'
         file_h = self.read_template_file(self.param_template_h) % replace_dict

--- a/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006923198699951172 [0m
+[1;32mDEBUG: model prefixing  takes 0.006922483444213867 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -80,20 +80,20 @@ INFO: Processing color information for process: e+ e- > mu+ mu- @1
 [1;32mDEBUG:    type(subproc_group)=<class 'madgraph.core.helas_objects.HelasMatrixElement'> [1;30m[output.py at line 171][0m [0m
 [1;32mDEBUG:    type(fortran_model)=<class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_GPUFOHelasCallWriter'> [1;30m[output.py at line 172][0m [0m
 INFO: Creating files in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/./CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/./CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.004 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
@@ -101,7 +101,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 4 routines in  0.323 s
+ALOHA: aloha creates 4 routines in  0.320 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -127,6 +127,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mu
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m1.073s
-user	0m0.928s
-sys	0m0.122s
+real	0m1.145s
+user	0m0.923s
+sys	0m0.117s

--- a/epochX/cudacpp/ee_mumu.auto/src/rambo.h
+++ b/epochX/cudacpp/ee_mumu.auto/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006918430328369141 [0m
+[1;32mDEBUG: model prefixing  takes 0.006900787353515625 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -83,22 +83,22 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f76a18eeeb0> [1;30m[export_v4.py at line 5955][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f2fa6c46eb0> [1;30m[export_v4.py at line 5955][0m [0m
 INFO: Creating files in directory . 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
 [1;32mDEBUG:  proc_id = [0m 1 [1;30m[export_cpp.py at line 710][0m [0m
 [1;32mDEBUG:  config_map = [0m [1, 2] [1;30m[export_cpp.py at line 711][0m [0m
 [1;32mDEBUG:  subproc_number = [0m 0 [1;30m[export_cpp.py at line 712][0m [0m
@@ -108,7 +108,7 @@ INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 [1;32mDEBUG:  done [1;30m[madgraph_interface.py at line 8458][0m [0m
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.104 s
+Wrote files for 8 helas calls in 0.103 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
@@ -126,7 +126,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.307 s
+ALOHA: aloha creates 7 routines in  0.305 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -160,6 +160,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.581s
-user	0m2.240s
-sys	0m0.326s
+real	0m2.607s
+user	0m2.255s
+sys	0m0.316s

--- a/epochX/cudacpp/ee_mumu.mad/src/rambo.h
+++ b/epochX/cudacpp/ee_mumu.mad/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/ee_mumu/src/rambo.h
+++ b/epochX/cudacpp/ee_mumu/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006888389587402344 [0m
+[1;32mDEBUG: model prefixing  takes 0.006866931915283203 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
 INFO: Process has 3 diagrams 
-1 processes with 3 diagrams generated in 0.011 s
+1 processes with 3 diagrams generated in 0.010 s
 Total: 1 processes with 3 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_tt
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -81,30 +81,30 @@ INFO: Processing color information for process: g g > t t~ @1
 [1;32mDEBUG:    type(subproc_group)=<class 'madgraph.core.helas_objects.HelasMatrixElement'> [1;30m[output.py at line 171][0m [0m
 [1;32mDEBUG:    type(fortran_model)=<class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_GPUFOHelasCallWriter'> [1;30m[output.py at line 172][0m [0m
 INFO: Creating files in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/./CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/./CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1598][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1601][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.007 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.162 s
+ALOHA: aloha creates 2 routines in  0.164 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -122,6 +122,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m0.927s
-user	0m0.782s
-sys	0m0.126s
+real	0m0.917s
+user	0m0.769s
+sys	0m0.125s

--- a/epochX/cudacpp/gg_tt.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_tt.auto/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006908893585205078 [0m
+[1;32mDEBUG: model prefixing  takes 0.006837368011474609 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
 INFO: Process has 3 diagrams 
-1 processes with 3 diagrams generated in 0.011 s
+1 processes with 3 diagrams generated in 0.010 s
 Total: 1 processes with 3 diagrams
 output madevent CODEGEN_mad_gg_tt --hel_recycling=False --vector_size=16 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -86,26 +86,26 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fb5aceb3bb0> [1;30m[export_v4.py at line 5955][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fea4ccf77f0> [1;30m[export_v4.py at line 5955][0m [0m
 INFO: Creating files in directory . 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1598][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1601][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
 [1;32mDEBUG:  proc_id = [0m 1 [1;30m[export_cpp.py at line 710][0m [0m
 [1;32mDEBUG:  config_map = [0m [1, 2, 3] [1;30m[export_cpp.py at line 711][0m [0m
 [1;32mDEBUG:  subproc_number = [0m 0 [1;30m[export_cpp.py at line 712][0m [0m
@@ -114,11 +114,11 @@ INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 [1;32mDEBUG:  done [1;30m[madgraph_interface.py at line 8458][0m [0m
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.251 s
+Wrote files for 10 helas calls in 0.185 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.173 s
+ALOHA: aloha creates 2 routines in  0.175 s
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
@@ -127,7 +127,7 @@ ALOHA: aloha creates 2 routines in  0.173 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.159 s
+ALOHA: aloha creates 4 routines in  0.161 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -153,6 +153,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m6.585s
-user	0m2.060s
-sys	0m0.383s
+real	0m5.674s
+user	0m2.072s
+sys	0m0.360s

--- a/epochX/cudacpp/gg_tt.mad/src/rambo.h
+++ b/epochX/cudacpp/gg_tt.mad/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_tt.madonly/CODEGEN_madonly_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.madonly/CODEGEN_madonly_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006837368011474609 [0m
+[1;32mDEBUG: model prefixing  takes 0.0069408416748046875 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -80,11 +80,11 @@ INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 [1;32mDEBUG:  done [1;30m[madgraph_interface.py at line 8458][0m [0m
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.096 s
+Wrote files for 10 helas calls in 0.095 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.173 s
+ALOHA: aloha creates 2 routines in  0.175 s
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
@@ -100,6 +100,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.060s
-user	0m1.750s
-sys	0m0.295s
+real	0m2.109s
+user	0m1.743s
+sys	0m0.320s

--- a/epochX/cudacpp/gg_tt/src/rambo.h
+++ b/epochX/cudacpp/gg_tt/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006908416748046875 [0m
+[1;32mDEBUG: model prefixing  takes 0.006944894790649414 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -81,26 +81,26 @@ INFO: Processing color information for process: g g > t t~ g @1
 [1;32mDEBUG:    type(subproc_group)=<class 'madgraph.core.helas_objects.HelasMatrixElement'> [1;30m[output.py at line 171][0m [0m
 [1;32mDEBUG:    type(fortran_model)=<class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_GPUFOHelasCallWriter'> [1;30m[output.py at line 172][0m [0m
 INFO: Creating files in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/./CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/./CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1598][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1601][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
 Generated helas calls for 1 subprocesses (16 diagrams) in 0.049 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
@@ -109,7 +109,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.392 s
+ALOHA: aloha creates 5 routines in  0.387 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -137,6 +137,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m1.247s
-user	0m1.111s
-sys	0m0.115s
+real	0m1.240s
+user	0m1.096s
+sys	0m0.121s

--- a/epochX/cudacpp/gg_ttg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttg.auto/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttg/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006899595260620117 [0m
+[1;32mDEBUG: model prefixing  takes 0.006865262985229492 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.209 s
+1 processes with 123 diagrams generated in 0.211 s
 Total: 1 processes with 123 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttgg
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -81,29 +81,29 @@ INFO: Processing color information for process: g g > t t~ g g @1
 [1;32mDEBUG:    type(subproc_group)=<class 'madgraph.core.helas_objects.HelasMatrixElement'> [1;30m[output.py at line 171][0m [0m
 [1;32mDEBUG:    type(fortran_model)=<class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_GPUFOHelasCallWriter'> [1;30m[output.py at line 172][0m [0m
 INFO: Creating files in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/./CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/./CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 5, 1, 5, 5) [1;30m[model_handling.py at line 1598][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 5, 1, 5, 5) [1;30m[model_handling.py at line 1601][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.580 s
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.575 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -111,7 +111,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.390 s
+ALOHA: aloha creates 5 routines in  0.386 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -145,6 +145,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m2.156s
-user	0m2.006s
-sys	0m0.126s
+real	0m2.138s
+user	0m1.993s
+sys	0m0.124s

--- a/epochX/cudacpp/gg_ttgg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttgg.auto/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttgg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttgg/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006893634796142578 [0m
+[1;32mDEBUG: model prefixing  takes 0.006845951080322266 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.478 s
+1 processes with 1240 diagrams generated in 2.460 s
 Total: 1 processes with 1240 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttggg
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -81,31 +81,31 @@ INFO: Processing color information for process: g g > t t~ g g g @1
 [1;32mDEBUG:    type(subproc_group)=<class 'madgraph.core.helas_objects.HelasMatrixElement'> [1;30m[output.py at line 171][0m [0m
 [1;32mDEBUG:    type(fortran_model)=<class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_GPUFOHelasCallWriter'> [1;30m[output.py at line 172][0m [0m
 INFO: Creating files in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1162][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/./CPPProcess.h
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1265][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_h_file [1;30m[model_handling.py at line 1268][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/./CPPProcess.cc
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1287][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 5, 1, 5, 5) [1;30m[model_handling.py at line 1598][0m [0m
-[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1597][0m [0m
-[1;32mDEBUG:  ('ZERO', 6, 1, 6, 6) [1;30m[model_handling.py at line 1598][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.write_process_cc_file [1;30m[model_handling.py at line 1290][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 0, -1, 0, 0) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 1, -1, 1, 1) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 4, 1, 4, 4) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 5, 1, 5, 5) [1;30m[model_handling.py at line 1601][0m [0m
+[1;32mDEBUG:  call = [0m vxxxxx( momenta,m_pars->%s, cHel[ihel][%d],%+d, w_sv[%d], %d ); [1;30m[model_handling.py at line 1600][0m [0m
+[1;32mDEBUG:  ('ZERO', 6, 1, 6, 6) [1;30m[model_handling.py at line 1601][0m [0m
 [1;32mDEBUG: only one Matrix-element supported? [0m
 INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/. 
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1186][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1195][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1212][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1219][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1231][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1242][0m [0m
-[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1253][0m [0m
-Generated helas calls for 1 subprocesses (1240 diagrams) in 8.946 s
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_CMakeLists [1;30m[model_handling.py at line 1189][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_check_sa [1;30m[model_handling.py at line 1198][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_mgonGPU [1;30m[model_handling.py at line 1215][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_processidfile [1;30m[model_handling.py at line 1222][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
+[1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.996 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -113,7 +113,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.383 s
+ALOHA: aloha creates 5 routines in  0.403 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -147,6 +147,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m17.353s
-user	0m17.140s
-sys	0m0.193s
+real	0m17.506s
+user	0m17.252s
+sys	0m0.205s

--- a/epochX/cudacpp/gg_ttggg.auto/src/rambo.h
+++ b/epochX/cudacpp/gg_ttggg.auto/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/gg_ttggg/src/rambo.h
+++ b/epochX/cudacpp/gg_ttggg/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/heft_gg_h/src/Parameters_heft.h
+++ b/epochX/cudacpp/heft_gg_h/src/Parameters_heft.h
@@ -245,11 +245,11 @@ namespace Parameters_heft_dependentCouplings
     // ** NB #439: special handling is necessary ONLY FOR VECTORS OF FLOATS (variable Gs are vector floats, fixed parameters are scalar doubles)
     // Use an explicit loop to avoid <<error: conversion of scalar ‘double’ to vector ‘fptype_sv’ {aka ‘__vector(8) float’} involves truncation>>
     // Problems may come e.g. in EFTs from multiplying a vector float (related to aS-dependent G) by a scalar double (aS-independent parameters)
+    fptype_v GC_13r_v;
+    fptype_v GC_13i_v;
     for( int i = 0; i < neppV; i++ )
     {
       const fptype& G = G_sv[i];
-      fptype& GC_13r = cxreal( out.GC_13 )[i];
-      fptype& GC_13i = cximag( out.GC_13 )[i];
       // Model parameters dependent on aS
       //const fptype mdl_sqrt__aS = constexpr_sqrt( aS );
       //const fptype G = 2. * mdl_sqrt__aS * constexpr_sqrt( M_PI );
@@ -258,9 +258,10 @@ namespace Parameters_heft_dependentCouplings
       const fptype mdl_Gphi = -( mdl_G__exp__2 * ( 1. + mdl_MH__exp__6 / ( 560. * mdl_MT__exp__6 ) + mdl_MH__exp__4 / ( 90. * mdl_MT__exp__4 ) + mdl_MH__exp__2 / ( 12. * mdl_MT__exp__2 ) ) ) / ( 8. * ( ( M_PI ) * ( M_PI ) ) * mdl_v );
       // Model couplings dependent on aS
       const cxtype GC_13 = -( cI * mdl_GH );
-      GC_13r = cxreal( GC_13 );
-      GC_13i = cximag( GC_13 );
+      GC_13r_v[i] = cxreal( GC_13 );
+      GC_13i_v[i] = cximag( GC_13 );
     }
+    out.GC_13 = cxtype_v( GC_13r_v, GC_13i_v );
 #endif
     // End non-SM (e.g. EFT) implementation - special handling of vectors of floats (#439)
     return out;

--- a/epochX/cudacpp/heft_gg_h/src/rambo.h
+++ b/epochX/cudacpp/heft_gg_h/src/rambo.h
@@ -104,7 +104,8 @@ namespace mg5amcCpu
     const fptype twopi = 8. * atan( 1. );
     const fptype po2log = log( twopi / 4. );
     fptype z[nparf];
-    z[1] = po2log;
+    if constexpr( nparf > 1 ) // avoid build warning on clang (related to #358)
+      z[1] = po2log;
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = z[kpar - 1] + po2log - 2. * log( fptype( kpar - 1 ) );
     for( int kpar = 2; kpar < nparf; kpar++ ) z[kpar] = ( z[kpar] - log( fptype( kpar ) ) );
 

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_17:54:53
+DATE: 2022-05-10_21:28:49
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.551172e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.628685e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.110200e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.724060e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.820666e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.137231e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.873947 sec
-       450,512,798      cycles:u                  #    0.439 GHz                    
-       803,193,200      instructions:u            #    1.78  insn per cycle         
-       1.345437119 seconds time elapsed
+TOTAL       :     0.897611 sec
+       448,876,625      cycles:u                  #    0.440 GHz                    
+       796,460,256      instructions:u            #    1.77  insn per cycle         
+       1.398918888 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.079679e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.635045e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.635045e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.084095e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.643106e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.643106e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.298074 sec
-    16,681,917,926      cycles:u                  #    2.644 GHz                    
-    40,655,255,050      instructions:u            #    2.44  insn per cycle         
-       6.344427670 seconds time elapsed
+TOTAL       :     6.259095 sec
+    16,585,236,095      cycles:u                  #    2.646 GHz                    
+    40,655,246,702      instructions:u            #    2.45  insn per cycle         
+       6.320662333 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  281) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.539249e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.098491e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.098491e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.543923e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.096811e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.096811e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.548565 sec
-    12,004,946,047      cycles:u                  #    2.632 GHz                    
-    26,025,117,363      instructions:u            #    2.17  insn per cycle         
-       4.598083235 seconds time elapsed
+TOTAL       :     4.525696 sec
+    11,952,071,641      cycles:u                  #    2.635 GHz                    
+    26,025,111,701      instructions:u            #    2.18  insn per cycle         
+       4.652395849 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1277) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.010148e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.443883e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.443883e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.009896e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.411536e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.411536e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.592950 sec
-     9,007,250,924      cycles:u                  #    2.498 GHz                    
-    15,530,339,663      instructions:u            #    1.72  insn per cycle         
-       3.628933055 seconds time elapsed
+TOTAL       :     3.578021 sec
+     8,969,950,304      cycles:u                  #    2.500 GHz                    
+    15,530,333,200      instructions:u            #    1.73  insn per cycle         
+       3.768537901 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1019) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.076560e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.947327e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.947327e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.086054e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.944359e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.944359e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.497054 sec
-     8,772,538,944      cycles:u                  #    2.500 GHz                    
-    15,064,770,588      instructions:u            #    1.72  insn per cycle         
-       3.622082391 seconds time elapsed
+TOTAL       :     3.472085 sec
+     8,720,882,028      cycles:u                  #    2.505 GHz                    
+    15,064,763,069      instructions:u            #    1.73  insn per cycle         
+       3.549229027 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  954) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.857475e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.498927e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.498927e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.896616e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.623665e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.623665e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.857542 sec
-     8,548,204,675      cycles:u                  #    2.209 GHz                    
-    12,378,290,243      instructions:u            #    1.45  insn per cycle         
-       3.904135263 seconds time elapsed
+TOTAL       :     3.774543 sec
+     8,468,811,591      cycles:u                  #    2.238 GHz                    
+    12,378,282,096      instructions:u            #    1.46  insn per cycle         
+       3.853370653 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  193) (512y:    0) (512z:  760)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:43:45
+DATE: 2022-05-10_22:17:56
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -80,14 +80,14 @@ WARNING! Set grid in Bridge (nevt=524288, gpublocks=2048, gputhreads=256, gpublo
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.675251e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.898843e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.898843e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.672697e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.905653e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.905653e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.358983 sec
-     7,111,777,280      cycles:u                  #    1.967 GHz                    
-    11,595,510,622      instructions:u            #    1.63  insn per cycle         
-       3.673407145 seconds time elapsed
+TOTAL       :     3.363813 sec
+     7,112,708,298      cycles:u                  #    1.967 GHz                    
+    11,587,803,967      instructions:u            #    1.63  insn per cycle         
+       3.673942366 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -104,14 +104,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.054236e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.573569e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.573569e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.705245e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.395554e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.395554e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.702891 sec
-    17,538,989,076      cycles:u                  #    2.608 GHz                    
-    41,030,053,116      instructions:u            #    2.34  insn per cycle         
-       6.727535142 seconds time elapsed
+TOTAL       :     7.211652 sec
+    18,921,614,322      cycles:u                  #    2.616 GHz                    
+    41,030,053,869      instructions:u            #    2.17  insn per cycle         
+       7.235942537 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  281) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -130,14 +130,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.473941e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.831475e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.831475e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.470151e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.822795e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.822795e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.991715 sec
-    12,993,472,236      cycles:u                  #    2.592 GHz                    
-    26,858,669,341      instructions:u            #    2.07  insn per cycle         
-       5.016658791 seconds time elapsed
+TOTAL       :     4.998473 sec
+    12,995,052,737      cycles:u                  #    2.589 GHz                    
+    26,858,669,666      instructions:u            #    2.07  insn per cycle         
+       5.022995113 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1277) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -156,14 +156,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.892119e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.675420e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.675420e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.851993e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.661476e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.661476e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.053401 sec
-    10,045,903,819      cycles:u                  #    2.465 GHz                    
-    16,763,662,135      instructions:u            #    1.67  insn per cycle         
-       4.078103268 seconds time elapsed
+TOTAL       :     4.126390 sec
+    10,231,303,518      cycles:u                  #    2.466 GHz                    
+    16,763,661,855      instructions:u            #    1.64  insn per cycle         
+       4.151479187 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1019) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -182,14 +182,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.965325e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.074421e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.074421e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.956433e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.063219e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.063219e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.927463 sec
-     9,768,162,290      cycles:u                  #    2.473 GHz                    
-    16,298,092,264      instructions:u            #    1.67  insn per cycle         
-       3.952240110 seconds time elapsed
+TOTAL       :     3.956953 sec
+     9,820,715,534      cycles:u                  #    2.468 GHz                    
+    16,298,092,491      instructions:u            #    1.66  insn per cycle         
+       3.981475647 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  954) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -208,14 +208,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.779984e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.001192e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.001192e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.783569e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.031032e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.031032e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.266049 sec
-     9,586,749,139      cycles:u                  #    2.236 GHz                    
-    13,514,944,639      instructions:u            #    1.41  insn per cycle         
-       4.290762297 seconds time elapsed
+TOTAL       :     4.259521 sec
+     9,578,637,180      cycles:u                  #    2.238 GHz                    
+    13,514,944,579      instructions:u            #    1.41  insn per cycle         
+       4.284404021 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  193) (512y:    0) (512z:  760)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:53:11
+DATE: 2022-05-10_22:27:26
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.761201e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.800387e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.063897e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.764804e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.789031e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.067110e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     1.618586 sec
-     2,201,482,584      cycles:u                  #    1.188 GHz                    
-     3,679,780,592      instructions:u            #    1.67  insn per cycle         
-       1.912012031 seconds time elapsed
+TOTAL       :     1.618015 sec
+     2,207,858,511      cycles:u                  #    1.191 GHz                    
+     3,683,988,341      instructions:u            #    1.67  insn per cycle         
+       1.912281313 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.093641e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.664800e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.664800e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.086270e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.648412e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.648412e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     6.771748 sec
-    17,417,909,126      cycles:u                  #    2.568 GHz                    
-    40,817,137,860      instructions:u            #    2.34  insn per cycle         
-       6.786439388 seconds time elapsed
+TOTAL       :     6.810412 sec
+    17,509,923,474      cycles:u                  #    2.567 GHz                    
+    40,817,137,912      instructions:u            #    2.33  insn per cycle         
+       6.824958556 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  281) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.546948e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.115698e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.115698e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.540118e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.092812e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.092812e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     5.070282 sec
-    12,878,972,042      cycles:u                  #    2.534 GHz                    
-    26,086,335,741      instructions:u            #    2.03  insn per cycle         
-       5.085009955 seconds time elapsed
+TOTAL       :     5.093159 sec
+    12,907,393,177      cycles:u                  #    2.529 GHz                    
+    26,086,335,929      instructions:u            #    2.02  insn per cycle         
+       5.107879737 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1277) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.985241e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.454727e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.454727e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.001736e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.407791e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.407791e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     4.168350 sec
-    10,024,133,719      cycles:u                  #    2.398 GHz                    
-    15,541,207,892      instructions:u            #    1.55  insn per cycle         
-       4.182843020 seconds time elapsed
+TOTAL       :     4.144882 sec
+     9,939,006,813      cycles:u                  #    2.391 GHz                    
+    15,541,208,263      instructions:u            #    1.56  insn per cycle         
+       4.159431029 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1019) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.073719e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.938158e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.938158e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.068954e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.930468e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.930468e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     4.041928 sec
-     9,725,047,431      cycles:u                  #    2.399 GHz                    
-    14,823,979,502      instructions:u            #    1.52  insn per cycle         
-       4.057865784 seconds time elapsed
+TOTAL       :     4.054250 sec
+     9,740,206,348      cycles:u                  #    2.395 GHz                    
+    14,823,980,042      instructions:u            #    1.52  insn per cycle         
+       4.068962754 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  954) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.888003e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.594075e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.594075e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.886384e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.581320e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.581320e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371879e-02 +- 3.270020e-06 )  GeV^0
-TOTAL       :     4.345517 sec
-     9,447,507,498      cycles:u                  #    2.169 GHz                    
-    12,137,498,065      instructions:u            #    1.28  insn per cycle         
-       4.360210710 seconds time elapsed
+TOTAL       :     4.346716 sec
+     9,444,724,617      cycles:u                  #    2.167 GHz                    
+    12,137,498,476      instructions:u            #    1.29  insn per cycle         
+       4.361436610 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  193) (512y:    0) (512z:  760)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:50:09
+DATE: 2022-05-10_22:24:22
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.804522e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.883273e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.069161e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.793775e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.884603e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.071941e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     1.082640 sec
-     1,275,265,860      cycles:u                  #    0.968 GHz                    
-     3,511,537,884      instructions:u            #    2.75  insn per cycle         
-       1.376266500 seconds time elapsed
+TOTAL       :     1.080855 sec
+     1,276,687,314      cycles:u                  #    0.970 GHz                    
+     3,516,084,956      instructions:u            #    2.75  insn per cycle         
+       1.375193742 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.093099e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.661828e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.661828e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.086947e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.649491e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.649491e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.228398 sec
-    16,482,807,204      cycles:u                  #    2.642 GHz                    
-    40,655,261,247      instructions:u            #    2.47  insn per cycle         
-       6.243126365 seconds time elapsed
+TOTAL       :     6.262114 sec
+    16,565,670,406      cycles:u                  #    2.641 GHz                    
+    40,655,261,333      instructions:u            #    2.45  insn per cycle         
+       6.276991058 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  281) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.548654e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.112284e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.112284e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.545372e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.099843e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.099843e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.525333 sec
-    11,942,835,875      cycles:u                  #    2.633 GHz                    
-    26,025,122,623      instructions:u            #    2.18  insn per cycle         
-       4.539827208 seconds time elapsed
+TOTAL       :     4.534450 sec
+    11,969,413,234      cycles:u                  #    2.633 GHz                    
+    26,025,122,528      instructions:u            #    2.17  insn per cycle         
+       4.549219036 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1277) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.009963e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.440749e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.440749e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.011587e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.456969e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.456969e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.595048 sec
-     8,991,994,404      cycles:u                  #    2.494 GHz                    
-    15,530,344,882      instructions:u            #    1.73  insn per cycle         
-       3.609817589 seconds time elapsed
+TOTAL       :     3.591072 sec
+     8,990,964,452      cycles:u                  #    2.495 GHz                    
+    15,530,344,867      instructions:u            #    1.73  insn per cycle         
+       3.606216446 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1019) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.086503e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.976461e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.976461e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.080152e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.944661e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.944661e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.482951 sec
-     8,746,925,789      cycles:u                  #    2.503 GHz                    
-    15,064,775,136      instructions:u            #    1.72  insn per cycle         
-       3.497349557 seconds time elapsed
+TOTAL       :     3.495710 sec
+     8,764,372,921      cycles:u                  #    2.499 GHz                    
+    15,064,774,916      instructions:u            #    1.72  insn per cycle         
+       3.511067653 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  954) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.895371e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.617153e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.617153e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.898273e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.648736e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.648736e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.789962 sec
-     8,489,035,280      cycles:u                  #    2.233 GHz                    
-    12,378,293,479      instructions:u            #    1.46  insn per cycle         
-       3.804710953 seconds time elapsed
+TOTAL       :     3.785148 sec
+     8,481,320,564      cycles:u                  #    2.234 GHz                    
+    12,378,293,326      instructions:u            #    1.46  insn per cycle         
+       3.799898844 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  193) (512y:    0) (512z:  760)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:47:00
+DATE: 2022-05-10_22:21:12
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.029323e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.679523e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.033250e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.035283e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.694884e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.042557e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     2.905646 sec
-     6,522,195,270      cycles:u                  #    2.212 GHz                    
-    10,783,075,528      instructions:u            #    1.65  insn per cycle         
-       3.200913244 seconds time elapsed
+TOTAL       :     3.019808 sec
+     6,510,400,866      cycles:u                  #    1.999 GHz                    
+    10,780,681,097      instructions:u            #    1.66  insn per cycle         
+       3.314747597 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -100,14 +100,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.091710e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.658960e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.658960e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.086663e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.647642e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.647642e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.235375 sec
-    16,505,406,182      cycles:u                  #    2.642 GHz                    
-    40,655,261,572      instructions:u            #    2.46  insn per cycle         
-       6.250111117 seconds time elapsed
+TOTAL       :     6.263520 sec
+    16,565,941,866      cycles:u                  #    2.640 GHz                    
+    40,655,261,640      instructions:u            #    2.45  insn per cycle         
+       6.278356518 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  281) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd0/runTest.exe
@@ -125,14 +125,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.546678e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.104466e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.104466e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.541416e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.096191e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.096191e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.531594 sec
-    11,959,282,213      cycles:u                  #    2.632 GHz                    
-    26,025,122,728      instructions:u            #    2.18  insn per cycle         
-       4.546303225 seconds time elapsed
+TOTAL       :     4.545094 sec
+    11,981,341,870      cycles:u                  #    2.630 GHz                    
+    26,025,122,516      instructions:u            #    2.17  insn per cycle         
+       4.559854744 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1277) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd0/runTest.exe
@@ -150,14 +150,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.014492e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.443655e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.443655e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.012410e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.437252e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.437252e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.585317 sec
-     8,972,252,366      cycles:u                  #    2.495 GHz                    
-    15,530,345,386      instructions:u            #    1.73  insn per cycle         
-       3.600162270 seconds time elapsed
+TOTAL       :     3.589887 sec
+     8,982,467,629      cycles:u                  #    2.494 GHz                    
+    15,530,344,933      instructions:u            #    1.73  insn per cycle         
+       3.605196168 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1019) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd0/runTest.exe
@@ -175,14 +175,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.083263e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.962548e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.962548e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.075858e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.901504e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.901504e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.489017 sec
-     8,753,813,131      cycles:u                  #    2.501 GHz                    
-    15,064,775,122      instructions:u            #    1.72  insn per cycle         
-       3.503826196 seconds time elapsed
+TOTAL       :     3.500223 sec
+     8,781,632,973      cycles:u                  #    2.500 GHz                    
+    15,064,775,322      instructions:u            #    1.72  insn per cycle         
+       3.515061772 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  954) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd0/runTest.exe
@@ -200,14 +200,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.893172e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.603508e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.603508e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.896306e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.685703e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.685703e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.793197 sec
-     8,496,532,782      cycles:u                  #    2.233 GHz                    
-    12,378,293,978      instructions:u            #    1.46  insn per cycle         
-       3.807828131 seconds time elapsed
+TOTAL       :     3.788611 sec
+     8,501,301,530      cycles:u                  #    2.237 GHz                    
+    12,378,294,042      instructions:u            #    1.46  insn per cycle         
+       3.804134608 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  193) (512y:    0) (512z:  760)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_17:55:32
+DATE: 2022-05-10_21:29:29
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.293123e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.225074e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.291807e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.199316e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.247839e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.302241e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.751773 sec
-       436,066,762      cycles:u                  #    0.440 GHz                    
-       775,071,189      instructions:u            #    1.78  insn per cycle         
-       1.177401651 seconds time elapsed
+TOTAL       :     0.746996 sec
+       433,406,472      cycles:u                  #    0.438 GHz                    
+       781,223,038      instructions:u            #    1.80  insn per cycle         
+       1.148518130 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 122
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.090491e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.659886e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.659886e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.090838e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.657128e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.657128e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     6.241817 sec
-    16,516,010,611      cycles:u                  #    2.641 GHz                    
-    40,629,329,001      instructions:u            #    2.46  insn per cycle         
-       6.300922024 seconds time elapsed
+TOTAL       :     6.228157 sec
+    16,491,846,761      cycles:u                  #    2.644 GHz                    
+    40,629,321,496      instructions:u            #    2.46  insn per cycle         
+       6.282000956 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  272) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl0_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.537555e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.084245e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.084245e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.538066e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.079205e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.079205e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     4.553654 sec
-    12,019,251,824      cycles:u                  #    2.633 GHz                    
-    25,999,191,348      instructions:u            #    2.16  insn per cycle         
-       4.693503654 seconds time elapsed
+TOTAL       :     4.540260 sec
+    11,992,633,217      cycles:u                  #    2.636 GHz                    
+    25,999,184,555      instructions:u            #    2.17  insn per cycle         
+       4.655282634 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1268) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl0_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.006850e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.462442e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.462442e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.995138e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.359406e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.359406e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.598946 sec
-     9,013,465,020      cycles:u                  #    2.496 GHz                    
-    15,504,413,912      instructions:u            #    1.72  insn per cycle         
-       3.653843881 seconds time elapsed
+TOTAL       :     3.603758 sec
+     8,945,762,889      cycles:u                  #    2.475 GHz                    
+    15,504,405,467      instructions:u            #    1.73  insn per cycle         
+       3.683459366 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  993) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl0_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.073555e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.905790e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.905790e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.074847e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.898612e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.898612e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.501043 sec
-     8,787,771,633      cycles:u                  #    2.501 GHz                    
-    15,051,426,711      instructions:u            #    1.71  insn per cycle         
-       3.635334458 seconds time elapsed
+TOTAL       :     3.489015 sec
+     8,763,385,647      cycles:u                  #    2.505 GHz                    
+    15,051,419,476      instructions:u            #    1.72  insn per cycle         
+       3.553353280 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  928) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl0_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.919037e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.812272e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.812272e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.920132e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.810013e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.810013e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.750182 sec
-     8,445,118,132      cycles:u                  #    2.244 GHz                    
-    12,280,011,552      instructions:u            #    1.45  insn per cycle         
-       3.837998537 seconds time elapsed
+TOTAL       :     3.738335 sec
+     8,413,389,397      cycles:u                  #    2.247 GHz                    
+    12,280,002,932      instructions:u            #    1.46  insn per cycle         
+       3.812003895 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  167) (512y:    0) (512z:  748)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:34:09
+DATE: 2022-05-10_22:08:15
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.463350e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.315864e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.080567e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.458479e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.309921e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.080214e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.799737 sec
-       455,058,786      cycles:u                  #    0.444 GHz                    
-       816,701,515      instructions:u            #    1.79  insn per cycle         
-       1.101565842 seconds time elapsed
+TOTAL       :     0.781105 sec
+       455,020,794      cycles:u                  #    0.444 GHz                    
+       802,452,655      instructions:u            #    1.76  insn per cycle         
+       1.083267464 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 156
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.898945e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.782175e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.782175e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.895949e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.775224e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.775224e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.798070 sec
-     9,983,988,178      cycles:u                  #    2.618 GHz                    
-    17,672,364,750      instructions:u            #    1.77  insn per cycle         
-       3.816157765 seconds time elapsed
+TOTAL       :     3.803320 sec
+     9,995,286,169      cycles:u                  #    2.618 GHz                    
+    17,672,364,521      instructions:u            #    1.77  insn per cycle         
+       3.822925397 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2407) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl1_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.132662e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.220825e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.220825e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.133350e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.233168e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.233168e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.424505 sec
-     8,986,522,473      cycles:u                  #    2.612 GHz                    
-    15,266,612,168      instructions:u            #    1.70  insn per cycle         
-       3.442707800 seconds time elapsed
+TOTAL       :     3.426783 sec
+     8,975,552,208      cycles:u                  #    2.608 GHz                    
+    15,266,612,292      instructions:u            #    1.70  insn per cycle         
+       3.445140685 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  416) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl1_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.445392e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.093186e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.093186e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.436924e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.087377e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.087377e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.048140 sec
-     7,758,929,170      cycles:u                  #    2.533 GHz                    
-    11,815,190,921      instructions:u            #    1.52  insn per cycle         
-       3.066623786 seconds time elapsed
+TOTAL       :     3.058634 sec
+     7,778,648,677      cycles:u                  #    2.530 GHz                    
+    11,815,191,192      instructions:u            #    1.52  insn per cycle         
+       3.076888013 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  413) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl1_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.442539e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.084576e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.084576e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.427170e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.083718e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.083718e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.055746 sec
-     7,779,331,924      cycles:u                  #    2.533 GHz                    
-    11,582,407,539      instructions:u            #    1.49  insn per cycle         
-       3.073722876 seconds time elapsed
+TOTAL       :     3.072638 sec
+     7,817,804,475      cycles:u                  #    2.532 GHz                    
+    11,582,407,204      instructions:u            #    1.48  insn per cycle         
+       3.090696443 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  368) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl1_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.301991e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.997689e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.997689e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.337424e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.995416e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.995416e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.214391 sec
-     7,672,187,491      cycles:u                  #    2.375 GHz                    
-    10,766,083,770      instructions:u            #    1.40  insn per cycle         
-       3.232576797 seconds time elapsed
+TOTAL       :     3.172889 sec
+     7,557,009,337      cycles:u                  #    2.370 GHz                    
+    10,766,083,754      instructions:u            #    1.42  insn per cycle         
+       3.191162568 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  164) (512y:    0) (512z:  269)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_d_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:34:38
+DATE: 2022-05-10_22:08:45
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.534673e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.953180e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.309914e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.547446e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.978376e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.311974e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     0.777803 sec
-       451,806,700      cycles:u                  #    0.446 GHz                    
-       800,300,227      instructions:u            #    1.77  insn per cycle         
-       1.077557012 seconds time elapsed
+TOTAL       :     0.777240 sec
+       452,006,940      cycles:u                  #    0.446 GHz                    
+       813,410,474      instructions:u            #    1.80  insn per cycle         
+       1.078570836 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 122
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.927270e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.964405e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.964405e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.916282e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.935584e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.935584e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.748142 sec
-     9,857,245,095      cycles:u                  #    2.619 GHz                    
-    17,385,267,195      instructions:u            #    1.76  insn per cycle         
-       3.766207395 seconds time elapsed
+TOTAL       :     3.767818 sec
+     9,899,912,736      cycles:u                  #    2.617 GHz                    
+    17,385,267,864      instructions:u            #    1.76  insn per cycle         
+       3.785984724 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_d_inl1_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.298028e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.544810e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.544810e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.310862e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.677775e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.677775e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.211811 sec
-     8,426,369,096      cycles:u                  #    2.611 GHz                    
-    13,535,681,822      instructions:u            #    1.61  insn per cycle         
-       3.230080849 seconds time elapsed
+TOTAL       :     3.196701 sec
+     8,383,264,536      cycles:u                  #    2.610 GHz                    
+    13,535,681,680      instructions:u            #    1.61  insn per cycle         
+       3.214737121 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  332) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_d_inl1_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.523502e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.293575e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.293575e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.484597e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.294119e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.294119e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     2.968581 sec
-     7,585,897,180      cycles:u                  #    2.542 GHz                    
-    11,223,024,301      instructions:u            #    1.48  insn per cycle         
-       2.987024775 seconds time elapsed
+TOTAL       :     3.007927 sec
+     7,678,008,121      cycles:u                  #    2.540 GHz                    
+    11,223,024,353      instructions:u            #    1.46  insn per cycle         
+       3.026502344 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  331) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_d_inl1_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.558709e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.349136e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.349136e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.555602e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.354014e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.354014e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     2.937604 sec
-     7,512,416,619      cycles:u                  #    2.544 GHz                    
-    11,125,509,884      instructions:u            #    1.48  insn per cycle         
-       2.955701754 seconds time elapsed
+TOTAL       :     2.941743 sec
+     7,516,286,111      cycles:u                  #    2.542 GHz                    
+    11,125,509,755      instructions:u            #    1.48  insn per cycle         
+       2.959886994 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  304) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_d_inl1_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.371248e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.658031e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.658031e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.376169e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.605669e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.605669e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270315e-06 )  GeV^0
-TOTAL       :     3.134582 sec
-     7,500,212,803      cycles:u                  #    2.382 GHz                    
-    10,669,375,210      instructions:u            #    1.42  insn per cycle         
-       3.152665152 seconds time elapsed
+TOTAL       :     3.129019 sec
+     7,484,153,203      cycles:u                  #    2.380 GHz                    
+    10,669,375,293      instructions:u            #    1.43  insn per cycle         
+       3.147062000 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  139) (512y:    0) (512z:  218)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_d_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_17:56:10
+DATE: 2022-05-10_21:30:06
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=2, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.252426e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.326615e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.041350e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.220556e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.337610e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.073206e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
-TOTAL       :     0.652250 sec
-       310,680,370      cycles:u                  #    0.353 GHz                    
-       677,209,444      instructions:u            #    2.18  insn per cycle         
-       1.155073745 seconds time elapsed
+TOTAL       :     0.639366 sec
+       307,899,046      cycles:u                  #    0.354 GHz                    
+       676,743,125      instructions:u            #    2.20  insn per cycle         
+       1.156880981 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.201961e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.737619e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.737619e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.203776e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.734133e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.734133e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
-TOTAL       :     5.646004 sec
-    15,010,456,008      cycles:u                  #    2.655 GHz                    
-    39,446,277,105      instructions:u            #    2.63  insn per cycle         
-       5.671334663 seconds time elapsed
+TOTAL       :     5.629107 sec
+    14,987,695,684      cycles:u                  #    2.660 GHz                    
+    39,446,270,520      instructions:u            #    2.63  insn per cycle         
+       5.682942885 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.348179e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.138203e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.138203e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.347337e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.109686e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.109686e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     3.078565 sec
-     8,156,076,067      cycles:u                  #    2.643 GHz                    
-    17,698,463,759      instructions:u            #    2.17  insn per cycle         
-       3.119469669 seconds time elapsed
+TOTAL       :     3.074674 sec
+     8,162,841,007      cycles:u                  #    2.650 GHz                    
+    17,698,456,835      instructions:u            #    2.17  insn per cycle         
+       3.179629453 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.862575e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.129096e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.129096e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.887602e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.128981e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.128981e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.601739 sec
-     6,657,176,698      cycles:u                  #    2.551 GHz                    
-    11,976,067,191      instructions:u            #    1.80  insn per cycle         
-       2.625473175 seconds time elapsed
+TOTAL       :     2.578809 sec
+     6,605,155,159      cycles:u                  #    2.554 GHz                    
+    11,976,061,602      instructions:u            #    1.81  insn per cycle         
+       2.656382769 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1093) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.933004e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.235720e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.235720e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.952875e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.233864e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.233864e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.547103 sec
-     6,533,689,588      cycles:u                  #    2.557 GHz                    
-    11,755,866,887      instructions:u            #    1.80  insn per cycle         
-       2.640871929 seconds time elapsed
+TOTAL       :     2.524604 sec
+     6,486,806,506      cycles:u                  #    2.563 GHz                    
+    11,755,860,273      instructions:u            #    1.81  insn per cycle         
+       2.576131407 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1029) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.793935e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.963019e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.963019e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.798310e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.033242e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.033242e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.655106 sec
-     6,329,978,371      cycles:u                  #    2.377 GHz                    
-    10,495,985,438      instructions:u            #    1.66  insn per cycle         
-       2.757861847 seconds time elapsed
+TOTAL       :     2.643092 sec
+     6,337,064,793      cycles:u                  #    2.392 GHz                    
+    10,495,978,990      instructions:u            #    1.66  insn per cycle         
+       2.880863664 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  287) (512y:    0) (512z:  774)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:44:25
+DATE: 2022-05-10_22:18:38
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -86,14 +86,14 @@ WARNING! flagging abnormal ME for ievt=247522
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.098233e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.423244e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.423244e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.102726e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.462296e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.462296e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371709e-02 +- 3.270378e-06 )  GeV^0
-TOTAL       :     1.942976 sec
-     3,664,230,172      cycles:u                  #    1.684 GHz                    
-     7,424,069,881      instructions:u            #    2.03  insn per cycle         
-       2.234180466 seconds time elapsed
+TOTAL       :     1.944185 sec
+     3,663,116,929      cycles:u                  #    1.682 GHz                    
+     7,425,631,996      instructions:u            #    2.03  insn per cycle         
+       2.235999743 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -116,14 +116,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.183116e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.693660e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.693660e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.181516e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.691092e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.691092e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
-TOTAL       :     5.859242 sec
-    15,508,001,839      cycles:u                  #    2.641 GHz                    
-    39,653,109,907      instructions:u            #    2.56  insn per cycle         
-       5.874777448 seconds time elapsed
+TOTAL       :     5.864344 sec
+    15,511,900,596      cycles:u                  #    2.639 GHz                    
+    39,653,109,805      instructions:u            #    2.56  insn per cycle         
+       5.880069003 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd0/runTest.exe
@@ -148,14 +148,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.250401e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.531841e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.531841e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.248797e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.525538e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.525538e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     3.345822 sec
-     8,787,493,122      cycles:u                  #    2.616 GHz                    
-    18,914,554,202      instructions:u            #    2.15  insn per cycle         
-       3.361881375 seconds time elapsed
+TOTAL       :     3.347754 sec
+     8,787,735,290      cycles:u                  #    2.615 GHz                    
+    18,914,554,018      instructions:u            #    2.15  insn per cycle         
+       3.363470589 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd0/runTest.exe
@@ -179,14 +179,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.714509e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.410752e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.410752e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.713838e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.396556e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.396556e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.872766 sec
-     7,298,148,240      cycles:u                  #    2.529 GHz                    
-    13,095,491,271      instructions:u            #    1.79  insn per cycle         
-       2.888730869 seconds time elapsed
+TOTAL       :     2.872673 sec
+     7,297,031,134      cycles:u                  #    2.529 GHz                    
+    13,095,491,049      instructions:u            #    1.79  insn per cycle         
+       2.888466690 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1093) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd0/runTest.exe
@@ -210,14 +210,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.778031e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.011068e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.011068e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.774031e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.012416e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.012416e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.817044 sec
-     7,170,636,872      cycles:u                  #    2.534 GHz                    
-    12,875,290,615      instructions:u            #    1.80  insn per cycle         
-       2.832593406 seconds time elapsed
+TOTAL       :     2.820025 sec
+     7,172,594,927      cycles:u                  #    2.532 GHz                    
+    12,875,291,136      instructions:u            #    1.80  insn per cycle         
+       2.835717203 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1029) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd0/runTest.exe
@@ -241,14 +241,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.634276e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.243476e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.243476e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.636691e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.265998e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.265998e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.940921 sec
-     6,997,798,503      cycles:u                  #    2.369 GHz                    
-    11,623,602,197      instructions:u            #    1.66  insn per cycle         
-       2.956638710 seconds time elapsed
+TOTAL       :     2.940586 sec
+     6,988,491,840      cycles:u                  #    2.367 GHz                    
+    11,623,602,049      instructions:u            #    1.66  insn per cycle         
+       2.956308644 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  287) (512y:    0) (512z:  774)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:53:50
+DATE: 2022-05-10_22:28:06
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.361254e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.393352e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.992257e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.366681e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.390037e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.014067e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371863e-02 +- 3.269951e-06 )  GeV^0
-TOTAL       :     1.459747 sec
-     1,970,815,802      cycles:u                  #    1.169 GHz                    
-     3,591,512,491      instructions:u            #    1.82  insn per cycle         
-       1.750260327 seconds time elapsed
+TOTAL       :     1.449280 sec
+     1,966,453,412      cycles:u                  #    1.173 GHz                    
+     3,590,188,463      instructions:u            #    1.83  insn per cycle         
+       1.734038245 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=3, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.204015e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.737747e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.737747e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.205260e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.739894e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.739894e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371887e-02 +- 3.270268e-06 )  GeV^0
-TOTAL       :     6.150758 sec
-    15,850,669,112      cycles:u                  #    2.574 GHz                    
-    39,649,119,924      instructions:u            #    2.50  insn per cycle         
-       6.161676799 seconds time elapsed
+TOTAL       :     6.151808 sec
+    15,837,531,269      cycles:u                  #    2.571 GHz                    
+    39,649,120,255      instructions:u            #    2.50  insn per cycle         
+       6.162610062 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=3, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.339496e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.142972e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.142972e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.339375e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.104701e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.104701e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371887e-02 +- 3.270268e-06 )  GeV^0
-TOTAL       :     3.606230 sec
-     9,028,440,628      cycles:u                  #    2.499 GHz                    
-    17,800,644,098      instructions:u            #    1.97  insn per cycle         
-       3.617378769 seconds time elapsed
+TOTAL       :     3.600556 sec
+     9,019,309,408      cycles:u                  #    2.500 GHz                    
+    17,800,644,001      instructions:u            #    1.97  insn per cycle         
+       3.611564843 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=3, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.842150e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.117917e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.117917e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.819892e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.119160e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.119160e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371884e-02 +- 3.270112e-06 )  GeV^0
-TOTAL       :     3.128084 sec
-     7,518,414,392      cycles:u                  #    2.397 GHz                    
-    11,958,709,784      instructions:u            #    1.59  insn per cycle         
-       3.139123692 seconds time elapsed
+TOTAL       :     3.140731 sec
+     7,553,651,285      cycles:u                  #    2.399 GHz                    
+    11,958,709,650      instructions:u            #    1.58  insn per cycle         
+       3.151656636 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1093) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=3, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.918437e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.227489e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.227489e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.910480e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.221507e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.221507e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371884e-02 +- 3.270112e-06 )  GeV^0
-TOTAL       :     3.068915 sec
-     7,395,451,094      cycles:u                  #    2.404 GHz                    
-    11,486,850,213      instructions:u            #    1.55  insn per cycle         
-       3.079581119 seconds time elapsed
+TOTAL       :     3.078295 sec
+     7,404,301,893      cycles:u                  #    2.399 GHz                    
+    11,486,850,454      instructions:u            #    1.55  insn per cycle         
+       3.088934839 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1029) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=3, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.781938e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.900553e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.900553e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.785016e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.916571e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.916571e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371884e-02 +- 3.270112e-06 )  GeV^0
-TOTAL       :     3.177550 sec
-     7,182,352,310      cycles:u                  #    2.255 GHz                    
-    10,226,969,831      instructions:u            #    1.42  insn per cycle         
-       3.188213777 seconds time elapsed
+TOTAL       :     3.176667 sec
+     7,178,112,993      cycles:u                  #    2.254 GHz                    
+    10,226,970,023      instructions:u            #    1.42  insn per cycle         
+       3.187594215 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  287) (512y:    0) (512z:  774)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:50:44
+DATE: 2022-05-10_22:24:57
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=2, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.369905e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.404024e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.042545e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.369813e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.411992e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.054129e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
-TOTAL       :     0.954880 sec
-     1,127,633,669      cycles:u                  #    0.952 GHz                    
-     3,382,115,743      instructions:u            #    3.00  insn per cycle         
-       1.242690980 seconds time elapsed
+TOTAL       :     0.955078 sec
+     1,126,251,855      cycles:u                  #    0.943 GHz                    
+     3,384,196,998      instructions:u            #    3.00  insn per cycle         
+       1.252694543 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.205856e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.739716e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.739716e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.205615e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.739787e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.739787e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
-TOTAL       :     5.630768 sec
-    14,979,010,977      cycles:u                  #    2.657 GHz                    
-    39,446,280,015      instructions:u            #    2.63  insn per cycle         
-       5.641634395 seconds time elapsed
+TOTAL       :     5.635553 sec
+    14,982,244,648      cycles:u                  #    2.655 GHz                    
+    39,446,279,961      instructions:u            #    2.63  insn per cycle         
+       5.646655663 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.351218e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.151465e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.151465e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.347240e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.125834e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.125834e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     3.078705 sec
-     8,146,641,388      cycles:u                  #    2.639 GHz                    
-    17,698,467,662      instructions:u            #    2.17  insn per cycle         
-       3.089707228 seconds time elapsed
+TOTAL       :     3.083940 sec
+     8,153,577,610      cycles:u                  #    2.638 GHz                    
+    17,698,467,420      instructions:u            #    2.17  insn per cycle         
+       3.095012792 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.841174e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.130691e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.130691e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.863987e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.130373e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.130373e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.621500 sec
-     6,711,209,724      cycles:u                  #    2.552 GHz                    
-    11,976,070,428      instructions:u            #    1.78  insn per cycle         
-       2.632531664 seconds time elapsed
+TOTAL       :     2.603509 sec
+     6,657,789,436      cycles:u                  #    2.549 GHz                    
+    11,976,070,755      instructions:u            #    1.80  insn per cycle         
+       2.614583685 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1093) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.914796e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.226853e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.226853e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.933952e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.236233e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.236233e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.564235 sec
-     6,568,036,901      cycles:u                  #    2.554 GHz                    
-    11,755,869,693      instructions:u            #    1.79  insn per cycle         
-       2.575153344 seconds time elapsed
+TOTAL       :     2.548063 sec
+     6,531,294,166      cycles:u                  #    2.555 GHz                    
+    11,755,869,564      instructions:u            #    1.80  insn per cycle         
+       2.558653407 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1029) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.804013e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.005133e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.005133e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.793869e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.908503e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.908503e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.649658 sec
-     6,318,122,091      cycles:u                  #    2.377 GHz                    
-    10,495,989,039      instructions:u            #    1.66  insn per cycle         
-       2.660587502 seconds time elapsed
+TOTAL       :     2.658055 sec
+     6,329,576,599      cycles:u                  #    2.374 GHz                    
+    10,495,988,833      instructions:u            #    1.66  insn per cycle         
+       2.668860773 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  287) (512y:    0) (512z:  774)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:47:37
+DATE: 2022-05-10_22:21:50
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.114848e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.344088e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.798769e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.120802e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.344055e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.804264e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371709e-02 +- 3.270378e-06 )  GeV^0
-TOTAL       :     1.776939 sec
-     3,339,931,292      cycles:u                  #    1.665 GHz                    
-     6,766,902,286      instructions:u            #    2.03  insn per cycle         
-       2.064427412 seconds time elapsed
+TOTAL       :     1.777365 sec
+     3,347,083,228      cycles:u                  #    1.659 GHz                    
+     6,769,796,003      instructions:u            #    2.02  insn per cycle         
+       2.075251446 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -100,14 +100,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.205469e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.740293e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.740293e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.205141e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.738626e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.738626e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
-TOTAL       :     5.631945 sec
-    14,983,325,165      cycles:u                  #    2.657 GHz                    
-    39,446,279,984      instructions:u            #    2.63  insn per cycle         
-       5.642787069 seconds time elapsed
+TOTAL       :     5.634644 sec
+    14,978,032,358      cycles:u                  #    2.655 GHz                    
+    39,446,280,229      instructions:u            #    2.63  insn per cycle         
+       5.645598307 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  257) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd0/runTest.exe
@@ -125,14 +125,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.325586e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.135331e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.135331e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.349420e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.129788e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.129788e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     3.108963 sec
-     8,230,965,897      cycles:u                  #    2.640 GHz                    
-    17,698,467,926      instructions:u            #    2.15  insn per cycle         
-       3.119823890 seconds time elapsed
+TOTAL       :     3.084797 sec
+     8,163,629,602      cycles:u                  #    2.640 GHz                    
+    17,698,467,458      instructions:u            #    2.17  insn per cycle         
+       3.095992648 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1356) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd0/runTest.exe
@@ -150,14 +150,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.847806e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.130942e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.130942e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.864022e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.127028e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.127028e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.616782 sec
-     6,695,965,413      cycles:u                  #    2.551 GHz                    
-    11,976,070,596      instructions:u            #    1.79  insn per cycle         
-       2.627745848 seconds time elapsed
+TOTAL       :     2.603201 sec
+     6,657,239,239      cycles:u                  #    2.549 GHz                    
+    11,976,070,942      instructions:u            #    1.80  insn per cycle         
+       2.613866893 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1093) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd0/runTest.exe
@@ -175,14 +175,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.923198e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.229304e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.229304e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.926434e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.234541e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.234541e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.556823 sec
-     6,551,358,975      cycles:u                  #    2.555 GHz                    
-    11,755,869,650      instructions:u            #    1.79  insn per cycle         
-       2.567560950 seconds time elapsed
+TOTAL       :     2.555202 sec
+     6,547,577,268      cycles:u                  #    2.555 GHz                    
+    11,755,869,668      instructions:u            #    1.80  insn per cycle         
+       2.565875561 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1029) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd0/runTest.exe
@@ -200,14 +200,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.788780e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.001564e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.001564e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.803675e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.002785e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.002785e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.662399 sec
-     6,349,101,458      cycles:u                  #    2.377 GHz                    
-    10,495,989,228      instructions:u            #    1.65  insn per cycle         
-       2.674340911 seconds time elapsed
+TOTAL       :     2.658611 sec
+     6,315,913,726      cycles:u                  #    2.369 GHz                    
+    10,495,989,131      instructions:u            #    1.66  insn per cycle         
+       2.669789467 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  287) (512y:    0) (512z:  774)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_17:56:42
+DATE: 2022-05-10_21:30:39
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=2, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.260380e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.330703e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.100733e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.235364e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.343174e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.113326e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
-TOTAL       :     0.640820 sec
-       306,609,042      cycles:u                  #    0.352 GHz                    
-       677,081,287      instructions:u            #    2.21  insn per cycle         
-       1.109176742 seconds time elapsed
+TOTAL       :     0.638050 sec
+       305,462,915      cycles:u                  #    0.352 GHz                    
+       678,155,539      instructions:u            #    2.22  insn per cycle         
+       1.063020813 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 56
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.206552e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.742275e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.742275e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.204836e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.736512e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.736512e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371707e-02 +- 3.270376e-06 )  GeV^0
-TOTAL       :     5.628100 sec
-    14,979,035,083      cycles:u                  #    2.658 GHz                    
-    39,370,016,031      instructions:u            #    2.63  insn per cycle         
-       5.668159112 seconds time elapsed
+TOTAL       :     5.623184 sec
+    14,972,897,092      cycles:u                  #    2.660 GHz                    
+    39,370,009,159      instructions:u            #    2.63  insn per cycle         
+       5.677927077 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  251) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl0_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.348256e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.140455e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.140455e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.348295e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.119301e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.119301e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     3.077256 sec
-     8,156,451,887      cycles:u                  #    2.644 GHz                    
-    17,650,516,064      instructions:u            #    2.16  insn per cycle         
-       3.137121047 seconds time elapsed
+TOTAL       :     3.074168 sec
+     8,148,878,163      cycles:u                  #    2.645 GHz                    
+    17,650,512,980      instructions:u            #    2.17  insn per cycle         
+       3.169775003 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1344) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl0_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.707409e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.129656e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.129656e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.890496e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.129434e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.129434e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.728525 sec
-     6,999,955,237      cycles:u                  #    2.557 GHz                    
-    11,962,721,224      instructions:u            #    1.71  insn per cycle         
-       2.773819417 seconds time elapsed
+TOTAL       :     2.571960 sec
+     6,595,212,636      cycles:u                  #    2.558 GHz                    
+    11,962,714,584      instructions:u            #    1.81  insn per cycle         
+       2.678825545 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1050) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl0_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.937514e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.239343e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.239343e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.947902e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.231716e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.231716e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.546204 sec
-     6,523,737,793      cycles:u                  #    2.554 GHz                    
-    11,742,520,789      instructions:u            #    1.80  insn per cycle         
-       2.630041208 seconds time elapsed
+TOTAL       :     2.528080 sec
+     6,492,095,132      cycles:u                  #    2.562 GHz                    
+    11,742,515,137      instructions:u            #    1.81  insn per cycle         
+       2.570117700 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  985) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl0_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.816535e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.025492e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.025492e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.848878e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.065021e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.065021e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.634059 sec
-     6,297,752,345      cycles:u                  #    2.383 GHz                    
-    10,419,725,559      instructions:u            #    1.65  insn per cycle         
-       2.673080771 seconds time elapsed
+TOTAL       :     2.601500 sec
+     6,240,747,170      cycles:u                  #    2.394 GHz                    
+    10,419,719,290      instructions:u            #    1.67  insn per cycle         
+       2.703196040 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  235) (512y:    0) (512z:  751)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:35:08
+DATE: 2022-05-10_22:09:14
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=2, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.092187e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.225444e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.065891e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.095120e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.235428e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.076222e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
-TOTAL       :     0.659419 sec
-       319,647,973      cycles:u                  #    0.359 GHz                    
-       689,965,015      instructions:u            #    2.16  insn per cycle         
-       0.948444781 seconds time elapsed
+TOTAL       :     0.660133 sec
+       323,488,348      cycles:u                  #    0.363 GHz                    
+       693,059,637      instructions:u            #    2.14  insn per cycle         
+       0.948668815 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 64
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.942394e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.199940e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.199940e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.936428e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.197606e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.197606e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     2.558257 sec
-     6,757,888,701      cycles:u                  #    2.631 GHz                    
-    12,814,324,700      instructions:u            #    1.90  insn per cycle         
-       2.570735752 seconds time elapsed
+TOTAL       :     2.563790 sec
+     6,767,038,089      cycles:u                  #    2.629 GHz                    
+    12,814,324,785      instructions:u            #    1.89  insn per cycle         
+       2.576821008 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  757) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl1_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.019610e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.517804e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.517804e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.987108e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.518697e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.518697e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     2.495050 sec
-     6,583,259,252      cycles:u                  #    2.629 GHz                    
-    12,363,246,820      instructions:u            #    1.88  insn per cycle         
-       2.507326731 seconds time elapsed
+TOTAL       :     2.520295 sec
+     6,646,888,996      cycles:u                  #    2.627 GHz                    
+    12,363,246,880      instructions:u            #    1.86  insn per cycle         
+       2.533266506 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  497) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl1_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.323430e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.574085e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.574085e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.331446e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.588690e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.588690e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.307271 sec
-     5,983,324,738      cycles:u                  #    2.582 GHz                    
-     9,969,063,809      instructions:u            #    1.67  insn per cycle         
-       2.319657636 seconds time elapsed
+TOTAL       :     2.301925 sec
+     5,971,187,158      cycles:u                  #    2.583 GHz                    
+     9,969,063,779      instructions:u            #    1.67  insn per cycle         
+       2.314345502 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  502) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl1_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.342732e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.673457e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.673457e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.329152e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.596909e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.596909e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.294239 sec
-     5,960,759,078      cycles:u                  #    2.587 GHz                    
-     9,895,140,799      instructions:u            #    1.66  insn per cycle         
-       2.307383870 seconds time elapsed
+TOTAL       :     2.304688 sec
+     5,969,585,290      cycles:u                  #    2.580 GHz                    
+     9,895,140,661      instructions:u            #    1.66  insn per cycle         
+       2.317567581 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  463) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl1_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.181585e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.820824e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.820824e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.187557e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.836532e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.836532e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.389113 sec
-     5,921,838,596      cycles:u                  #    2.469 GHz                    
-     9,693,811,915      instructions:u            #    1.64  insn per cycle         
-       2.401610303 seconds time elapsed
+TOTAL       :     2.384697 sec
+     5,909,451,090      cycles:u                  #    2.468 GHz                    
+     9,693,811,856      instructions:u            #    1.64  insn per cycle         
+       2.397144473 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  255) (512y:    0) (512z:  292)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_eemumu_manu/log_eemumu_manu_f_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum'
 
-DATE: 2022-05-09_18:35:33
+DATE: 2022-05-10_22:09:40
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=2, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.093142e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.239149e+09                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.103038e+09                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.092712e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.240075e+09                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.121293e+09                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371686e-02 +- 3.270219e-06 )  GeV^0
-TOTAL       :     0.657118 sec
-       314,679,115      cycles:u                  #    0.355 GHz                    
-       689,636,040      instructions:u            #    2.19  insn per cycle         
-       0.946388527 seconds time elapsed
+TOTAL       :     0.574657 sec
+       315,516,525      cycles:u                  #    0.551 GHz                    
+       687,793,215      instructions:u            #    2.18  insn per cycle         
+       0.864771473 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 56
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.025003e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.360953e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.360953e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.985783e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.362009e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.362009e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     2.498948 sec
-     6,597,166,224      cycles:u                  #    2.630 GHz                    
-    12,429,744,765      instructions:u            #    1.88  insn per cycle         
-       2.511451644 seconds time elapsed
+TOTAL       :     2.529733 sec
+     6,674,696,149      cycles:u                  #    2.629 GHz                    
+    12,429,744,555      instructions:u            #    1.86  insn per cycle         
+       2.542618085 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  643) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.none_f_inl1_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=6, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.199511e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.092740e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.092740e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.173549e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.045260e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.045260e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371706e-02 +- 3.270375e-06 )  GeV^0
-TOTAL       :     2.374884 sec
-     6,269,320,950      cycles:u                  #    2.629 GHz                    
-    11,239,448,674      instructions:u            #    1.79  insn per cycle         
-       2.387632472 seconds time elapsed
+TOTAL       :     2.392351 sec
+     6,301,544,107      cycles:u                  #    2.625 GHz                    
+    11,239,448,692      instructions:u            #    1.78  insn per cycle         
+       2.404780194 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  364) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.sse4_f_inl1_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.381098e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.903613e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.903613e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.374968e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.860355e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.860355e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.273890 sec
-     5,913,073,185      cycles:u                  #    2.589 GHz                    
-     9,787,418,032      instructions:u            #    1.66  insn per cycle         
-       2.286367441 seconds time elapsed
+TOTAL       :     2.276983 sec
+     5,914,469,376      cycles:u                  #    2.586 GHz                    
+     9,787,418,145      instructions:u            #    1.65  insn per cycle         
+       2.289532999 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  368) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.avx2_f_inl1_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.353225e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.884733e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.884733e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.330577e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.966773e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.966773e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270339e-06 )  GeV^0
-TOTAL       :     2.286400 sec
-     5,946,511,761      cycles:u                  #    2.590 GHz                    
-     9,754,391,636      instructions:u            #    1.64  insn per cycle         
-       2.299135406 seconds time elapsed
+TOTAL       :     2.299666 sec
+     5,978,658,904      cycles:u                  #    2.589 GHz                    
+     9,754,391,615      instructions:u            #    1.63  insn per cycle         
+       2.312268890 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  349) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512y_f_inl1_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=1
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=5, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.201459e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.948906e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.948906e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.203242e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.969307e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.969307e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 1.371705e-02 +- 3.270340e-06 )  GeV^0
-TOTAL       :     2.374815 sec
-     5,912,424,119      cycles:u                  #    2.480 GHz                    
-     9,618,337,373      instructions:u            #    1.63  insn per cycle         
-       2.387200672 seconds time elapsed
+TOTAL       :     2.375568 sec
+     5,900,091,857      cycles:u                  #    2.475 GHz                    
+     9,618,337,251      instructions:u            #    1.63  insn per cycle         
+       2.388472967 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  204) (512y:    0) (512z:  224)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu/SubProcesses/P1_Sigma_sm_epem_mupmum/build.512z_f_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_17:57:14
+DATE: 2022-05-10_21:31:11
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.445343e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.224762e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.365248e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.494183e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.220758e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.364704e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.636479 sec
-       128,544,116      cycles:u                  #    0.159 GHz                    
-       152,395,997      instructions:u            #    1.19  insn per cycle         
-       1.015622661 seconds time elapsed
+TOTAL       :     0.592018 sec
+       124,784,745      cycles:u                  #    0.154 GHz                    
+       152,675,466      instructions:u            #    1.22  insn per cycle         
+       0.997677114 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.864055e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.980479e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980479e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.864721e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.981143e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981143e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.917648 sec
-     7,638,122,452      cycles:u                  #    2.606 GHz                    
-    22,282,032,621      instructions:u            #    2.92  insn per cycle         
-       2.974785228 seconds time elapsed
+TOTAL       :     2.909525 sec
+     7,639,392,554      cycles:u                  #    2.615 GHz                    
+    22,282,026,979      instructions:u            #    2.92  insn per cycle         
+       2.944505493 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  474) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.842175e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.133475e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.133475e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.838081e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.129081e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.129081e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.946875 sec
-     5,052,602,123      cycles:u                  #    2.577 GHz                    
-    13,084,824,943      instructions:u            #    2.59  insn per cycle         
-       2.076656538 seconds time elapsed
+TOTAL       :     1.947413 sec
+     5,055,604,735      cycles:u                  #    2.579 GHz                    
+    13,084,822,968      instructions:u            #    2.59  insn per cycle         
+       2.087613500 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2387) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.810018e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.667550e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.667550e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.785652e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.633139e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.633139e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.194443 sec
-     2,674,509,389      cycles:u                  #    2.213 GHz                    
-     5,519,847,593      instructions:u            #    2.06  insn per cycle         
-       1.247743152 seconds time elapsed
+TOTAL       :     1.192920 sec
+     2,672,900,354      cycles:u                  #    2.217 GHz                    
+     5,519,841,953      instructions:u            #    2.07  insn per cycle         
+       1.275007531 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2116) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.136071e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.128282e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.128282e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.139198e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.124607e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.124607e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.125483 sec
-     2,514,241,503      cycles:u                  #    2.208 GHz                    
-     5,318,515,149      instructions:u            #    2.12  insn per cycle         
-       1.261478713 seconds time elapsed
+TOTAL       :     1.119144 sec
+     2,510,883,900      cycles:u                  #    2.218 GHz                    
+     5,318,510,539      instructions:u            #    2.12  insn per cycle         
+       1.192405839 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1944) (512y:  116) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.393366e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.798832e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.798832e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.393683e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.797657e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.797657e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.651666 sec
-     2,747,693,654      cycles:u                  #    1.650 GHz                    
-     3,537,976,219      instructions:u            #    1.29  insn per cycle         
-       1.700669377 seconds time elapsed
+TOTAL       :     1.644834 sec
+     2,741,272,793      cycles:u                  #    1.654 GHz                    
+     3,537,972,376      instructions:u            #    1.29  insn per cycle         
+       1.706398682 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  987) (512y:   99) (512z: 1590)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:44:58
+DATE: 2022-05-10_22:19:11
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -80,14 +80,14 @@ WARNING! Set grid in Bridge (nevt=524288, gpublocks=2048, gputhreads=256, gpublo
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.625760e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.724872e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.724872e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.633537e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.766002e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.766002e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.817233 sec
-       678,004,041      cycles:u                  #    0.635 GHz                    
-     1,044,033,652      instructions:u            #    1.54  insn per cycle         
-       1.125463954 seconds time elapsed
+TOTAL       :     0.816076 sec
+       676,611,213      cycles:u                  #    0.634 GHz                    
+     1,042,738,663      instructions:u            #    1.54  insn per cycle         
+       1.125352708 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -104,14 +104,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.863766e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.979344e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979344e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.856903e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.972440e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.972440e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     3.020513 sec
-     7,768,984,479      cycles:u                  #    2.553 GHz                    
-    22,339,975,147      instructions:u            #    2.88  insn per cycle         
-       3.046352509 seconds time elapsed
+TOTAL       :     3.033209 sec
+     7,786,746,770      cycles:u                  #    2.549 GHz                    
+    22,339,974,843      instructions:u            #    2.87  insn per cycle         
+       3.058943158 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  474) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
@@ -130,14 +130,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.827351e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.114746e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.114746e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.809320e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.093401e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.093401e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.062790 sec
-     5,197,342,695      cycles:u                  #    2.492 GHz                    
-    13,197,819,938      instructions:u            #    2.54  insn per cycle         
-       2.088553744 seconds time elapsed
+TOTAL       :     2.073520 sec
+     5,224,109,893      cycles:u                  #    2.491 GHz                    
+    13,197,819,885      instructions:u            #    2.53  insn per cycle         
+       2.099696465 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2387) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
@@ -156,14 +156,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.747595e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.578772e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.578772e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.707508e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.527712e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.527712e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.312753 sec
-     2,831,686,500      cycles:u                  #    2.120 GHz                    
-     5,680,813,585      instructions:u            #    2.01  insn per cycle         
-       1.338384365 seconds time elapsed
+TOTAL       :     1.324126 sec
+     2,844,451,630      cycles:u                  #    2.112 GHz                    
+     5,680,813,703      instructions:u            #    2.00  insn per cycle         
+       1.349717563 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2116) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
@@ -182,14 +182,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.040549e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.983110e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.983110e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.045376e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.994818e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.994818e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.247976 sec
-     2,684,328,466      cycles:u                  #    2.112 GHz                    
-     5,479,483,161      instructions:u            #    2.04  insn per cycle         
-       1.273684012 seconds time elapsed
+TOTAL       :     1.248002 sec
+     2,680,744,013      cycles:u                  #    2.109 GHz                    
+     5,479,483,088      instructions:u            #    2.04  insn per cycle         
+       1.273788610 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1944) (512y:  116) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
@@ -208,14 +208,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.369706e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.767599e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.767599e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.350997e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.742087e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.742087e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.766141 sec
-     2,903,384,634      cycles:u                  #    1.623 GHz                    
-     3,687,344,458      instructions:u            #    1.27  insn per cycle         
-       1.791726457 seconds time elapsed
+TOTAL       :     1.775067 sec
+     2,913,767,506      cycles:u                  #    1.621 GHz                    
+     3,687,344,547      instructions:u            #    1.27  insn per cycle         
+       1.800938803 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  987) (512y:   99) (512z: 1590)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:54:23
+DATE: 2022-05-10_22:28:39
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.698343e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.225653e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.360616e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.706042e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.223837e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.358018e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     0.636457 sec
-       254,560,119      cycles:u                  #    0.292 GHz                    
-       369,335,770      instructions:u            #    1.45  insn per cycle         
-       0.929729584 seconds time elapsed
+TOTAL       :     0.645956 sec
+       255,870,192      cycles:u                  #    0.288 GHz                    
+       369,137,837      instructions:u            #    1.44  insn per cycle         
+       0.954526947 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.865964e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.982075e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.982075e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.870712e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.987844e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.987844e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     2.962122 sec
-     7,723,377,716      cycles:u                  #    2.596 GHz                    
-    22,294,986,509      instructions:u            #    2.89  insn per cycle         
-       2.977750024 seconds time elapsed
+TOTAL       :     2.953691 sec
+     7,697,156,863      cycles:u                  #    2.595 GHz                    
+    22,294,986,424      instructions:u            #    2.90  insn per cycle         
+       2.969878974 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  474) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.865216e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.160115e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.160115e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.830718e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.120295e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.120295e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     1.980664 sec
-     5,094,058,000      cycles:u                  #    2.555 GHz                    
-    13,089,311,802      instructions:u            #    2.57  insn per cycle         
-       1.996162931 seconds time elapsed
+TOTAL       :     2.001814 sec
+     5,148,119,836      cycles:u                  #    2.555 GHz                    
+    13,089,311,545      instructions:u            #    2.54  insn per cycle         
+       2.017837734 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2387) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.858347e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.737652e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.737652e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.799773e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.651940e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.651940e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     1.229595 sec
-     2,728,994,712      cycles:u                  #    2.196 GHz                    
-     5,520,203,608      instructions:u            #    2.02  insn per cycle         
-       1.245149525 seconds time elapsed
+TOTAL       :     1.241637 sec
+     2,755,589,371      cycles:u                  #    2.196 GHz                    
+     5,520,203,605      instructions:u            #    2.00  insn per cycle         
+       1.257266439 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2116) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.159688e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.154009e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.154009e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.120172e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.097364e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.097364e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     1.167747 sec
-     2,588,627,478      cycles:u                  #    2.192 GHz                    
-     5,297,900,731      instructions:u            #    2.05  insn per cycle         
-       1.183465528 seconds time elapsed
+TOTAL       :     1.174399 sec
+     2,601,471,916      cycles:u                  #    2.191 GHz                    
+     5,297,900,813      instructions:u            #    2.04  insn per cycle         
+       1.190208714 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1944) (512y:  116) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.379810e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.785746e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.785746e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.375363e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.774237e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.774237e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082594e+00 +- 4.821650e-03 )  GeV^0
-TOTAL       :     1.703434 sec
-     2,832,887,910      cycles:u                  #    1.653 GHz                    
-     3,517,362,143      instructions:u            #    1.24  insn per cycle         
-       1.719425693 seconds time elapsed
+TOTAL       :     1.704164 sec
+     2,838,057,658      cycles:u                  #    1.653 GHz                    
+     3,517,361,466      instructions:u            #    1.24  insn per cycle         
+       1.720387517 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  987) (512y:   99) (512z: 1590)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:51:14
+DATE: 2022-05-10_22:25:28
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.710640e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.229479e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.362223e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.703443e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.228709e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.362209e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.590522 sec
-       179,011,515      cycles:u                  #    0.217 GHz                    
-       356,649,948      instructions:u            #    1.99  insn per cycle         
-       0.884002629 seconds time elapsed
+TOTAL       :     0.591016 sec
+       178,766,505      cycles:u                  #    0.216 GHz                    
+       358,251,180      instructions:u            #    2.00  insn per cycle         
+       0.884557750 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.867066e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.983167e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.983167e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.871541e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.988577e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.988577e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.913324 sec
-     7,630,207,016      cycles:u                  #    2.607 GHz                    
-    22,282,036,476      instructions:u            #    2.92  insn per cycle         
-       2.929315620 seconds time elapsed
+TOTAL       :     2.907330 sec
+     7,620,492,275      cycles:u                  #    2.609 GHz                    
+    22,282,036,381      instructions:u            #    2.92  insn per cycle         
+       2.923310588 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  474) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.859089e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.155306e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.155306e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.844259e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.136193e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.136193e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.939725 sec
-     5,028,247,400      cycles:u                  #    2.575 GHz                    
-    13,084,829,202      instructions:u            #    2.60  insn per cycle         
-       1.955579502 seconds time elapsed
+TOTAL       :     1.947765 sec
+     5,051,249,054      cycles:u                  #    2.576 GHz                    
+    13,084,829,164      instructions:u            #    2.59  insn per cycle         
+       1.963607044 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2387) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.833858e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.696960e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.696960e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.789688e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.639769e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.639769e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.189889 sec
-     2,664,585,273      cycles:u                  #    2.215 GHz                    
-     5,519,850,820      instructions:u            #    2.07  insn per cycle         
-       1.205761593 seconds time elapsed
+TOTAL       :     1.200989 sec
+     2,683,786,781      cycles:u                  #    2.211 GHz                    
+     5,519,850,926      instructions:u            #    2.06  insn per cycle         
+       1.216637899 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2116) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.151611e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.137124e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.137124e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.123194e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.099384e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.099384e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.122819 sec
-     2,512,719,393      cycles:u                  #    2.212 GHz                    
-     5,318,519,110      instructions:u            #    2.12  insn per cycle         
-       1.138322093 seconds time elapsed
+TOTAL       :     1.128965 sec
+     2,524,799,091      cycles:u                  #    2.211 GHz                    
+     5,318,519,505      instructions:u            #    2.11  insn per cycle         
+       1.144681093 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1944) (512y:  116) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.414398e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.825659e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.825659e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.390834e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.793705e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.793705e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.641453 sec
-     2,734,472,312      cycles:u                  #    1.653 GHz                    
-     3,537,980,098      instructions:u            #    1.29  insn per cycle         
-       1.657310999 seconds time elapsed
+TOTAL       :     1.652385 sec
+     2,749,666,069      cycles:u                  #    1.651 GHz                    
+     3,537,980,345      instructions:u            #    1.29  insn per cycle         
+       1.668131307 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  987) (512y:   99) (512z: 1590)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:48:08
+DATE: 2022-05-10_22:22:21
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.985075e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.232335e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.362585e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.978256e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.226957e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.361090e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.751961 sec
-       614,391,745      cycles:u                  #    0.622 GHz                    
-       961,663,468      instructions:u            #    1.57  insn per cycle         
-       1.045755624 seconds time elapsed
+TOTAL       :     0.751479 sec
+       614,565,219      cycles:u                  #    0.623 GHz                    
+       961,956,297      instructions:u            #    1.57  insn per cycle         
+       1.044945204 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -100,14 +100,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.871349e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.987795e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.987795e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.870119e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.987723e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.987723e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.906647 sec
-     7,621,017,125      cycles:u                  #    2.610 GHz                    
-    22,282,036,992      instructions:u            #    2.92  insn per cycle         
-       2.922542700 seconds time elapsed
+TOTAL       :     2.909030 sec
+     7,627,214,091      cycles:u                  #    2.610 GHz                    
+    22,282,036,705      instructions:u            #    2.92  insn per cycle         
+       2.925851528 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  474) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd0/runTest.exe
@@ -125,14 +125,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.854971e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.147154e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.147154e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.849922e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.142741e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.142741e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.940376 sec
-     5,032,793,288      cycles:u                  #    2.577 GHz                    
-    13,084,829,922      instructions:u            #    2.60  insn per cycle         
-       1.956010838 seconds time elapsed
+TOTAL       :     1.947292 sec
+     5,038,161,774      cycles:u                  #    2.572 GHz                    
+    13,084,829,679      instructions:u            #    2.60  insn per cycle         
+       1.964095365 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2387) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd0/runTest.exe
@@ -150,14 +150,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.814783e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.671540e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.671540e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.796800e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.652017e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.652017e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.195902 sec
-     2,670,870,209      cycles:u                  #    2.210 GHz                    
-     5,519,850,992      instructions:u            #    2.07  insn per cycle         
-       1.211892656 seconds time elapsed
+TOTAL       :     1.199013 sec
+     2,680,416,248      cycles:u                  #    2.212 GHz                    
+     5,519,850,900      instructions:u            #    2.06  insn per cycle         
+       1.214825056 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2116) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd0/runTest.exe
@@ -175,14 +175,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.158434e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.149606e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.149606e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.124866e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.112823e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.112823e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.122149 sec
-     2,508,917,759      cycles:u                  #    2.210 GHz                    
-     5,318,519,801      instructions:u            #    2.12  insn per cycle         
-       1.137747857 seconds time elapsed
+TOTAL       :     1.128864 sec
+     2,523,442,678      cycles:u                  #    2.210 GHz                    
+     5,318,519,975      instructions:u            #    2.11  insn per cycle         
+       1.144573219 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1944) (512y:  116) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd0/runTest.exe
@@ -200,14 +200,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.394271e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.797554e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.797554e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.374387e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.773390e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.773390e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.650943 sec
-     2,748,415,359      cycles:u                  #    1.652 GHz                    
-     3,537,980,543      instructions:u            #    1.29  insn per cycle         
-       1.666651063 seconds time elapsed
+TOTAL       :     1.660481 sec
+     2,758,321,623      cycles:u                  #    1.648 GHz                    
+     3,537,980,722      instructions:u            #    1.28  insn per cycle         
+       1.676674803 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  987) (512y:   99) (512z: 1590)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_17:57:39
+DATE: 2022-05-10_21:31:35
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.452134e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.225218e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.364613e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.466125e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.226690e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.366529e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.569414 sec
-       126,706,929      cycles:u                  #    0.157 GHz                    
-       153,401,892      instructions:u            #    1.21  insn per cycle         
-       0.969643295 seconds time elapsed
+TOTAL       :     0.566384 sec
+       124,168,501      cycles:u                  #    0.154 GHz                    
+       151,924,579      instructions:u            #    1.22  insn per cycle         
+       0.963661147 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 200
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.920117e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.043810e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.043810e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.920622e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.045154e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.045154e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.834217 sec
-     7,426,940,525      cycles:u                  #    2.609 GHz                    
-    21,459,158,497      instructions:u            #    2.89  insn per cycle         
-       2.892318101 seconds time elapsed
+TOTAL       :     2.830870 sec
+     7,420,560,943      cycles:u                  #    2.609 GHz                    
+    21,459,156,895      instructions:u            #    2.89  insn per cycle         
+       2.879801686 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  416) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl0_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.941367e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.254877e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.254877e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.948088e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.262559e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.262559e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.885867 sec
-     4,885,400,414      cycles:u                  #    2.572 GHz                    
-    12,233,478,481      instructions:u            #    2.50  insn per cycle         
-       1.947908478 seconds time elapsed
+TOTAL       :     1.877195 sec
+     4,872,492,381      cycles:u                  #    2.578 GHz                    
+    12,233,475,135      instructions:u            #    2.51  insn per cycle         
+       1.968139276 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2212) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl0_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.997208e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.571318e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.571318e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.969840e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.539589e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.539589e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.414196 sec
-     3,175,612,806      cycles:u                  #    2.224 GHz                    
-     6,005,725,832      instructions:u            #    1.89  insn per cycle         
-       1.459223924 seconds time elapsed
+TOTAL       :     1.419227 sec
+     3,185,156,478      cycles:u                  #    2.226 GHz                    
+     6,005,721,955      instructions:u            #    1.89  insn per cycle         
+       1.558652963 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2251) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl0_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.070375e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.671235e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.671235e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.056813e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.651523e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.651523e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.390944 sec
-     3,122,776,661      cycles:u                  #    2.224 GHz                    
-     5,810,687,664      instructions:u            #    1.86  insn per cycle         
-       1.459813623 seconds time elapsed
+TOTAL       :     1.392135 sec
+     3,122,978,489      cycles:u                  #    2.224 GHz                    
+     5,810,684,118      instructions:u            #    1.86  insn per cycle         
+       1.471596588 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1952) (512y:  260) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl0_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.134209e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.475505e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.475505e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.145062e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.490237e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.490237e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.776463 sec
-     2,944,210,822      cycles:u                  #    1.645 GHz                    
-     3,916,153,399      instructions:u            #    1.33  insn per cycle         
-       1.816342021 seconds time elapsed
+TOTAL       :     1.766183 sec
+     2,931,496,464      cycles:u                  #    1.649 GHz                    
+     3,916,149,605      instructions:u            #    1.34  insn per cycle         
+       1.849206106 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  915) (512y:  195) (512z: 1646)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:35:58
+DATE: 2022-05-10_22:10:05
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.048698e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.218952e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.362884e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.067595e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.221194e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.365937e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.579341 sec
-       132,968,740      cycles:u                  #    0.160 GHz                    
-       156,099,921      instructions:u            #    1.17  insn per cycle         
-       0.886967594 seconds time elapsed
+TOTAL       :     0.580383 sec
+       130,875,575      cycles:u                  #    0.157 GHz                    
+       155,379,268      instructions:u            #    1.19  insn per cycle         
+       0.890297569 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 204
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.147693e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.305980e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.305980e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.147189e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.305536e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.305536e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.552930 sec
-     6,651,457,795      cycles:u                  #    2.590 GHz                    
-    16,443,381,476      instructions:u            #    2.47  insn per cycle         
-       2.572696645 seconds time elapsed
+TOTAL       :     2.553821 sec
+     6,649,931,290      cycles:u                  #    2.588 GHz                    
+    16,443,381,391      instructions:u            #    2.47  insn per cycle         
+       2.573102315 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  658) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl1_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.518813e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.748667e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.748667e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.523954e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.754325e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.754325e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.192000 sec
-     5,690,438,644      cycles:u                  #    2.577 GHz                    
-    11,699,095,939      instructions:u            #    2.06  insn per cycle         
-       2.211964718 seconds time elapsed
+TOTAL       :     2.187143 sec
+     5,678,992,786      cycles:u                  #    2.577 GHz                    
+    11,699,096,244      instructions:u            #    2.06  insn per cycle         
+       2.206343445 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2560) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl1_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.899204e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.453127e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.453127e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.891076e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.442636e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.442636e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.454887 sec
-     3,255,597,713      cycles:u                  #    2.213 GHz                    
-     5,180,182,133      instructions:u            #    1.59  insn per cycle         
-       1.473912422 seconds time elapsed
+TOTAL       :     1.458274 sec
+     3,238,556,880      cycles:u                  #    2.196 GHz                    
+     5,180,182,114      instructions:u            #    1.60  insn per cycle         
+       1.477437362 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2609) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl1_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.079627e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.685381e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.685381e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.066062e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.671003e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.671003e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.395923 sec
-     3,121,556,206      cycles:u                  #    2.210 GHz                    
-     4,792,198,247      instructions:u            #    1.54  insn per cycle         
-       1.415431453 seconds time elapsed
+TOTAL       :     1.400837 sec
+     3,130,175,780      cycles:u                  #    2.209 GHz                    
+     4,792,197,900      instructions:u            #    1.53  insn per cycle         
+       1.420015872 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2216) (512y:  186) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl1_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.150232e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.498859e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.498859e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.149853e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.498519e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.498519e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.775689 sec
-     2,938,113,523      cycles:u                  #    1.639 GHz                    
-     3,785,039,854      instructions:u            #    1.29  insn per cycle         
-       1.794815694 seconds time elapsed
+TOTAL       :     1.776572 sec
+     2,937,213,516      cycles:u                  #    1.638 GHz                    
+     3,785,040,104      instructions:u            #    1.29  insn per cycle         
+       1.795626796 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1538) (512y:  252) (512z: 1670)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_d_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:36:21
+DATE: 2022-05-10_22:10:27
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.076608e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.211926e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.366335e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.084981e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.213577e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.366603e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     0.583444 sec
-       130,835,659      cycles:u                  #    0.159 GHz                    
-       153,891,298      instructions:u            #    1.18  insn per cycle         
-       0.884638327 seconds time elapsed
+TOTAL       :     0.582411 sec
+       130,369,630      cycles:u                  #    0.158 GHz                    
+       153,345,877      instructions:u            #    1.18  insn per cycle         
+       0.884358012 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 200
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.269968e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.447738e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.447738e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.262172e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.437869e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.437869e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.420789 sec
-     6,298,418,359      cycles:u                  #    2.585 GHz                    
-    17,155,669,920      instructions:u            #    2.72  insn per cycle         
-       2.439958127 seconds time elapsed
+TOTAL       :     2.428858 sec
+     6,315,126,721      cycles:u                  #    2.583 GHz                    
+    17,155,670,490      instructions:u            #    2.72  insn per cycle         
+       2.448092933 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  399) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_d_inl1_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.652757e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.912410e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.912410e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.655987e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.912671e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.912671e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     2.085722 sec
-     5,410,527,897      cycles:u                  #    2.574 GHz                    
-    10,897,198,156      instructions:u            #    2.01  insn per cycle         
-       2.105154433 seconds time elapsed
+TOTAL       :     2.083817 sec
+     5,400,227,947      cycles:u                  #    2.571 GHz                    
+    10,897,198,425      instructions:u            #    2.02  insn per cycle         
+       2.102915564 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2209) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_d_inl1_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.261814e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.933818e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.933818e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.270042e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.944802e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.944802e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.341348 sec
-     2,995,072,805      cycles:u                  #    2.206 GHz                    
-     4,719,132,262      instructions:u            #    1.58  insn per cycle         
-       1.360465049 seconds time elapsed
+TOTAL       :     1.339049 sec
+     2,989,756,823      cycles:u                  #    2.205 GHz                    
+     4,719,132,119      instructions:u            #    1.58  insn per cycle         
+       1.358626404 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1919) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_d_inl1_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.374097e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.087265e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.087265e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.372640e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.075896e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.075896e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.308863 sec
-     2,925,221,902      cycles:u                  #    2.207 GHz                    
-     4,431,012,570      instructions:u            #    1.51  insn per cycle         
-       1.327862144 seconds time elapsed
+TOTAL       :     1.309449 sec
+     2,923,884,978      cycles:u                  #    2.205 GHz                    
+     4,431,012,384      instructions:u            #    1.52  insn per cycle         
+       1.328535561 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1647) (512y:  126) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_d_inl1_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.260591e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.637390e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.637390e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.254246e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.630390e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.630390e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085623e+00 +- 4.835084e-03 )  GeV^0
-TOTAL       :     1.719051 sec
-     2,850,629,763      cycles:u                  #    1.643 GHz                    
-     3,511,938,852      instructions:u            #    1.23  insn per cycle         
-       1.737963005 seconds time elapsed
+TOTAL       :     1.722864 sec
+     2,851,625,889      cycles:u                  #    1.640 GHz                    
+     3,511,939,062      instructions:u            #    1.23  insn per cycle         
+       1.742182885 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1202) (512y:  188) (512z: 1197)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_d_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_17:58:03
+DATE: 2022-05-10_21:32:00
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.606094e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.189369e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.722320e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.642539e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.198942e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.718310e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085652e+00 +- 4.835323e-03 )  GeV^0
-TOTAL       :     0.532413 sec
-       110,753,542      cycles:u                  #    0.143 GHz                    
-       134,854,848      instructions:u            #    1.22  insn per cycle         
-       0.987308688 seconds time elapsed
+TOTAL       :     0.739736 sec
+       110,572,930      cycles:u                  #    0.143 GHz                    
+       135,143,838      instructions:u            #    1.22  insn per cycle         
+       1.174482026 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.944850e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.046676e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.046676e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.946918e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.048604e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.048604e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.760017 sec
-     7,308,826,103      cycles:u                  #    2.641 GHz                    
-    22,167,484,459      instructions:u            #    3.03  insn per cycle         
-       2.818634857 seconds time elapsed
+TOTAL       :     2.754284 sec
+     7,302,073,271      cycles:u                  #    2.644 GHz                    
+    22,167,481,679      instructions:u            #    3.04  insn per cycle         
+       2.806772076 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  431) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.257235e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.795887e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.795887e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.261524e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.799733e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.799733e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.295385 sec
-     3,394,757,254      cycles:u                  #    2.604 GHz                    
-     8,215,290,255      instructions:u            #    2.42  insn per cycle         
-       1.360647599 seconds time elapsed
+TOTAL       :     1.290719 sec
+     3,384,910,449      cycles:u                  #    2.608 GHz                    
+     8,215,287,508      instructions:u            #    2.43  insn per cycle         
+       1.322809378 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2958) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.005345e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.018005e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.018005e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.073593e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.021310e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.021310e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.720112 sec
-     1,649,364,052      cycles:u                  #    2.262 GHz                    
-     3,508,466,114      instructions:u            #    2.13  insn per cycle         
-       0.837732683 seconds time elapsed
+TOTAL       :     0.710861 sec
+     1,631,825,699      cycles:u                  #    2.271 GHz                    
+     3,508,462,984      instructions:u            #    2.15  insn per cycle         
+       0.772136077 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2557) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.385068e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.072855e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.072855e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.396373e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.074115e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.074115e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.688419 sec
-     1,577,558,783      cycles:u                  #    2.264 GHz                    
-     3,380,011,885      instructions:u            #    2.14  insn per cycle         
-       0.730044761 seconds time elapsed
+TOTAL       :     0.685781 sec
+     1,575,848,714      cycles:u                  #    2.271 GHz                    
+     3,380,010,292      instructions:u            #    2.14  insn per cycle         
+       0.777769365 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2445) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.393353e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.659643e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.659643e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.386116e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.642053e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.642053e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.883738 sec
-     1,541,799,975      cycles:u                  #    1.729 GHz                    
-     2,447,274,911      instructions:u            #    1.59  insn per cycle         
-       0.952397620 seconds time elapsed
+TOTAL       :     0.881273 sec
+     1,543,184,971      cycles:u                  #    1.737 GHz                    
+     2,447,272,521      instructions:u            #    1.59  insn per cycle         
+       0.946462989 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1568) (512y:    7) (512z: 1787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:45:21
+DATE: 2022-05-10_22:19:34
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -80,14 +80,14 @@ WARNING! Set grid in Bridge (nevt=524288, gpublocks=2048, gputhreads=256, gpublo
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.989370e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.922609e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.922609e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.956383e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.997494e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.997494e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085678e+00 +- 4.835493e-03 )  GeV^0
-TOTAL       :     0.657022 sec
-       380,030,619      cycles:u                  #    0.428 GHz                    
-       679,584,186      instructions:u            #    1.79  insn per cycle         
-       0.947502241 seconds time elapsed
+TOTAL       :     0.655619 sec
+       382,416,333      cycles:u                  #    0.427 GHz                    
+       679,798,635      instructions:u            #    1.78  insn per cycle         
+       0.954808477 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -104,14 +104,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.941368e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.042614e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.042614e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.937698e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.041897e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.041897e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.820343 sec
-     7,385,684,268      cycles:u                  #    2.607 GHz                    
-    22,198,393,749      instructions:u            #    3.01  insn per cycle         
-       2.836616640 seconds time elapsed
+TOTAL       :     2.824765 sec
+     7,397,495,799      cycles:u                  #    2.606 GHz                    
+    22,198,394,472      instructions:u            #    3.00  insn per cycle         
+       2.840987989 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  431) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd0/runTest.exe
@@ -130,14 +130,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.250815e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.787927e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.787927e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.224780e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.757713e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.757713e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.355070 sec
-     3,463,348,687      cycles:u                  #    2.531 GHz                    
-     8,367,312,373      instructions:u            #    2.42  insn per cycle         
-       1.371315857 seconds time elapsed
+TOTAL       :     1.363099 sec
+     3,484,099,909      cycles:u                  #    2.531 GHz                    
+     8,367,312,122      instructions:u            #    2.40  insn per cycle         
+       1.380431172 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2958) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd0/runTest.exe
@@ -156,14 +156,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.958106e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.005208e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.005208e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.945345e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.002647e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.002647e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.780544 sec
-     1,727,248,728      cycles:u                  #    2.175 GHz                    
-     3,648,887,648      instructions:u            #    2.11  insn per cycle         
-       0.796655299 seconds time elapsed
+TOTAL       :     0.781406 sec
+     1,728,488,254      cycles:u                  #    2.174 GHz                    
+     3,648,887,750      instructions:u            #    2.11  insn per cycle         
+       0.797516211 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2557) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd0/runTest.exe
@@ -182,14 +182,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.247442e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.051488e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.051488e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.204036e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.045393e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.045393e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.756878 sec
-     1,673,863,107      cycles:u                  #    2.173 GHz                    
-     3,520,435,310      instructions:u            #    2.10  insn per cycle         
-       0.772977194 seconds time elapsed
+TOTAL       :     0.761079 sec
+     1,677,986,456      cycles:u                  #    2.166 GHz                    
+     3,520,435,152      instructions:u            #    2.10  insn per cycle         
+       0.777484616 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2445) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd0/runTest.exe
@@ -208,14 +208,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.279719e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.498107e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.498107e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.302719e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.544146e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.544146e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.958347 sec
-     1,647,997,144      cycles:u                  #    1.696 GHz                    
-     2,588,681,292      instructions:u            #    1.57  insn per cycle         
-       0.974512709 seconds time elapsed
+TOTAL       :     0.954171 sec
+     1,643,112,771      cycles:u                  #    1.698 GHz                    
+     2,588,681,222      instructions:u            #    1.58  insn per cycle         
+       0.970839240 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1568) (512y:    7) (512z: 1787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:54:46
+DATE: 2022-05-10_22:29:02
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.020081e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.214162e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.689135e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.024288e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.229522e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.703606e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082622e+00 +- 4.821886e-03 )  GeV^0
-TOTAL       :     0.600541 sec
-       233,145,463      cycles:u                  #    0.282 GHz                    
-       352,185,747      instructions:u            #    1.51  insn per cycle         
-       0.885753271 seconds time elapsed
+TOTAL       :     0.596807 sec
+       231,169,665      cycles:u                  #    0.279 GHz                    
+       352,537,943      instructions:u            #    1.53  insn per cycle         
+       0.888539098 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.938768e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.039827e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.039827e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.945926e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.048302e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.048302e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082726e+00 +- 4.823178e-03 )  GeV^0
-TOTAL       :     2.815320 sec
-     7,402,370,614      cycles:u                  #    2.622 GHz                    
-    22,183,716,009      instructions:u            #    3.00  insn per cycle         
-       2.826682188 seconds time elapsed
+TOTAL       :     2.805143 sec
+     7,378,232,951      cycles:u                  #    2.623 GHz                    
+    22,183,715,776      instructions:u            #    3.01  insn per cycle         
+       2.816388773 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  431) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.264123e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.805758e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.805758e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.256616e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.795739e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.795739e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082730e+00 +- 4.823213e-03 )  GeV^0
-TOTAL       :     1.338825 sec
-     3,462,857,005      cycles:u                  #    2.570 GHz                    
-     8,223,134,192      instructions:u            #    2.37  insn per cycle         
-       1.350120232 seconds time elapsed
+TOTAL       :     1.341921 sec
+     3,461,395,681      cycles:u                  #    2.565 GHz                    
+     8,223,133,782      instructions:u            #    2.38  insn per cycle         
+       1.353156725 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2958) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.109269e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.030902e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.030902e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.042160e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.019318e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.019318e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082720e+00 +- 4.822916e-03 )  GeV^0
-TOTAL       :     0.756128 sec
-     1,699,641,329      cycles:u                  #    2.222 GHz                    
-     3,506,346,582      instructions:u            #    2.06  insn per cycle         
-       0.767517834 seconds time elapsed
+TOTAL       :     0.761303 sec
+     1,710,122,190      cycles:u                  #    2.220 GHz                    
+     3,506,346,764      instructions:u            #    2.05  insn per cycle         
+       0.772758820 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2557) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.390211e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.081021e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.081021e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.332850e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.067145e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.067145e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082720e+00 +- 4.822916e-03 )  GeV^0
-TOTAL       :     0.735541 sec
-     1,645,815,982      cycles:u                  #    2.217 GHz                    
-     3,356,922,217      instructions:u            #    2.04  insn per cycle         
-       0.747017795 seconds time elapsed
+TOTAL       :     0.739940 sec
+     1,658,004,436      cycles:u                  #    2.215 GHz                    
+     3,356,922,617      instructions:u            #    2.02  insn per cycle         
+       0.751196762 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2445) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.423145e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.704555e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.704555e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.399100e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.668501e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.668501e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.082720e+00 +- 4.822916e-03 )  GeV^0
-TOTAL       :     0.928038 sec
-     1,608,693,452      cycles:u                  #    1.718 GHz                    
-     2,424,185,570      instructions:u            #    1.51  insn per cycle         
-       0.939202611 seconds time elapsed
+TOTAL       :     0.929284 sec
+     1,612,374,621      cycles:u                  #    1.719 GHz                    
+     2,424,185,274      instructions:u            #    1.50  insn per cycle         
+       0.940412541 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1568) (512y:    7) (512z: 1787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:51:36
+DATE: 2022-05-10_22:25:50
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.025527e+08                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.225181e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.703975e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.023941e+08                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.219062e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.693740e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085652e+00 +- 4.835323e-03 )  GeV^0
-TOTAL       :     0.553714 sec
-       162,133,627      cycles:u                  #    0.208 GHz                    
-       336,319,909      instructions:u            #    2.07  insn per cycle         
-       0.836962819 seconds time elapsed
+TOTAL       :     0.303033 sec
+       161,983,015      cycles:u                  #    0.349 GHz                    
+       335,842,130      instructions:u            #    2.07  insn per cycle         
+       0.586863122 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.942972e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.044203e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.044203e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.944883e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.046265e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.046265e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.766487 sec
-     7,320,967,773      cycles:u                  #    2.638 GHz                    
-    22,167,489,668      instructions:u            #    3.03  insn per cycle         
-       2.777862722 seconds time elapsed
+TOTAL       :     2.764664 sec
+     7,311,681,253      cycles:u                  #    2.637 GHz                    
+    22,167,489,587      instructions:u            #    3.03  insn per cycle         
+       2.776128737 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  431) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.252748e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.804169e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.804169e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.264498e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.804765e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.804765e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.300136 sec
-     3,398,618,410      cycles:u                  #    2.597 GHz                    
-     8,215,295,415      instructions:u            #    2.42  insn per cycle         
-       1.311254431 seconds time elapsed
+TOTAL       :     1.296988 sec
+     3,389,512,694      cycles:u                  #    2.596 GHz                    
+     8,215,295,762      instructions:u            #    2.42  insn per cycle         
+       1.308251564 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2958) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.086836e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.026403e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.026403e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.051442e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.019971e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.019971e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.716178 sec
-     1,636,542,008      cycles:u                  #    2.257 GHz                    
-     3,508,470,526      instructions:u            #    2.14  insn per cycle         
-       0.727909727 seconds time elapsed
+TOTAL       :     0.719062 sec
+     1,640,463,257      cycles:u                  #    2.254 GHz                    
+     3,508,470,310      instructions:u            #    2.14  insn per cycle         
+       0.730226784 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2557) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.423106e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.081458e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.081458e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.375805e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.071497e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.071497e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.690078 sec
-     1,577,130,546      cycles:u                  #    2.256 GHz                    
-     3,380,017,592      instructions:u            #    2.14  insn per cycle         
-       0.701744749 seconds time elapsed
+TOTAL       :     0.693573 sec
+     1,583,199,716      cycles:u                  #    2.254 GHz                    
+     3,380,017,412      instructions:u            #    2.13  insn per cycle         
+       0.705108491 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2445) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.457214e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.749608e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.749608e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.403059e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.670891e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.670891e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.879548 sec
-     1,533,910,975      cycles:u                  #    1.726 GHz                    
-     2,447,280,331      instructions:u            #    1.60  insn per cycle         
-       0.891151492 seconds time elapsed
+TOTAL       :     0.887053 sec
+     1,543,181,306      cycles:u                  #    1.723 GHz                    
+     2,447,280,086      instructions:u            #    1.59  insn per cycle         
+       0.898276986 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1568) (512y:    7) (512z: 1787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:48:31
+DATE: 2022-05-10_22:22:43
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.019118e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.225832e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.706664e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.014800e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.227273e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.707888e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085678e+00 +- 4.835493e-03 )  GeV^0
-TOTAL       :     0.619444 sec
-       345,834,557      cycles:u                  #    0.409 GHz                    
-       617,912,243      instructions:u            #    1.79  insn per cycle         
-       0.902566192 seconds time elapsed
+TOTAL       :     0.622221 sec
+       346,182,060      cycles:u                  #    0.409 GHz                    
+       617,888,180      instructions:u            #    1.78  insn per cycle         
+       0.906142570 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -100,14 +100,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.944653e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.045958e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.045958e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.946285e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.047984e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.047984e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.764264 sec
-     7,318,502,281      cycles:u                  #    2.639 GHz                    
-    22,167,489,132      instructions:u            #    3.03  insn per cycle         
-       2.775561670 seconds time elapsed
+TOTAL       :     2.761870 sec
+     7,306,889,210      cycles:u                  #    2.637 GHz                    
+    22,167,489,399      instructions:u            #    3.03  insn per cycle         
+       2.773704188 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  431) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd0/runTest.exe
@@ -125,14 +125,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.278132e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.820045e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.820045e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.250120e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.793409e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.793409e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.293038 sec
-     3,381,056,495      cycles:u                  #    2.597 GHz                    
-     8,215,295,445      instructions:u            #    2.43  insn per cycle         
-       1.304648032 seconds time elapsed
+TOTAL       :     1.300945 sec
+     3,402,121,967      cycles:u                  #    2.597 GHz                    
+     8,215,295,965      instructions:u            #    2.41  insn per cycle         
+       1.312567597 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2958) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd0/runTest.exe
@@ -150,14 +150,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.055913e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.022080e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.022080e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.039025e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.018232e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.018232e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.718819 sec
-     1,641,630,968      cycles:u                  #    2.257 GHz                    
-     3,508,470,727      instructions:u            #    2.14  insn per cycle         
-       0.729975780 seconds time elapsed
+TOTAL       :     0.720430 sec
+     1,642,488,222      cycles:u                  #    2.253 GHz                    
+     3,508,470,955      instructions:u            #    2.14  insn per cycle         
+       0.731709483 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2557) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd0/runTest.exe
@@ -175,14 +175,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.375641e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.071368e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.071368e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.370989e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.071481e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.071481e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.693328 sec
-     1,583,022,122      cycles:u                  #    2.255 GHz                    
-     3,380,017,987      instructions:u            #    2.14  insn per cycle         
-       0.704508843 seconds time elapsed
+TOTAL       :     0.693838 sec
+     1,583,442,335      cycles:u                  #    2.254 GHz                    
+     3,380,017,653      instructions:u            #    2.13  insn per cycle         
+       0.705185226 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2445) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd0/runTest.exe
@@ -200,14 +200,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.434809e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.714713e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.714713e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.392080e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.655498e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.655498e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.882348 sec
-     1,537,055,539      cycles:u                  #    1.725 GHz                    
-     2,447,280,357      instructions:u            #    1.59  insn per cycle         
-       0.893739441 seconds time elapsed
+TOTAL       :     0.887761 sec
+     1,546,554,717      cycles:u                  #    1.725 GHz                    
+     2,447,280,559      instructions:u            #    1.58  insn per cycle         
+       0.899042730 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1568) (512y:    7) (512z: 1787)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_17:58:25
+DATE: 2022-05-10_21:32:21
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.646070e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.219461e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.733785e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.672070e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.215025e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.734266e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085652e+00 +- 4.835323e-03 )  GeV^0
-TOTAL       :     0.535221 sec
-       109,753,583      cycles:u                  #    0.143 GHz                    
-       133,262,512      instructions:u            #    1.21  insn per cycle         
-       1.015517638 seconds time elapsed
+TOTAL       :     0.535448 sec
+       110,010,045      cycles:u                  #    0.143 GHz                    
+       133,459,446      instructions:u            #    1.21  insn per cycle         
+       0.892505417 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.000513e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.108358e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.108358e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.001730e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.109681e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.109681e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.684189 sec
-     7,108,089,251      cycles:u                  #    2.641 GHz                    
-    21,411,720,327      instructions:u            #    3.01  insn per cycle         
-       2.722268951 seconds time elapsed
+TOTAL       :     2.681769 sec
+     7,104,420,610      cycles:u                  #    2.642 GHz                    
+    21,411,719,785      instructions:u            #    3.01  insn per cycle         
+       2.718478690 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  393) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl0_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.836786e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.543187e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.543187e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.791418e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.488549e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.488549e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.146687 sec
-     2,999,402,992      cycles:u                  #    2.596 GHz                    
-     7,687,479,910      instructions:u            #    2.56  insn per cycle         
-       1.202186321 seconds time elapsed
+TOTAL       :     1.156244 sec
+     3,007,790,025      cycles:u                  #    2.591 GHz                    
+     7,687,478,788      instructions:u            #    2.56  insn per cycle         
+       1.227392934 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2678) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl0_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.382347e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.263194e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.263194e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.373013e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.250158e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.250158e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     1.038298 sec
-     2,372,404,869      cycles:u                  #    2.266 GHz                    
-     4,248,255,529      instructions:u            #    1.79  insn per cycle         
-       1.166088603 seconds time elapsed
+TOTAL       :     1.037571 sec
+     2,372,038,369      cycles:u                  #    2.269 GHz                    
+     4,248,253,475      instructions:u            #    1.79  insn per cycle         
+       1.115090731 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3109) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl0_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.441296e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.338211e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.338211e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.466647e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.370431e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.370431e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     1.028024 sec
-     2,349,884,733      cycles:u                  #    2.267 GHz                    
-     4,138,678,997      instructions:u            #    1.76  insn per cycle         
-       1.081148539 seconds time elapsed
+TOTAL       :     1.020339 sec
+     2,334,830,179      cycles:u                  #    2.271 GHz                    
+     4,138,677,053      instructions:u            #    1.77  insn per cycle         
+       1.225945049 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3020) (512y:   24) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl0_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.441820e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.015901e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.015901e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.430591e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.004371e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.004371e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     1.243221 sec
-     2,109,814,157      cycles:u                  #    1.686 GHz                    
-     3,169,205,238      instructions:u            #    1.50  insn per cycle         
-       1.294243710 seconds time elapsed
+TOTAL       :     1.245556 sec
+     2,111,459,562      cycles:u                  #    1.685 GHz                    
+     3,169,203,839      instructions:u            #    1.50  insn per cycle         
+       1.281761369 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2086) (512y:   16) (512z: 2104)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:36:43
+DATE: 2022-05-10_22:10:50
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 8.670628e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.141565e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.723758e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.675941e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.137309e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.712722e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085652e+00 +- 4.835323e-03 )  GeV^0
-TOTAL       :     0.543400 sec
-       114,745,025      cycles:u                  #    0.148 GHz                    
-       135,804,627      instructions:u            #    1.18  insn per cycle         
-       0.832338595 seconds time elapsed
+TOTAL       :     0.436705 sec
+       115,182,615      cycles:u                  #    0.245 GHz                    
+       135,903,831      instructions:u            #    1.18  insn per cycle         
+       0.736427512 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.328589e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.477490e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.477490e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.327825e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.475970e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.475970e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.322683 sec
-     6,128,656,171      cycles:u                  #    2.627 GHz                    
-    16,404,333,333      instructions:u            #    2.68  insn per cycle         
-       2.335732610 seconds time elapsed
+TOTAL       :     2.323793 sec
+     6,128,297,956      cycles:u                  #    2.625 GHz                    
+    16,404,333,482      instructions:u            #    2.68  insn per cycle         
+       2.336976226 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  665) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl1_hrd0/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.851269e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.570455e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.570455e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.839493e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.559256e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.559256e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.150889 sec
-     2,992,556,466      cycles:u                  #    2.577 GHz                    
-     6,585,102,352      instructions:u            #    2.20  insn per cycle         
-       1.164079142 seconds time elapsed
+TOTAL       :     1.153662 sec
+     2,993,813,854      cycles:u                  #    2.573 GHz                    
+     6,585,102,719      instructions:u            #    2.20  insn per cycle         
+       1.166916066 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2821) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl1_hrd0/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.889814e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.976548e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.976548e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.895613e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.020923e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.020923e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.961489 sec
-     2,183,104,909      cycles:u                  #    2.246 GHz                    
-     3,703,739,577      instructions:u            #    1.70  insn per cycle         
-       0.974935269 seconds time elapsed
+TOTAL       :     0.961335 sec
+     2,177,754,076      cycles:u                  #    2.242 GHz                    
+     3,703,739,408      instructions:u            #    1.70  insn per cycle         
+       0.974745282 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3539) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl1_hrd0/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.038258e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.172094e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.172094e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.004308e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.125821e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.125821e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.939201 sec
-     2,132,794,108      cycles:u                  #    2.246 GHz                    
-     3,506,078,273      instructions:u            #    1.64  insn per cycle         
-       0.952429395 seconds time elapsed
+TOTAL       :     0.943991 sec
+     2,145,280,988      cycles:u                  #    2.247 GHz                    
+     3,506,078,108      instructions:u            #    1.63  insn per cycle         
+       0.957318991 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3313) (512y:   24) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl1_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.962780e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.711175e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.711175e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.982304e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.723308e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.723308e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     1.126908 sec
-     1,920,739,522      cycles:u                  #    1.689 GHz                    
-     3,062,118,801      instructions:u            #    1.59  insn per cycle         
-       1.139911699 seconds time elapsed
+TOTAL       :     1.123681 sec
+     1,912,524,593      cycles:u                  #    1.686 GHz                    
+     3,062,118,956      instructions:u            #    1.60  insn per cycle         
+       1.136857492 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3337) (512y:    0) (512z: 1993)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggtt_manu/log_ggtt_manu_f_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx'
 
-DATE: 2022-05-09_18:37:02
+DATE: 2022-05-10_22:11:10
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 8.679762e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.156755e+08                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.738561e+08                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.685802e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.157447e+08                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.740541e+08                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085652e+00 +- 4.835323e-03 )  GeV^0
-TOTAL       :     0.543049 sec
-       113,777,240      cycles:u                  #    0.147 GHz                    
-       135,255,893      instructions:u            #    1.19  insn per cycle         
-       0.831014716 seconds time elapsed
+TOTAL       :     0.552376 sec
+       114,172,957      cycles:u                  #    0.146 GHz                    
+       135,314,077      instructions:u            #    1.19  insn per cycle         
+       0.848424571 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 96
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 -------------------------------------------------------------------------
@@ -99,14 +99,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.445445e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.611542e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.611542e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.445461e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.610291e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.610291e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085710e+00 +- 4.835784e-03 )  GeV^0
-TOTAL       :     2.215143 sec
-     5,839,025,011      cycles:u                  #    2.623 GHz                    
-    17,208,899,627      instructions:u            #    2.95  insn per cycle         
-       2.229269386 seconds time elapsed
+TOTAL       :     2.215736 sec
+     5,836,250,475      cycles:u                  #    2.622 GHz                    
+    17,208,899,807      instructions:u            #    2.95  insn per cycle         
+       2.228950266 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  421) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.none_f_inl1_hrd1/runTest.exe
@@ -124,14 +124,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.953626e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.709699e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.709699e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.942560e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.695087e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.695087e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085711e+00 +- 4.835793e-03 )  GeV^0
-TOTAL       :     1.128690 sec
-     2,932,072,542      cycles:u                  #    2.574 GHz                    
-     6,369,610,680      instructions:u            #    2.17  insn per cycle         
-       1.141901714 seconds time elapsed
+TOTAL       :     1.130781 sec
+     2,933,626,625      cycles:u                  #    2.573 GHz                    
+     6,369,610,603      instructions:u            #    2.17  insn per cycle         
+       1.143856867 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 2352) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.sse4_f_inl1_hrd1/runTest.exe
@@ -149,14 +149,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.372732e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.667973e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.667973e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.360075e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.657650e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.657650e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.893965 sec
-     2,030,224,734      cycles:u                  #    2.245 GHz                    
-     3,477,076,819      instructions:u            #    1.71  insn per cycle         
-       0.907406146 seconds time elapsed
+TOTAL       :     0.895710 sec
+     2,031,476,722      cycles:u                  #    2.244 GHz                    
+     3,477,076,605      instructions:u            #    1.71  insn per cycle         
+       0.909121098 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2657) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.avx2_f_inl1_hrd1/runTest.exe
@@ -174,14 +174,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.323725e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.574358e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.574358e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.267096e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.535810e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.535810e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085720e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     0.899489 sec
-     2,045,008,921      cycles:u                  #    2.247 GHz                    
-     3,310,573,941      instructions:u            #    1.62  insn per cycle         
-       0.912562121 seconds time elapsed
+TOTAL       :     0.907650 sec
+     2,064,455,601      cycles:u                  #    2.248 GHz                    
+     3,310,574,058      instructions:u            #    1.60  insn per cycle         
+       0.920838890 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2468) (512y:   12) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512y_f_inl1_hrd1/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=1] [ha
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.019091e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.772076e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.772076e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.009566e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.761051e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.761051e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 2.085721e+00 +- 4.835915e-03 )  GeV^0
-TOTAL       :     1.114953 sec
-     1,900,178,922      cycles:u                  #    1.688 GHz                    
-     2,923,406,993      instructions:u            #    1.54  insn per cycle         
-       1.128110327 seconds time elapsed
+TOTAL       :     1.117532 sec
+     1,896,779,485      cycles:u                  #    1.682 GHz                    
+     2,923,407,249      instructions:u            #    1.54  insn per cycle         
+       1.130924818 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 2598) (512y:    0) (512z: 1461)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt/SubProcesses/P1_Sigma_sm_gg_ttx/build.512z_f_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-05-09_17:58:47
+DATE: 2022-05-10_21:32:43
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.858588e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.439588e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.571978e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.932081e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.488504e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.629898e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.574858 sec
-        97,323,185      cycles:u                  #    0.134 GHz                    
-        91,173,325      instructions:u            #    0.94  insn per cycle         
-       1.101951138 seconds time elapsed
+TOTAL       :     0.531258 sec
+        96,132,381      cycles:u                  #    0.133 GHz                    
+        91,334,870      instructions:u            #    0.95  insn per cycle         
+       0.892035765 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.606259e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.153413e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.164876e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.615870e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.155811e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.167066e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.734461e+02 +- 4.775415e+02 )  GeV^-2
-TOTAL       :     0.678375 sec
-       205,026,578      cycles:u                  #    0.223 GHz                    
-       323,408,090      instructions:u            #    1.58  insn per cycle         
-       0.983228981 seconds time elapsed
+TOTAL       :     0.669516 sec
+       208,928,987      cycles:u                  #    0.228 GHz                    
+       323,763,863      instructions:u            #    1.55  insn per cycle         
+       0.976229071 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.428830e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.458142e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.458142e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.428447e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.457175e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.457175e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.681497 sec
-     1,815,991,982      cycles:u                  #    2.645 GHz                    
-     5,772,156,275      instructions:u            #    3.18  insn per cycle         
-       0.757415660 seconds time elapsed
+TOTAL       :     0.680963 sec
+     1,815,406,226      cycles:u                  #    2.648 GHz                    
+     5,772,155,944      instructions:u            #    3.18  insn per cycle         
+       0.741559505 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  689) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.334235e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.427323e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.427323e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.330479e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.423662e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.423662e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.384480 sec
-     1,023,031,133      cycles:u                  #    2.627 GHz                    
-     3,023,614,993      instructions:u            #    2.96  insn per cycle         
-       0.404842337 seconds time elapsed
+TOTAL       :     0.384973 sec
+     1,023,464,484      cycles:u                  #    2.624 GHz                    
+     3,023,614,667      instructions:u            #    2.95  insn per cycle         
+       0.460789397 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4273) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.439649e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.794706e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.794706e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.436829e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.793659e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.793659e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.200499 sec
-       455,959,503      cycles:u                  #    2.220 GHz                    
-     1,070,443,053      instructions:u            #    2.35  insn per cycle         
-       0.266938864 seconds time elapsed
+TOTAL       :     0.200640 sec
+       456,437,259      cycles:u                  #    2.219 GHz                    
+     1,070,443,094      instructions:u            #    2.35  insn per cycle         
+       0.316868322 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3460) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 9.496337e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.939080e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.939080e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.464141e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.909966e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.909966e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.178861 sec
-       407,407,043      cycles:u                  #    2.209 GHz                    
-       994,233,532      instructions:u            #    2.44  insn per cycle         
-       0.226140140 seconds time elapsed
+TOTAL       :     0.179470 sec
+       407,512,464      cycles:u                  #    2.208 GHz                    
+       994,233,502      instructions:u            #    2.44  insn per cycle         
+       0.244299608 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3281) (512y:   53) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.918278e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.149363e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.149363e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.900497e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.130297e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.130297e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.243533 sec
-       393,417,568      cycles:u                  #    1.580 GHz                    
-       553,401,726      instructions:u            #    1.41  insn per cycle         
-       0.365131306 seconds time elapsed
+TOTAL       :     0.244122 sec
+       393,761,936      cycles:u                  #    1.579 GHz                    
+       553,401,736      instructions:u            #    1.41  insn per cycle         
+       0.314216489 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1116) (512y:   71) (512z: 2831)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_d_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-05-09_17:59:06
+DATE: 2022-05-10_21:33:01
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.843539e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.396634e+06                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.522575e+06                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.813268e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.322694e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.453373e+06                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.505356 sec
-        97,299,095      cycles:u                  #    0.133 GHz                    
-        90,837,585      instructions:u            #    0.93  insn per cycle         
-       0.912258684 seconds time elapsed
+TOTAL       :     0.506916 sec
+        95,622,919      cycles:u                  #    0.132 GHz                    
+        89,935,100      instructions:u            #    0.94  insn per cycle         
+       0.890286567 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.529532e+06                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.143559e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.154763e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.529431e+06                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.143006e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.154269e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.734461e+02 +- 4.775415e+02 )  GeV^-2
-TOTAL       :     0.672643 sec
-       202,342,507      cycles:u                  #    0.221 GHz                    
-       319,786,117      instructions:u            #    1.58  insn per cycle         
-       0.977492540 seconds time elapsed
+TOTAL       :     0.671685 sec
+       208,434,590      cycles:u                  #    0.226 GHz                    
+       316,533,494      instructions:u            #    1.52  insn per cycle         
+       0.981857245 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.437376e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.466684e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.466684e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.446424e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.476022e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.476022e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.678792 sec
-     1,801,655,428      cycles:u                  #    2.641 GHz                    
-     5,728,359,329      instructions:u            #    3.18  insn per cycle         
-       0.716163504 seconds time elapsed
+TOTAL       :     0.676347 sec
+     1,801,397,163      cycles:u                  #    2.646 GHz                    
+     5,728,358,917      instructions:u            #    3.18  insn per cycle         
+       0.729411746 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  633) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_d_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 4.401369e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.498325e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.498325e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.396279e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.491762e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.491762e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.378570 sec
-     1,006,342,821      cycles:u                  #    2.622 GHz                    
-     2,980,688,522      instructions:u            #    2.96  insn per cycle         
-       0.568266092 seconds time elapsed
+TOTAL       :     0.379039 sec
+     1,006,429,659      cycles:u                  #    2.622 GHz                    
+     2,980,688,461      instructions:u            #    2.96  insn per cycle         
+       0.562405322 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4108) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_d_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.825129e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.127963e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.127963e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.842779e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.145726e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.145726e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.215579 sec
-       490,310,574      cycles:u                  #    2.221 GHz                    
-     1,104,285,092      instructions:u            #    2.25  insn per cycle         
-       0.273187763 seconds time elapsed
+TOTAL       :     0.214554 sec
+       488,471,929      cycles:u                  #    2.227 GHz                    
+     1,104,284,615      instructions:u            #    2.26  insn per cycle         
+       0.280380036 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3596) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_d_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.639339e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.002096e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.002096e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.617610e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.981261e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.981261e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.195725 sec
-       445,901,643      cycles:u                  #    2.220 GHz                    
-     1,027,288,251      instructions:u            #    2.30  insn per cycle         
-       0.220583419 seconds time elapsed
+TOTAL       :     0.196290 sec
+       445,813,786      cycles:u                  #    2.215 GHz                    
+     1,027,287,996      instructions:u            #    2.30  insn per cycle         
+       0.243348392 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3278) (512y:  187) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_d_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.607139e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.818067e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.818067e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.670778e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.883392e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.883392e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.061783e+02 +- 3.760219e+02 )  GeV^-2
-TOTAL       :     0.254379 sec
-       410,160,828      cycles:u                  #    1.581 GHz                    
-       578,741,148      instructions:u            #    1.41  insn per cycle         
-       0.316979093 seconds time elapsed
+TOTAL       :     0.251519 sec
+       406,221,189      cycles:u                  #    1.584 GHz                    
+       578,740,668      instructions:u            #    1.42  insn per cycle         
+       0.303395003 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  947) (512y:  162) (512z: 2949)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_d_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_f_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_f_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-05-09_17:59:23
+DATE: 2022-05-10_21:33:21
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.445333e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.451589e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.589228e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.403689e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.460497e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.589299e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063193e+02 +- 3.761164e+02 )  GeV^-2
-TOTAL       :     0.505218 sec
-        95,158,400      cycles:u                  #    0.130 GHz                    
-        85,315,828      instructions:u            #    0.90  insn per cycle         
-       0.846846528 seconds time elapsed
+TOTAL       :     0.500512 sec
+        93,166,399      cycles:u                  #    0.129 GHz                    
+        85,506,285      instructions:u            #    0.92  insn per cycle         
+       0.886730848 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.264431e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.613232e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.707563e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.268253e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.613957e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.708575e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.630098e+02 +- 4.770718e+02 )  GeV^-2
-TOTAL       :     0.567989 sec
-       132,678,305      cycles:u                  #    0.165 GHz                    
-       176,262,225      instructions:u            #    1.33  insn per cycle         
-       0.861050698 seconds time elapsed
+TOTAL       :     0.560758 sec
+       129,618,135      cycles:u                  #    0.163 GHz                    
+       175,664,463      instructions:u            #    1.36  insn per cycle         
+       0.851779090 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.469682e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.494016e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.494016e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.467186e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.491414e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.491414e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062573e+02 +- 3.760985e+02 )  GeV^-2
-TOTAL       :     0.668788 sec
-     1,787,017,150      cycles:u                  #    2.652 GHz                    
-     5,769,318,946      instructions:u            #    3.23  insn per cycle         
-       0.710434371 seconds time elapsed
+TOTAL       :     0.669385 sec
+     1,786,857,661      cycles:u                  #    2.650 GHz                    
+     5,769,319,304      instructions:u            #    3.23  insn per cycle         
+       0.786536624 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  641) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.940586e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.202018e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.202018e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.930301e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.188577e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.188577e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062574e+02 +- 3.760986e+02 )  GeV^-2
-TOTAL       :     0.211066 sec
-       562,439,597      cycles:u                  #    2.607 GHz                    
-     1,642,581,692      instructions:u            #    2.92  insn per cycle         
-       0.351202021 seconds time elapsed
+TOTAL       :     0.211381 sec
+       562,316,065      cycles:u                  #    2.580 GHz                    
+     1,642,581,783      instructions:u            #    2.92  insn per cycle         
+       0.288998179 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 5047) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.625130e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.736747e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.736747e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.627139e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.737984e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.737984e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062817e+02 +- 3.761081e+02 )  GeV^-2
-TOTAL       :     0.105551 sec
-       242,059,931      cycles:u                  #    2.194 GHz                    
-       572,860,140      instructions:u            #    2.37  insn per cycle         
-       0.128400679 seconds time elapsed
+TOTAL       :     0.105439 sec
+       241,570,434      cycles:u                  #    2.193 GHz                    
+       572,860,498      instructions:u            #    2.37  insn per cycle         
+       0.169645230 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3749) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.787628e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.922178e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.922178e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.782613e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.916887e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.916887e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062817e+02 +- 3.761081e+02 )  GeV^-2
-TOTAL       :     0.096342 sec
-       221,411,879      cycles:u                  #    2.191 GHz                    
-       531,877,904      instructions:u            #    2.40  insn per cycle         
-       0.192917658 seconds time elapsed
+TOTAL       :     0.096713 sec
+       221,457,045      cycles:u                  #    2.182 GHz                    
+       531,878,148      instructions:u            #    2.40  insn per cycle         
+       0.143607259 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3552) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_f_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.401883e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.482644e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.482644e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.400434e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.482723e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.482723e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062815e+02 +- 3.761080e+02 )  GeV^-2
-TOTAL       :     0.121781 sec
-       201,680,047      cycles:u                  #    1.593 GHz                    
-       307,467,232      instructions:u            #    1.52  insn per cycle         
-       0.153028549 seconds time elapsed
+TOTAL       :     0.121923 sec
+       201,656,273      cycles:u                  #    1.588 GHz                    
+       307,467,038      instructions:u            #    1.52  insn per cycle         
+       0.205488209 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1429) (512y:   16) (512z: 2949)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_f_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttg_manu/log_ggttg_manu_f_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg'
 
-DATE: 2022-05-09_17:59:41
+DATE: 2022-05-10_21:33:38
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.374954e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.410271e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.530030e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.436862e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.470848e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.594417e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063193e+02 +- 3.761164e+02 )  GeV^-2
-TOTAL       :     0.507131 sec
-        95,523,582      cycles:u                  #    0.132 GHz                    
-        84,611,804      instructions:u            #    0.89  insn per cycle         
-       0.876228618 seconds time elapsed
+TOTAL       :     0.499645 sec
+        93,464,417      cycles:u                  #    0.129 GHz                    
+        84,805,293      instructions:u            #    0.91  insn per cycle         
+       0.857423605 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.283619e+07                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.650248e+07                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.746337e+07                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.278711e+07                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.619783e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.713290e+07                 )  sec^-1
 MeanMatrixElemValue         = ( 6.630098e+02 +- 4.770718e+02 )  GeV^-2
-TOTAL       :     0.567200 sec
-       133,266,499      cycles:u                  #    0.167 GHz                    
-       176,445,830      instructions:u            #    1.32  insn per cycle         
-       0.856807902 seconds time elapsed
+TOTAL       :     0.564759 sec
+       131,266,000      cycles:u                  #    0.165 GHz                    
+       176,710,007      instructions:u            #    1.35  insn per cycle         
+       0.854774190 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.483542e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.508128e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.508128e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.495197e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.520510e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.520510e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062573e+02 +- 3.760985e+02 )  GeV^-2
-TOTAL       :     0.664753 sec
-     1,767,165,986      cycles:u                  #    2.648 GHz                    
-     5,725,523,143      instructions:u            #    3.24  insn per cycle         
-       0.726809562 seconds time elapsed
+TOTAL       :     0.661661 sec
+     1,767,354,903      cycles:u                  #    2.653 GHz                    
+     5,725,523,155      instructions:u            #    3.24  insn per cycle         
+       0.707144683 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:  607) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.none_f_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 8.306860e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 8.590723e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 8.590723e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 8.292756e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 8.583817e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.583817e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062574e+02 +- 3.760986e+02 )  GeV^-2
-TOTAL       :     0.201755 sec
-       537,747,245      cycles:u                  #    2.604 GHz                    
-     1,614,587,462      instructions:u            #    3.00  insn per cycle         
-       0.286410595 seconds time elapsed
+TOTAL       :     0.202105 sec
+       538,276,192      cycles:u                  #    2.602 GHz                    
+     1,614,587,380      instructions:u            #    3.00  insn per cycle         
+       0.367421383 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4796) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.sse4_f_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.364162e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.440457e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.440457e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.361897e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.438135e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.438135e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062817e+02 +- 3.761081e+02 )  GeV^-2
-TOTAL       :     0.124586 sec
-       285,737,954      cycles:u                  #    2.210 GHz                    
-       621,728,888      instructions:u            #    2.18  insn per cycle         
-       0.190238518 seconds time elapsed
+TOTAL       :     0.124810 sec
+       285,694,981      cycles:u                  #    2.199 GHz                    
+       621,728,715      instructions:u            #    2.18  insn per cycle         
+       0.227072117 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 4312) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.avx2_f_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.468744e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.558713e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.558713e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.471539e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.561953e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.561953e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062817e+02 +- 3.761081e+02 )  GeV^-2
-TOTAL       :     0.116059 sec
-       265,806,783      cycles:u                  #    2.203 GHz                    
-       580,483,518      instructions:u            #    2.18  insn per cycle         
-       0.168719975 seconds time elapsed
+TOTAL       :     0.115897 sec
+       265,956,725      cycles:u                  #    2.204 GHz                    
+       580,483,540      instructions:u            #    2.18  insn per cycle         
+       0.225250599 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 4122) (512y:   14) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512y_f_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [h
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.170159e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.226116e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.226116e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.167186e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.223045e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.223045e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.062815e+02 +- 3.761080e+02 )  GeV^-2
-TOTAL       :     0.144715 sec
-       237,859,807      cycles:u                  #    1.588 GHz                    
-       352,147,028      instructions:u            #    1.48  insn per cycle         
-       0.192548368 seconds time elapsed
+TOTAL       :     0.145082 sec
+       237,939,523      cycles:u                  #    1.586 GHz                    
+       352,146,902      instructions:u            #    1.48  insn per cycle         
+       0.207539687 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1881) (512y:    9) (512z: 3307)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg/SubProcesses/P1_Sigma_sm_gg_ttxg/build.512z_f_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_17:59:58
+DATE: 2022-05-10_21:33:57
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.283112e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.329485e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.333190e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.289458e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.334530e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.337501e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.640902 sec
-       174,347,381      cycles:u                  #    0.213 GHz                    
-       242,690,082      instructions:u            #    1.39  insn per cycle         
-       1.332335282 seconds time elapsed
+TOTAL       :     0.657010 sec
+       170,440,301      cycles:u                  #    0.206 GHz                    
+       240,300,665      instructions:u            #    1.41  insn per cycle         
+       1.115784878 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.806898e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.855340e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.857467e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.809439e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.858721e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.860747e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.757700 sec
-     2,056,761,947      cycles:u                  #    0.682 GHz                    
-     4,464,341,660      instructions:u            #    2.17  insn per cycle         
-       3.072683949 seconds time elapsed
+TOTAL       :     2.761710 sec
+     2,084,215,620      cycles:u                  #    0.690 GHz                    
+     4,365,360,984      instructions:u            #    2.09  insn per cycle         
+       3.077233939 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.792147e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.794114e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.794114e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.791808e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.793760e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.793760e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.158329 sec
-    24,478,481,910      cycles:u                  #    2.672 GHz                    
-    76,143,156,702      instructions:u            #    3.11  insn per cycle         
-       9.228475613 seconds time elapsed
+TOTAL       :     9.160832 sec
+    24,479,119,881      cycles:u                  #    2.671 GHz                    
+    76,143,156,180      instructions:u            #    3.11  insn per cycle         
+       9.250016110 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1190) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.316452e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.323168e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.323168e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.317575e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.324285e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.324285e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.952342 sec
-    13,230,038,389      cycles:u                  #    2.669 GHz                    
-    40,281,734,979      instructions:u            #    3.04  insn per cycle         
-       5.026934898 seconds time elapsed
+TOTAL       :     4.950583 sec
+    13,227,668,226      cycles:u                  #    2.669 GHz                    
+    40,281,734,938      instructions:u            #    3.05  insn per cycle         
+       5.075683411 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8051) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.731697e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.758525e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.758525e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.736467e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.763472e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.763472e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.442941 sec
-     5,553,367,407      cycles:u                  #    2.269 GHz                    
-    13,858,332,079      instructions:u            #    2.50  insn per cycle         
-       2.515738306 seconds time elapsed
+TOTAL       :     2.441191 sec
+     5,552,605,471      cycles:u                  #    2.270 GHz                    
+    13,858,331,787      instructions:u            #    2.50  insn per cycle         
+       2.581975327 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6296) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.543452e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.577188e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.577188e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.544238e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.577968e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.577968e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.180809 sec
-     4,960,396,969      cycles:u                  #    2.270 GHz                    
-    12,547,054,938      instructions:u            #    2.53  insn per cycle         
-       2.412606637 seconds time elapsed
+TOTAL       :     2.181211 sec
+     4,959,989,544      cycles:u                  #    2.267 GHz                    
+    12,547,055,253      instructions:u            #    2.53  insn per cycle         
+       2.255695362 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6076) (512y:   46) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.458113e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.482754e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.482754e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.458307e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.483793e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.483793e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.546431 sec
-     4,026,408,677      cycles:u                  #    1.578 GHz                    
-     6,391,812,650      instructions:u            #    1.59  insn per cycle         
-       2.608891603 seconds time elapsed
+TOTAL       :     2.547031 sec
+     4,026,759,466      cycles:u                  #    1.578 GHz                    
+     6,391,813,475      instructions:u            #    1.59  insn per cycle         
+       2.644123578 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1225) (512y:   75) (512z: 5699)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:45:41
+DATE: 2022-05-10_22:19:55
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -80,14 +80,14 @@ WARNING! Set grid in Bridge (nevt=16384, gpublocks=64, gputhreads=256, gpublocks
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.357420e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.325515e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.325515e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.358288e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.319407e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.319407e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.589566 sec
-       180,545,355      cycles:u                  #    0.222 GHz                    
-       269,129,597      instructions:u            #    1.49  insn per cycle         
-       0.871983396 seconds time elapsed
+TOTAL       :     0.588727 sec
+       179,151,971      cycles:u                  #    0.220 GHz                    
+       267,943,236      instructions:u            #    1.50  insn per cycle         
+       0.871158531 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -99,14 +99,14 @@ WARNING! Set grid in Bridge (nevt=524288, gpublocks=2048, gputhreads=256, gpublo
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.644587e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.832914e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.832914e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.601195e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.847071e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.847071e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.206839 sec
-     3,172,538,520      cycles:u                  #    0.912 GHz                    
-     6,200,046,828      instructions:u            #    1.95  insn per cycle         
-       3.536731324 seconds time elapsed
+TOTAL       :     3.230917 sec
+     3,285,139,055      cycles:u                  #    0.939 GHz                    
+     6,339,565,792      instructions:u            #    1.93  insn per cycle         
+       3.560787177 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -121,14 +121,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.670814e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.672522e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.672522e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.791530e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.793530e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.793530e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.827213 sec
-    26,262,191,370      cycles:u                  #    2.671 GHz                    
-    76,146,467,995      instructions:u            #    2.90  insn per cycle         
-       9.835118794 seconds time elapsed
+TOTAL       :     9.165855 sec
+    24,485,306,981      cycles:u                  #    2.670 GHz                    
+    76,146,467,133      instructions:u            #    3.11  insn per cycle         
+       9.174878631 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1190) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -147,14 +147,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.314872e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.321711e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.321711e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.315436e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.322226e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.322226e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.958927 sec
-    13,241,127,220      cycles:u                  #    2.668 GHz                    
-    40,290,331,464      instructions:u            #    3.04  insn per cycle         
-       4.966925441 seconds time elapsed
+TOTAL       :     4.958059 sec
+    13,239,432,297      cycles:u                  #    2.668 GHz                    
+    40,290,331,331      instructions:u            #    3.04  insn per cycle         
+       4.965616188 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8051) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -173,14 +173,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.728624e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.756024e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.756024e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.726671e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.754074e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.754074e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.449090 sec
-     5,563,352,042      cycles:u                  #    2.268 GHz                    
-    13,865,081,878      instructions:u            #    2.49  insn per cycle         
-       2.456915409 seconds time elapsed
+TOTAL       :     2.449397 sec
+     5,563,239,673      cycles:u                  #    2.267 GHz                    
+    13,865,081,774      instructions:u            #    2.49  insn per cycle         
+       2.457261966 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6296) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.542001e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.576171e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.576171e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.542937e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.577181e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.577181e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.185978 sec
-     4,966,817,115      cycles:u                  #    2.267 GHz                    
-    12,553,805,626      instructions:u            #    2.53  insn per cycle         
-       2.193529251 seconds time elapsed
+TOTAL       :     2.185756 sec
+     4,964,292,482      cycles:u                  #    2.266 GHz                    
+    12,553,805,472      instructions:u            #    2.53  insn per cycle         
+       2.193517682 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6076) (512y:   46) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -225,14 +225,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.459026e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.484193e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.484193e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.453226e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.478143e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.478143e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.550956 sec
-     4,031,808,435      cycles:u                  #    1.577 GHz                    
-     6,399,151,188      instructions:u            #    1.59  insn per cycle         
-       2.558689614 seconds time elapsed
+TOTAL       :     2.552850 sec
+     4,032,118,023      cycles:u                  #    1.576 GHz                    
+     6,399,151,646      instructions:u            #    1.59  insn per cycle         
+       2.561295607 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1225) (512y:   75) (512z: 5699)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:55:05
+DATE: 2022-05-10_22:29:22
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.312924e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.356178e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.358975e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.295858e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.340150e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.342974e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     0.581729 sec
-       154,925,177      cycles:u                  #    0.193 GHz                    
-       226,975,909      instructions:u            #    1.47  insn per cycle         
-       0.865677096 seconds time elapsed
+TOTAL       :     0.578277 sec
+       156,563,969      cycles:u                  #    0.195 GHz                    
+       224,686,874      instructions:u            #    1.44  insn per cycle         
+       0.866748473 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.829560e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.874995e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.876913e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.833785e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.879221e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.881205e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 1.252232e+02 +- 1.234346e+02 )  GeV^-4
-TOTAL       :     2.902360 sec
-     2,382,618,506      cycles:u                  #    0.753 GHz                    
-     4,894,054,023      instructions:u            #    2.05  insn per cycle         
-       3.220778809 seconds time elapsed
+TOTAL       :     2.910689 sec
+     2,405,548,637      cycles:u                  #    0.762 GHz                    
+     4,801,862,126      instructions:u            #    2.00  insn per cycle         
+       3.221659533 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.792388e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.794382e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.794382e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.790641e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.792624e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.792624e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     9.158744 sec
-    24,482,469,565      cycles:u                  #    2.672 GHz                    
-    76,142,792,578      instructions:u            #    3.11  insn per cycle         
-       9.166101114 seconds time elapsed
+TOTAL       :     9.167569 sec
+    24,490,048,493      cycles:u                  #    2.670 GHz                    
+    76,142,792,659      instructions:u            #    3.11  insn per cycle         
+       9.174989548 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1190) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.315930e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.322687e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.322687e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.312654e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.319371e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.319371e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     4.954676 sec
-    13,229,640,179      cycles:u                  #    2.669 GHz                    
-    40,280,846,140      instructions:u            #    3.04  insn per cycle         
-       4.962309610 seconds time elapsed
+TOTAL       :     4.959608 sec
+    13,243,381,066      cycles:u                  #    2.668 GHz                    
+    40,280,845,907      instructions:u            #    3.04  insn per cycle         
+       4.966801199 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8051) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.714307e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.741451e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.741451e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.723796e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.751118e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.751118e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     2.451410 sec
-     5,577,296,233      cycles:u                  #    2.271 GHz                    
-    13,857,175,232      instructions:u            #    2.48  insn per cycle         
-       2.458611853 seconds time elapsed
+TOTAL       :     2.447864 sec
+     5,555,355,718      cycles:u                  #    2.267 GHz                    
+    13,857,175,294      instructions:u            #    2.49  insn per cycle         
+       2.455051299 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6296) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.545273e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.579236e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.579236e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.540673e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.574674e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.574674e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     2.182688 sec
-     4,962,349,244      cycles:u                  #    2.269 GHz                    
-    12,544,587,513      instructions:u            #    2.53  insn per cycle         
-       2.189967329 seconds time elapsed
+TOTAL       :     2.183698 sec
+     4,961,564,870      cycles:u                  #    2.267 GHz                    
+    12,544,587,614      instructions:u            #    2.53  insn per cycle         
+       2.190867851 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6076) (512y:   46) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.461659e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.486904e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.486904e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.455292e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.480140e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.480140e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.197467e-01 +- 3.250467e-01 )  GeV^-4
-TOTAL       :     2.547106 sec
-     4,028,455,027      cycles:u                  #    1.579 GHz                    
-     6,389,345,799      instructions:u            #    1.59  insn per cycle         
-       2.554539877 seconds time elapsed
+TOTAL       :     2.549670 sec
+     4,028,512,506      cycles:u                  #    1.577 GHz                    
+     6,389,345,919      instructions:u            #    1.59  insn per cycle         
+       2.557040713 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1225) (512y:   75) (512z: 5699)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:51:55
+DATE: 2022-05-10_22:26:09
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.294083e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.337904e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.340894e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.297021e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.340852e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.343749e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.577347 sec
-       151,773,543      cycles:u                  #    0.188 GHz                    
-       226,888,747      instructions:u            #    1.49  insn per cycle         
-       0.869327760 seconds time elapsed
+TOTAL       :     0.584973 sec
+       152,399,741      cycles:u                  #    0.190 GHz                    
+       224,108,077      instructions:u            #    1.47  insn per cycle         
+       0.867443875 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.860756e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.906166e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.908205e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.837816e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.883358e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.885272e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.797211 sec
-     2,236,345,696      cycles:u                  #    0.733 GHz                    
-     4,871,754,055      instructions:u            #    2.18  insn per cycle         
-       3.110229695 seconds time elapsed
+TOTAL       :     2.804740 sec
+     2,263,489,490      cycles:u                  #    0.740 GHz                    
+     4,982,932,012      instructions:u            #    2.20  insn per cycle         
+       3.116437419 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.790626e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.792582e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.792582e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.790511e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.792456e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.792456e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.166019 sec
-    24,487,650,520      cycles:u                  #    2.670 GHz                    
-    76,143,157,924      instructions:u            #    3.11  insn per cycle         
-       9.173273565 seconds time elapsed
+TOTAL       :     9.166508 sec
+    24,480,178,330      cycles:u                  #    2.670 GHz                    
+    76,143,157,712      instructions:u            #    3.11  insn per cycle         
+       9.173866248 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1190) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.322239e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.329085e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.329085e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.314709e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.321632e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.321632e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.943583 sec
-    13,212,515,727      cycles:u                  #    2.670 GHz                    
-    40,281,735,518      instructions:u            #    3.05  insn per cycle         
-       4.950786878 seconds time elapsed
+TOTAL       :     4.954680 sec
+    13,230,592,847      cycles:u                  #    2.668 GHz                    
+    40,281,735,562      instructions:u            #    3.04  insn per cycle         
+       4.962056268 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8051) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.732959e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.760220e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.760220e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.737547e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.765085e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.765085e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.442993 sec
-     5,554,804,616      cycles:u                  #    2.268 GHz                    
-    13,858,333,572      instructions:u            #    2.49  insn per cycle         
-       2.454732877 seconds time elapsed
+TOTAL       :     2.441359 sec
+     5,552,616,080      cycles:u                  #    2.270 GHz                    
+    13,858,333,436      instructions:u            #    2.50  insn per cycle         
+       2.448580640 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6296) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.545595e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.579587e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.579587e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.547299e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.581842e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.581842e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.180659 sec
-     4,959,502,923      cycles:u                  #    2.270 GHz                    
-    12,547,056,050      instructions:u            #    2.53  insn per cycle         
-       2.187882223 seconds time elapsed
+TOTAL       :     2.180031 sec
+     4,958,897,519      cycles:u                  #    2.270 GHz                    
+    12,547,056,387      instructions:u            #    2.53  insn per cycle         
+       2.187255965 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6076) (512y:   46) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.458663e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.483837e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.483837e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.455969e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.481138e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.481138e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.546837 sec
-     4,026,103,202      cycles:u                  #    1.578 GHz                    
-     6,391,814,252      instructions:u            #    1.59  insn per cycle         
-       2.554491932 seconds time elapsed
+TOTAL       :     2.547575 sec
+     4,026,347,477      cycles:u                  #    1.578 GHz                    
+     6,391,814,099      instructions:u            #    1.59  insn per cycle         
+       2.554777730 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1225) (512y:   75) (512z: 5699)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:48:50
+DATE: 2022-05-10_22:23:03
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.420527e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.357289e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.360215e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.399139e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.343875e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.346855e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.592967 sec
-       177,784,889      cycles:u                  #    0.219 GHz                    
-       262,707,621      instructions:u            #    1.48  insn per cycle         
-       0.876263875 seconds time elapsed
+TOTAL       :     0.587545 sec
+       177,275,276      cycles:u                  #    0.219 GHz                    
+       265,667,506      instructions:u            #    1.50  insn per cycle         
+       0.871105987 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -93,14 +93,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.741046e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.902527e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.904537e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.741358e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.902625e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.904562e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.117965 sec
-     3,074,404,545      cycles:u                  #    0.912 GHz                    
-     6,073,611,157      instructions:u            #    1.98  insn per cycle         
-       3.431447785 seconds time elapsed
+TOTAL       :     3.118958 sec
+     3,041,698,716      cycles:u                  #    0.902 GHz                    
+     6,055,260,738      instructions:u            #    1.99  insn per cycle         
+       3.429668207 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -114,14 +114,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.790624e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.792579e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.792579e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.792111e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.794067e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.794067e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.165931 sec
-    24,490,802,786      cycles:u                  #    2.671 GHz                    
-    76,143,157,726      instructions:u            #    3.11  insn per cycle         
-       9.173118942 seconds time elapsed
+TOTAL       :     9.158339 sec
+    24,477,720,540      cycles:u                  #    2.672 GHz                    
+    76,143,157,326      instructions:u            #    3.11  insn per cycle         
+       9.165498699 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1190) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -139,14 +139,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.314911e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.321638e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.321638e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.316215e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.322923e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.322923e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.954391 sec
-    13,231,883,258      cycles:u                  #    2.669 GHz                    
-    40,281,735,964      instructions:u            #    3.04  insn per cycle         
-       4.961682883 seconds time elapsed
+TOTAL       :     4.952367 sec
+    13,225,270,253      cycles:u                  #    2.668 GHz                    
+    40,281,735,933      instructions:u            #    3.05  insn per cycle         
+       4.959967186 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8051) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -164,14 +164,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.602473e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.628627e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.628627e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.736543e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.763837e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.763837e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.491025 sec
-     5,667,133,908      cycles:u                  #    2.269 GHz                    
-    13,858,333,759      instructions:u            #    2.45  insn per cycle         
-       2.502701562 seconds time elapsed
+TOTAL       :     2.441652 sec
+     5,549,449,216      cycles:u                  #    2.269 GHz                    
+    13,858,333,654      instructions:u            #    2.50  insn per cycle         
+       2.449066567 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6296) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -189,14 +189,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.545756e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.579423e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.579423e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.541304e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.575095e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.575095e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.180542 sec
-     4,959,580,244      cycles:u                  #    2.270 GHz                    
-    12,547,056,263      instructions:u            #    2.53  insn per cycle         
-       2.188039502 seconds time elapsed
+TOTAL       :     2.181767 sec
+     4,960,813,453      cycles:u                  #    2.269 GHz                    
+    12,547,056,151      instructions:u            #    2.53  insn per cycle         
+       2.189001782 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6076) (512y:   46) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -214,14 +214,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.450736e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.475473e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.475473e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.455112e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.480140e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.480140e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.549692 sec
-     4,025,879,380      cycles:u                  #    1.577 GHz                    
-     6,391,814,632      instructions:u            #    1.59  insn per cycle         
-       2.557109137 seconds time elapsed
+TOTAL       :     2.547974 sec
+     4,026,901,757      cycles:u                  #    1.578 GHz                    
+     6,391,814,528      instructions:u            #    1.59  insn per cycle         
+       2.555366498 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1225) (512y:   75) (512z: 5699)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:00:40
+DATE: 2022-05-10_21:34:40
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.313202e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.357634e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.360890e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.368061e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.415488e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.418791e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.801622 sec
-       172,055,310      cycles:u                  #    0.212 GHz                    
-       234,910,484      instructions:u            #    1.37  insn per cycle         
-       1.213837525 seconds time elapsed
+TOTAL       :     0.233561 sec
+       167,527,545      cycles:u                  #    0.337 GHz                    
+       236,030,242      instructions:u            #    1.41  insn per cycle         
+       0.626141102 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.875570e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.926296e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.928330e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.898957e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.949888e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.951987e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     2.729229 sec
-     2,145,356,063      cycles:u                  #    0.718 GHz                    
-     4,384,745,814      instructions:u            #    2.04  insn per cycle         
-       3.043854015 seconds time elapsed
+TOTAL       :     2.729128 sec
+     2,055,100,018      cycles:u                  #    0.688 GHz                    
+     4,420,211,742      instructions:u            #    2.15  insn per cycle         
+       3.044888541 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.800296e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.802297e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.802297e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.765013e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.766937e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.766937e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.116664 sec
-    24,371,382,786      cycles:u                  #    2.672 GHz                    
-    76,098,312,080      instructions:u            #    3.12  insn per cycle         
-       9.195190703 seconds time elapsed
+TOTAL       :     9.298708 sec
+    24,851,189,975      cycles:u                  #    2.671 GHz                    
+    76,098,312,560      instructions:u            #    3.06  insn per cycle         
+       9.348653864 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1143) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.312016e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.318718e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.318718e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.304440e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.311091e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.311091e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.959203 sec
-    13,247,083,133      cycles:u                  #    2.669 GHz                    
-    40,210,293,569      instructions:u            #    3.04  insn per cycle         
-       5.121275540 seconds time elapsed
+TOTAL       :     4.970007 sec
+    13,265,540,268      cycles:u                  #    2.667 GHz                    
+    40,210,293,617      instructions:u            #    3.03  insn per cycle         
+       5.081570308 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 7863) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.682442e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.709529e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.709529e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.682500e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.708857e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.708857e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.460627 sec
-     5,595,905,137      cycles:u                  #    2.271 GHz                    
-    13,946,432,821      instructions:u            #    2.49  insn per cycle         
-       2.617936816 seconds time elapsed
+TOTAL       :     2.460696 sec
+     5,595,778,393      cycles:u                  #    2.270 GHz                    
+    13,946,432,955      instructions:u            #    2.49  insn per cycle         
+       2.592562329 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6426) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.434162e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.467129e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.467129e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.431276e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.464234e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.464234e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.213088 sec
-     5,035,391,452      cycles:u                  #    2.270 GHz                    
-    12,628,596,697      instructions:u            #    2.51  insn per cycle         
-       2.309215608 seconds time elapsed
+TOTAL       :     2.213885 sec
+     5,036,280,258      cycles:u                  #    2.270 GHz                    
+    12,628,596,821      instructions:u            #    2.51  insn per cycle         
+       2.317846023 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6062) (512y:  180) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.392254e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.416564e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.416564e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.409474e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.433967e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.433967e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.572897 sec
-     4,066,310,150      cycles:u                  #    1.578 GHz                    
-     6,455,163,113      instructions:u            #    1.59  insn per cycle         
-       2.634433194 seconds time elapsed
+TOTAL       :     2.566006 sec
+     4,053,794,547      cycles:u                  #    1.577 GHz                    
+     6,455,163,231      instructions:u            #    1.59  insn per cycle         
+       2.667126433 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1058) (512y:  165) (512z: 5830)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:37:22
+DATE: 2022-05-10_22:11:29
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.445081e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.478937e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.481396e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.426311e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.458947e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.461352e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.610894 sec
-       192,877,380      cycles:u                  #    0.228 GHz                    
-       282,486,190      instructions:u            #    1.46  insn per cycle         
-       0.904734704 seconds time elapsed
+TOTAL       :     0.617229 sec
+       189,308,213      cycles:u                  #    0.223 GHz                    
+       271,911,673      instructions:u            #    1.44  insn per cycle         
+       0.911313202 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.731635e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.762187e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.763417e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.731664e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.762167e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.763442e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.390243 sec
-     2,638,362,163      cycles:u                  #    0.720 GHz                    
-     5,717,441,102      instructions:u            #    2.17  insn per cycle         
-       3.723275060 seconds time elapsed
+TOTAL       :     3.387316 sec
+     2,633,591,458      cycles:u                  #    0.719 GHz                    
+     5,627,996,933      instructions:u            #    2.14  insn per cycle         
+       3.719053832 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.719029e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.719878e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.719878e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.720279e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.721144e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.721144e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :    44.105324 sec
-   117,697,150,801      cycles:u                  #    2.669 GHz                    
-   154,067,600,139      instructions:u            #    1.31  insn per cycle         
-      44.112988058 seconds time elapsed
+TOTAL       :    44.090260 sec
+   117,600,550,676      cycles:u                  #    2.667 GHz                    
+   154,067,600,421      instructions:u            #    1.31  insn per cycle         
+      44.097562625 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:15980) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.970440e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.975834e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.975834e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.966549e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.971956e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.971956e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     5.528600 sec
-    14,758,280,999      cycles:u                  #    2.667 GHz                    
-    40,174,300,005      instructions:u            #    2.72  insn per cycle         
-       5.536041521 seconds time elapsed
+TOTAL       :     5.535800 sec
+    14,767,468,305      cycles:u                  #    2.665 GHz                    
+    40,174,300,170      instructions:u            #    2.72  insn per cycle         
+       5.543092343 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:69772) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl1_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.058497e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.080595e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.080595e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.071233e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.093371e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.093371e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.714655 sec
-     6,165,227,377      cycles:u                  #    2.267 GHz                    
-    13,298,786,292      instructions:u            #    2.16  insn per cycle         
-       2.722166467 seconds time elapsed
+TOTAL       :     2.708765 sec
+     6,155,766,892      cycles:u                  #    2.268 GHz                    
+    13,298,786,361      instructions:u            #    2.16  insn per cycle         
+       2.716300311 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:45953) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl1_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.408987e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.441712e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.441712e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.404599e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.437939e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.437939e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.221045 sec
-     5,046,557,117      cycles:u                  #    2.268 GHz                    
-    11,372,705,693      instructions:u            #    2.25  insn per cycle         
-       2.228580934 seconds time elapsed
+TOTAL       :     2.222621 sec
+     5,049,067,059      cycles:u                  #    2.267 GHz                    
+    11,372,705,455      instructions:u            #    2.25  insn per cycle         
+       2.230652069 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:38443) (512y:  210) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl1_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.585455e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.611550e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.611550e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.581527e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.607507e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.607507e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.498359 sec
-     3,944,363,303      cycles:u                  #    1.576 GHz                    
-     5,837,905,638      instructions:u            #    1.48  insn per cycle         
-       2.505880736 seconds time elapsed
+TOTAL       :     2.499628 sec
+     3,945,748,704      cycles:u                  #    1.576 GHz                    
+     5,837,905,371      instructions:u            #    1.48  insn per cycle         
+       2.507066306 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1915) (512y:  306) (512z:37497)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_d_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:38:48
+DATE: 2022-05-10_22:12:54
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.449356e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.484188e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.486325e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.453531e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.486730e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.488809e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.609600 sec
-       188,493,911      cycles:u                  #    0.223 GHz                    
-       279,758,894      instructions:u            #    1.48  insn per cycle         
-       0.902126776 seconds time elapsed
+TOTAL       :     0.614652 sec
+       189,968,823      cycles:u                  #    0.224 GHz                    
+       279,017,620      instructions:u            #    1.47  insn per cycle         
+       0.907450207 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.727455e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.757193e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.758415e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.728231e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.757958e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.759221e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.601482 sec
-     2,756,910,283      cycles:u                  #    0.751 GHz                    
-     5,842,666,290      instructions:u            #    2.12  insn per cycle         
-       3.924477663 seconds time elapsed
+TOTAL       :     3.406803 sec
+     2,620,773,004      cycles:u                  #    0.714 GHz                    
+     5,710,912,606      instructions:u            #    2.18  insn per cycle         
+       3.729354501 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.741756e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.742615e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.742615e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.738368e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.739223e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.739223e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :    43.838078 sec
-   116,951,671,298      cycles:u                  #    2.668 GHz                    
-   153,510,547,715      instructions:u            #    1.31  insn per cycle         
-      43.845898281 seconds time elapsed
+TOTAL       :    43.877640 sec
+   117,033,858,583      cycles:u                  #    2.667 GHz                    
+   153,510,548,391      instructions:u            #    1.31  insn per cycle         
+      43.886096091 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:15827) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_d_inl1_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.020384e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.025996e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.025996e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.014723e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.020328e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.020328e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     5.437163 sec
-    14,520,399,110      cycles:u                  #    2.668 GHz                    
-    39,650,313,278      instructions:u            #    2.73  insn per cycle         
-       5.444631483 seconds time elapsed
+TOTAL       :     5.447386 sec
+    14,536,652,905      cycles:u                  #    2.666 GHz                    
+    39,650,313,419      instructions:u            #    2.73  insn per cycle         
+       5.455238666 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:68745) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_d_inl1_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.176223e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.199786e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.199786e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.173411e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.196337e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.196337e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.662915 sec
-     6,046,622,371      cycles:u                  #    2.267 GHz                    
-    13,065,012,086      instructions:u            #    2.16  insn per cycle         
-       2.670349587 seconds time elapsed
+TOTAL       :     2.663988 sec
+     6,047,799,366      cycles:u                  #    2.266 GHz                    
+    13,065,012,167      instructions:u            #    2.16  insn per cycle         
+       2.671617938 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:44777) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_d_inl1_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.463738e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.497612e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.497612e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.484320e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.517676e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.517676e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.204778 sec
-     5,003,235,115      cycles:u                  #    2.265 GHz                    
-    11,317,364,899      instructions:u            #    2.26  insn per cycle         
-       2.212617039 seconds time elapsed
+TOTAL       :     2.198610 sec
+     4,995,939,054      cycles:u                  #    2.267 GHz                    
+    11,317,364,963      instructions:u            #    2.27  insn per cycle         
+       2.206113378 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:37986) (512y:  150) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_d_inl1_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.605244e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.631352e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.631352e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.590410e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.616422e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.616422e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.491213 sec
-     3,928,547,684      cycles:u                  #    1.575 GHz                    
-     5,801,459,236      instructions:u            #    1.48  insn per cycle         
-       2.498551873 seconds time elapsed
+TOTAL       :     2.496187 sec
+     3,929,258,432      cycles:u                  #    1.571 GHz                    
+     5,801,459,348      instructions:u            #    1.48  insn per cycle         
+       2.503978652 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1515) (512y:  238) (512z:37226)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_d_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:01:23
+DATE: 2022-05-10_21:35:22
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.085284e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.154935e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.160393e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.204251e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.275410e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.282789e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059596e+00 +- 2.368053e+00 )  GeV^-4
-TOTAL       :     0.555328 sec
-       142,187,456      cycles:u                  #    0.183 GHz                    
-       180,189,014      instructions:u            #    1.27  insn per cycle         
-       1.007868059 seconds time elapsed
+TOTAL       :     0.552705 sec
+       143,387,611      cycles:u                  #    0.185 GHz                    
+       181,494,985      instructions:u            #    1.27  insn per cycle         
+       0.965700259 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.310713e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.403554e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.407631e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.313740e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.407278e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.411538e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.664703e+00 +- 5.072736e+00 )  GeV^-4
-TOTAL       :     1.739554 sec
-     1,216,990,674      cycles:u                  #    0.616 GHz                    
-     2,522,875,474      instructions:u            #    2.07  insn per cycle         
-       2.035034493 seconds time elapsed
+TOTAL       :     1.724234 sec
+     1,183,591,214      cycles:u                  #    0.603 GHz                    
+     2,452,865,338      instructions:u            #    2.07  insn per cycle         
+       2.019502375 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.887988e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.889685e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.889685e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.887923e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.889657e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.889657e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367903e+00 )  GeV^-4
-TOTAL       :     8.691881 sec
-    23,233,697,487      cycles:u                  #    2.672 GHz                    
-    74,964,351,155      instructions:u            #    3.23  insn per cycle         
-       8.761281579 seconds time elapsed
+TOTAL       :     8.692273 sec
+    23,231,591,607      cycles:u                  #    2.671 GHz                    
+    74,964,351,361      instructions:u            #    3.23  insn per cycle         
+       8.743244826 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1066) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.904890e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.928312e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.928312e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.901019e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.924427e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.924427e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367902e+00 )  GeV^-4
-TOTAL       :     2.380438 sec
-     6,360,297,331      cycles:u                  #    2.667 GHz                    
-    20,683,018,223      instructions:u            #    3.25  insn per cycle         
-       2.503759934 seconds time elapsed
+TOTAL       :     2.381836 sec
+     6,355,476,355      cycles:u                  #    2.664 GHz                    
+    20,683,018,227      instructions:u            #    3.25  insn per cycle         
+       2.446128904 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8570) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.342947e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.351839e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.351839e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.344217e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.353189e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.353189e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.226636 sec
-     2,790,842,590      cycles:u                  #    2.267 GHz                    
-     7,045,559,460      instructions:u            #    2.52  insn per cycle         
-       1.285757054 seconds time elapsed
+TOTAL       :     1.225475 sec
+     2,788,790,312      cycles:u                  #    2.267 GHz                    
+     7,045,559,677      instructions:u            #    2.53  insn per cycle         
+       1.285790435 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6540) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.500382e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.511424e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.511424e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.498807e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.509821e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.509821e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.098453 sec
-     2,501,442,839      cycles:u                  #    2.267 GHz                    
-     6,378,687,442      instructions:u            #    2.55  insn per cycle         
-       1.201408537 seconds time elapsed
+TOTAL       :     1.099610 sec
+     2,502,098,213      cycles:u                  #    2.265 GHz                    
+     6,378,687,429      instructions:u            #    2.55  insn per cycle         
+       1.153362276 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6303) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.299343e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.307693e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.307693e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.296033e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.304257e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.304257e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060588e+00 +- 2.367628e+00 )  GeV^-4
-TOTAL       :     1.267774 sec
-     2,009,933,416      cycles:u                  #    1.579 GHz                    
-     3,266,371,470      instructions:u            #    1.63  insn per cycle         
-       1.433192711 seconds time elapsed
+TOTAL       :     1.271031 sec
+     2,010,382,441      cycles:u                  #    1.576 GHz                    
+     3,266,371,649      instructions:u            #    1.62  insn per cycle         
+       1.375106761 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1291) (512y:   13) (512z: 5717)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_bridge.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_bridge.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:46:22
+DATE: 2022-05-10_22:20:36
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -80,14 +80,14 @@ WARNING! Set grid in Bridge (nevt=16384, gpublocks=64, gputhreads=256, gpublocks
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.102332e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.265351e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.265351e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.110231e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.260874e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.260874e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.048178e+00 +- 2.364572e+00 )  GeV^-4
-TOTAL       :     0.553036 sec
-       134,791,793      cycles:u                  #    0.176 GHz                    
-       183,356,640      instructions:u            #    1.36  insn per cycle         
-       0.828944012 seconds time elapsed
+TOTAL       :     0.550336 sec
+       135,702,846      cycles:u                  #    0.176 GHz                    
+       189,716,106      instructions:u            #    1.40  insn per cycle         
+       0.827019074 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -99,14 +99,14 @@ WARNING! Set grid in Bridge (nevt=524288, gpublocks=2048, gputhreads=256, gpublo
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.386930e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.240785e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.240785e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.392279e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.248871e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.248871e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.473419e+00 +- 4.973148e+00 )  GeV^-4
-TOTAL       :     1.946851 sec
-     1,701,395,217      cycles:u                  #    0.777 GHz                    
-     3,520,380,532      instructions:u            #    2.07  insn per cycle         
-       2.247401243 seconds time elapsed
+TOTAL       :     1.942905 sec
+     1,682,618,856      cycles:u                  #    0.767 GHz                    
+     3,535,686,995      instructions:u            #    2.10  insn per cycle         
+       2.251600937 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -121,14 +121,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.889224e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.890928e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.890928e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.887851e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.889606e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.889606e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367903e+00 )  GeV^-4
-TOTAL       :     8.688328 sec
-    23,224,352,925      cycles:u                  #    2.672 GHz                    
-    74,966,402,725      instructions:u            #    3.23  insn per cycle         
-       8.695724048 seconds time elapsed
+TOTAL       :     8.695234 sec
+    23,231,900,282      cycles:u                  #    2.671 GHz                    
+    74,966,402,029      instructions:u            #    3.23  insn per cycle         
+       8.702932930 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1066) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/runTest.exe
@@ -147,14 +147,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.910097e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.934194e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.934194e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.909062e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.932662e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.932662e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367902e+00 )  GeV^-4
-TOTAL       :     2.380969 sec
-     6,358,896,628      cycles:u                  #    2.666 GHz                    
-    20,689,367,961      instructions:u            #    3.25  insn per cycle         
-       2.388293819 seconds time elapsed
+TOTAL       :     2.381337 sec
+     6,358,830,283      cycles:u                  #    2.665 GHz                    
+    20,689,367,969      instructions:u            #    3.25  insn per cycle         
+       2.388777769 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8570) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -173,14 +173,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.345577e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.354505e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.354505e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.343357e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.352287e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.352287e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.226384 sec
-     2,790,691,471      cycles:u                  #    2.267 GHz                    
-     7,052,496,994      instructions:u            #    2.53  insn per cycle         
-       1.233563240 seconds time elapsed
+TOTAL       :     1.228556 sec
+     2,791,202,135      cycles:u                  #    2.264 GHz                    
+     7,052,496,586      instructions:u            #    2.53  insn per cycle         
+       1.235774982 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6540) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -199,14 +199,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.459710e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.470236e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.470236e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.497458e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.508607e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.508607e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.131213 sec
-     2,573,589,138      cycles:u                  #    2.266 GHz                    
-     6,385,625,429      instructions:u            #    2.48  insn per cycle         
-       1.138307392 seconds time elapsed
+TOTAL       :     1.103034 sec
+     2,505,729,749      cycles:u                  #    2.263 GHz                    
+     6,385,625,816      instructions:u            #    2.55  insn per cycle         
+       1.110504645 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6303) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd0/runTest.exe
@@ -225,14 +225,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+BRDHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.296945e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.305254e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.305254e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.298179e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.306647e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.306647e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060588e+00 +- 2.367628e+00 )  GeV^-4
-TOTAL       :     1.272575 sec
-     2,014,285,625      cycles:u                  #    1.578 GHz                    
-     3,273,368,220      instructions:u            #    1.63  insn per cycle         
-       1.279989125 seconds time elapsed
+TOTAL       :     1.271455 sec
+     2,013,983,314      cycles:u                  #    1.578 GHz                    
+     3,273,367,920      instructions:u            #    1.63  insn per cycle         
+       1.279273667 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1291) (512y:   13) (512z: 5717)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_common.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_common.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:55:46
+DATE: 2022-05-10_22:30:02
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.086831e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.152197e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.157845e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.265350e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.333791e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.341362e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.159397e-01 +- 3.238804e-01 )  GeV^-4
-TOTAL       :     0.545931 sec
-       125,326,717      cycles:u                  #    0.163 GHz                    
-       165,955,884      instructions:u            #    1.32  insn per cycle         
-       0.828523729 seconds time elapsed
+TOTAL       :     0.549717 sec
+       126,023,101      cycles:u                  #    0.164 GHz                    
+       162,656,643      instructions:u            #    1.29  insn per cycle         
+       0.826412946 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:COMMON+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.332672e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.416617e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.420407e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.273577e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.357731e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.361629e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 1.094367e+02 +- 1.071509e+02 )  GeV^-4
-TOTAL       :     1.856596 sec
-     1,468,032,637      cycles:u                  #    0.700 GHz                    
-     2,974,795,022      instructions:u            #    2.03  insn per cycle         
-       2.156612220 seconds time elapsed
+TOTAL       :     1.846842 sec
+     1,439,576,004      cycles:u                  #    0.692 GHz                    
+     2,870,678,326      instructions:u            #    1.99  insn per cycle         
+       2.138227707 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.888341e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.890049e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.890049e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.888235e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.889937e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.889937e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.208361e-01 +- 3.253447e-01 )  GeV^-4
-TOTAL       :     8.691829 sec
-    23,225,076,636      cycles:u                  #    2.671 GHz                    
-    74,964,167,062      instructions:u            #    3.23  insn per cycle         
-       8.698715550 seconds time elapsed
+TOTAL       :     8.692306 sec
+    23,227,914,150      cycles:u                  #    2.671 GHz                    
+    74,964,166,970      instructions:u            #    3.23  insn per cycle         
+       8.699771314 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1066) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.900541e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.924708e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.924708e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.901749e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.925864e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.925864e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.208361e-01 +- 3.253446e-01 )  GeV^-4
-TOTAL       :     2.383472 sec
-     6,367,586,679      cycles:u                  #    2.667 GHz                    
-    20,682,289,309      instructions:u            #    3.25  insn per cycle         
-       2.390998940 seconds time elapsed
+TOTAL       :     2.383042 sec
+     6,361,763,889      cycles:u                  #    2.665 GHz                    
+    20,682,289,400      instructions:u            #    3.25  insn per cycle         
+       2.389939866 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8570) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.345211e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.354223e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.354223e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.344104e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.353089e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.353089e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.214802e-01 +- 3.255522e-01 )  GeV^-4
-TOTAL       :     1.226041 sec
-     2,790,673,411      cycles:u                  #    2.268 GHz                    
-     7,044,228,420      instructions:u            #    2.52  insn per cycle         
-       1.232772073 seconds time elapsed
+TOTAL       :     1.227038 sec
+     2,790,212,911      cycles:u                  #    2.266 GHz                    
+     7,044,228,311      instructions:u            #    2.52  insn per cycle         
+       1.234175911 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6540) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.496430e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.507708e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.507708e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.498332e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.509541e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.509541e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.214802e-01 +- 3.255522e-01 )  GeV^-4
-TOTAL       :     1.102988 sec
-     2,507,767,574      cycles:u                  #    2.265 GHz                    
-     6,376,046,151      instructions:u            #    2.54  insn per cycle         
-       1.110056564 seconds time elapsed
+TOTAL       :     1.101496 sec
+     2,504,621,506      cycles:u                  #    2.265 GHz                    
+     6,376,046,012      instructions:u            #    2.55  insn per cycle         
+       1.108293873 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6303) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:COMMON+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.297834e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.306217e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.306217e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.298554e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.307013e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.307013e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.214804e-01 +- 3.255523e-01 )  GeV^-4
-TOTAL       :     1.270817 sec
-     2,012,340,912      cycles:u                  #    1.579 GHz                    
-     3,263,730,004      instructions:u            #    1.62  insn per cycle         
-       1.277784053 seconds time elapsed
+TOTAL       :     1.270114 sec
+     2,012,413,315      cycles:u                  #    1.579 GHz                    
+     3,263,729,788      instructions:u            #    1.62  insn per cycle         
+       1.277053783 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1291) (512y:   13) (512z: 5717)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_curhst.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_curhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:52:35
+DATE: 2022-05-10_22:26:50
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.144619e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.214319e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.219798e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.259976e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.328754e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.334785e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059596e+00 +- 2.368053e+00 )  GeV^-4
-TOTAL       :     0.546725 sec
-       122,797,917      cycles:u                  #    0.158 GHz                    
-       165,540,428      instructions:u            #    1.35  insn per cycle         
-       0.833704755 seconds time elapsed
+TOTAL       :     0.289485 sec
+       123,823,317      cycles:u                  #    0.274 GHz                    
+       166,597,620      instructions:u            #    1.35  insn per cycle         
+       0.572210658 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.309258e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.394517e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.398435e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.324551e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.409420e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.413327e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.664703e+00 +- 5.072736e+00 )  GeV^-4
-TOTAL       :     1.781200 sec
-     1,329,195,330      cycles:u                  #    0.660 GHz                    
-     2,902,411,639      instructions:u            #    2.18  insn per cycle         
-       2.072408159 seconds time elapsed
+TOTAL       :     1.772086 sec
+     1,329,110,729      cycles:u                  #    0.663 GHz                    
+     2,961,224,520      instructions:u            #    2.23  insn per cycle         
+       2.063905697 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.888990e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.890686e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.890686e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.887692e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.889414e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.889414e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367903e+00 )  GeV^-4
-TOTAL       :     8.687198 sec
-    23,222,541,444      cycles:u                  #    2.672 GHz                    
-    74,964,352,002      instructions:u            #    3.23  insn per cycle         
-       8.693919459 seconds time elapsed
+TOTAL       :     8.693270 sec
+    23,233,056,745      cycles:u                  #    2.671 GHz                    
+    74,964,352,412      instructions:u            #    3.23  insn per cycle         
+       8.700371420 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1066) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.911865e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.935272e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.935272e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.904585e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.928080e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.928080e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367902e+00 )  GeV^-4
-TOTAL       :     2.378140 sec
-     6,355,910,183      cycles:u                  #    2.668 GHz                    
-    20,683,019,037      instructions:u            #    3.25  insn per cycle         
-       2.385491968 seconds time elapsed
+TOTAL       :     2.380671 sec
+     6,361,496,824      cycles:u                  #    2.667 GHz                    
+    20,683,019,026      instructions:u            #    3.25  insn per cycle         
+       2.387985222 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8570) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.344681e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.353714e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.353714e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.342819e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.351660e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.351660e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.225004 sec
-     2,787,579,410      cycles:u                  #    2.267 GHz                    
-     7,045,560,383      instructions:u            #    2.53  insn per cycle         
-       1.232152915 seconds time elapsed
+TOTAL       :     1.226717 sec
+     2,792,430,415      cycles:u                  #    2.268 GHz                    
+     7,045,560,277      instructions:u            #    2.52  insn per cycle         
+       1.233771786 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6540) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.496858e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.507874e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.507874e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.499201e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.510275e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.510275e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.101015 sec
-     2,503,661,510      cycles:u                  #    2.265 GHz                    
-     6,378,688,305      instructions:u            #    2.55  insn per cycle         
-       1.108092929 seconds time elapsed
+TOTAL       :     1.099332 sec
+     2,502,424,455      cycles:u                  #    2.267 GHz                    
+     6,378,688,376      instructions:u            #    2.55  insn per cycle         
+       1.106746439 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6303) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.298201e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.306597e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.306597e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.298672e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.306933e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.306933e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060588e+00 +- 2.367628e+00 )  GeV^-4
-TOTAL       :     1.268860 sec
-     2,010,482,434      cycles:u                  #    1.579 GHz                    
-     3,266,372,043      instructions:u            #    1.62  insn per cycle         
-       1.275717195 seconds time elapsed
+TOTAL       :     1.268422 sec
+     2,010,991,272      cycles:u                  #    1.580 GHz                    
+     3,266,372,304      instructions:u            #    1.62  insn per cycle         
+       1.275744139 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1291) (512y:   13) (512z: 5717)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_rmbhst.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd0_rmbhst.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:49:30
+DATE: 2022-05-10_22:23:45
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -77,14 +77,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.175890e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.241163e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.246377e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.064746e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.115645e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.121508e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.048178e+00 +- 2.364572e+00 )  GeV^-4
-TOTAL       :     0.287612 sec
-       134,219,095      cycles:u                  #    0.300 GHz                    
-       182,247,388      instructions:u            #    1.36  insn per cycle         
-       0.562740120 seconds time elapsed
+TOTAL       :     0.548084 sec
+       134,574,425      cycles:u                  #    0.176 GHz                    
+       185,802,897      instructions:u            #    1.38  insn per cycle         
+       0.824769570 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -93,14 +93,14 @@ WARNING! RamboHost selected: cannot use CurandDevice, will use CurandHost
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURHST+RMBHST+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.623498e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.392382e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.396085e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.626575e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.414413e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.418350e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.473419e+00 +- 4.973148e+00 )  GeV^-4
-TOTAL       :     1.904644 sec
-     1,657,358,949      cycles:u                  #    0.776 GHz                    
-     3,480,589,532      instructions:u            #    2.10  insn per cycle         
-       2.195404209 seconds time elapsed
+TOTAL       :     1.921153 sec
+     1,649,423,491      cycles:u                  #    0.765 GHz                    
+     3,506,235,475      instructions:u            #    2.13  insn per cycle         
+       2.213104401 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -114,14 +114,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.885641e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.887351e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.887351e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.887723e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.889411e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.889411e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367903e+00 )  GeV^-4
-TOTAL       :     8.702692 sec
-    23,266,361,616      cycles:u                  #    2.672 GHz                    
-    74,964,351,980      instructions:u            #    3.22  insn per cycle         
-       8.709618005 seconds time elapsed
+TOTAL       :     8.693098 sec
+    23,230,667,373      cycles:u                  #    2.671 GHz                    
+    74,964,352,254      instructions:u            #    3.23  insn per cycle         
+       8.700754586 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1066) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd0/runTest.exe
@@ -139,14 +139,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.905853e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.929229e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.929229e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.910854e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.934372e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.934372e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367902e+00 )  GeV^-4
-TOTAL       :     2.380165 sec
-     6,356,884,239      cycles:u                  #    2.667 GHz                    
-    20,683,019,302      instructions:u            #    3.25  insn per cycle         
-       2.387310157 seconds time elapsed
+TOTAL       :     2.378443 sec
+     6,354,388,186      cycles:u                  #    2.666 GHz                    
+    20,683,019,017      instructions:u            #    3.25  insn per cycle         
+       2.385928076 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8570) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -164,14 +164,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.344247e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.353110e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.353110e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.343210e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.352149e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.352149e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.225350 sec
-     2,788,345,126      cycles:u                  #    2.268 GHz                    
-     7,045,560,230      instructions:u            #    2.53  insn per cycle         
-       1.232295150 seconds time elapsed
+TOTAL       :     1.226322 sec
+     2,788,425,490      cycles:u                  #    2.266 GHz                    
+     7,045,560,574      instructions:u            #    2.53  insn per cycle         
+       1.233390888 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6540) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -189,14 +189,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.500002e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.511081e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.511081e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.495057e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.506032e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.506032e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.098644 sec
-     2,502,824,777      cycles:u                  #    2.269 GHz                    
-     6,378,688,315      instructions:u            #    2.55  insn per cycle         
-       1.105550860 seconds time elapsed
+TOTAL       :     1.102253 sec
+     2,506,804,059      cycles:u                  #    2.266 GHz                    
+     6,378,688,126      instructions:u            #    2.54  insn per cycle         
+       1.109430269 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6303) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd0/runTest.exe
@@ -214,14 +214,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.294799e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.303005e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.303005e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.299500e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.307766e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.307766e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060588e+00 +- 2.367628e+00 )  GeV^-4
-TOTAL       :     1.272202 sec
-     2,017,108,425      cycles:u                  #    1.579 GHz                    
-     3,266,372,387      instructions:u            #    1.62  insn per cycle         
-       1.281047345 seconds time elapsed
+TOTAL       :     1.267558 sec
+     2,009,331,798      cycles:u                  #    1.579 GHz                    
+     3,266,372,202      instructions:u            #    1.63  insn per cycle         
+       1.274879338 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1291) (512y:   13) (512z: 5717)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:01:57
+DATE: 2022-05-10_21:35:55
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 6.947709e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.012866e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.020271e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.937248e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.003277e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.010349e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059596e+00 +- 2.368053e+00 )  GeV^-4
-TOTAL       :     0.557274 sec
-       141,804,856      cycles:u                  #    0.182 GHz                    
-       174,655,127      instructions:u            #    1.23  insn per cycle         
-       1.012681657 seconds time elapsed
+TOTAL       :     0.555978 sec
+       141,371,002      cycles:u                  #    0.182 GHz                    
+       177,438,834      instructions:u            #    1.26  insn per cycle         
+       1.000766565 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 9.509673e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 9.607260e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 9.611492e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 9.510702e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 9.608107e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.612628e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.664703e+00 +- 5.072736e+00 )  GeV^-4
-TOTAL       :     1.736608 sec
-     1,226,304,497      cycles:u                  #    0.623 GHz                    
-     2,501,545,442      instructions:u            #    2.04  insn per cycle         
-       2.032081860 seconds time elapsed
+TOTAL       :     1.722261 sec
+     1,209,446,259      cycles:u                  #    0.618 GHz                    
+     2,482,049,188      instructions:u            #    2.05  insn per cycle         
+       2.018215779 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.893955e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.895657e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.895657e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.895730e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.897457e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.897457e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367903e+00 )  GeV^-4
-TOTAL       :     8.664247 sec
-    23,155,952,587      cycles:u                  #    2.672 GHz                    
-    74,888,019,914      instructions:u            #    3.23  insn per cycle         
-       8.709175133 seconds time elapsed
+TOTAL       :     8.656239 sec
+    23,131,736,254      cycles:u                  #    2.671 GHz                    
+    74,888,019,217      instructions:u            #    3.24  insn per cycle         
+       8.727141997 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1033) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.929834e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.953536e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.953536e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.928987e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.952493e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.952493e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060121e+00 +- 2.367902e+00 )  GeV^-4
-TOTAL       :     2.371699 sec
-     6,334,750,101      cycles:u                  #    2.666 GHz                    
-    20,621,389,399      instructions:u            #    3.26  insn per cycle         
-       2.435227177 seconds time elapsed
+TOTAL       :     2.371976 sec
+     6,333,649,089      cycles:u                  #    2.665 GHz                    
+    20,621,389,756      instructions:u            #    3.26  insn per cycle         
+       2.450341367 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 8268) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.299690e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.307995e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.307995e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.300379e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.308649e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.308649e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.267019 sec
-     2,880,687,740      cycles:u                  #    2.265 GHz                    
-     7,151,374,220      instructions:u            #    2.48  insn per cycle         
-       1.316967575 seconds time elapsed
+TOTAL       :     1.266346 sec
+     2,880,549,836      cycles:u                  #    2.265 GHz                    
+     7,151,373,753      instructions:u            #    2.48  insn per cycle         
+       1.329576137 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 7121) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.446031e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.456340e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.456340e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.442394e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.452598e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.452598e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060587e+00 +- 2.367627e+00 )  GeV^-4
-TOTAL       :     1.139281 sec
-     2,594,355,004      cycles:u                  #    2.268 GHz                    
-     6,480,698,357      instructions:u            #    2.50  insn per cycle         
-       1.230415544 seconds time elapsed
+TOTAL       :     1.142192 sec
+     2,596,234,538      cycles:u                  #    2.264 GHz                    
+     6,480,698,406      instructions:u            #    2.50  insn per cycle         
+       1.197845675 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 6865) (512y:   14) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.257548e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.265278e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.265278e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.257428e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.265184e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.265184e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060588e+00 +- 2.367628e+00 )  GeV^-4
-TOTAL       :     1.309503 sec
-     2,074,941,431      cycles:u                  #    1.579 GHz                    
-     3,362,821,362      instructions:u            #    1.62  insn per cycle         
-       1.348089685 seconds time elapsed
+TOTAL       :     1.309583 sec
+     2,075,509,971      cycles:u                  #    1.579 GHz                    
+     3,362,821,757      instructions:u            #    1.62  insn per cycle         
+       1.396653068 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1745) (512y:    8) (512z: 6080)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl1_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl1_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:40:11
+DATE: 2022-05-10_22:14:21
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.128396e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.169653e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.173625e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.166060e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.207167e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.211464e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059596e+00 +- 2.368053e+00 )  GeV^-4
-TOTAL       :     0.572482 sec
-       154,887,082      cycles:u                  #    0.192 GHz                    
-       202,951,816      instructions:u            #    1.31  insn per cycle         
-       0.864744289 seconds time elapsed
+TOTAL       :     0.574301 sec
+       152,913,908      cycles:u                  #    0.189 GHz                    
+       203,552,579      instructions:u            #    1.33  insn per cycle         
+       0.866377895 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.115026e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.171548e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.173927e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.118955e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.175511e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.178072e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.664703e+00 +- 5.072736e+00 )  GeV^-4
-TOTAL       :     2.046446 sec
-     1,452,983,082      cycles:u                  #    0.634 GHz                    
-     3,086,817,547      instructions:u            #    2.12  insn per cycle         
-       2.350895193 seconds time elapsed
+TOTAL       :     2.048834 sec
+     1,471,655,331      cycles:u                  #    0.641 GHz                    
+     3,121,410,442      instructions:u            #    2.12  insn per cycle         
+       2.353574973 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.203324e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.204172e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.204172e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.203167e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.204008e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.204008e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059968e+00 +- 2.367799e+00 )  GeV^-4
-TOTAL       :    39.022675 sec
-   104,119,533,584      cycles:u                  #    2.668 GHz                    
-   173,983,650,006      instructions:u            #    1.67  insn per cycle         
-      39.029840761 seconds time elapsed
+TOTAL       :    39.024639 sec
+   104,038,084,045      cycles:u                  #    2.666 GHz                    
+   173,983,650,403      instructions:u            #    1.67  insn per cycle         
+      39.031633920 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6317) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.428466e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.448760e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.448760e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.819463e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.836010e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.836010e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059962e+00 +- 2.367792e+00 )  GeV^-4
-TOTAL       :     2.556854 sec
-     6,828,105,964      cycles:u                  #    2.666 GHz                    
-    20,570,843,716      instructions:u            #    3.01  insn per cycle         
-       2.564031989 seconds time elapsed
+TOTAL       :     2.823833 sec
+     7,538,556,766      cycles:u                  #    2.665 GHz                    
+    20,570,843,851      instructions:u            #    2.73  insn per cycle         
+       2.831066873 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:70596) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl1_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.183364e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.190514e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.190514e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.183890e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.190776e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.190776e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060904e+00 +- 2.367377e+00 )  GeV^-4
-TOTAL       :     1.391618 sec
-     3,164,844,289      cycles:u                  #    2.267 GHz                    
-     6,833,694,032      instructions:u            #    2.16  insn per cycle         
-       1.398792781 seconds time elapsed
+TOTAL       :     1.390992 sec
+     3,160,895,151      cycles:u                  #    2.265 GHz                    
+     6,833,693,704      instructions:u            #    2.16  insn per cycle         
+       1.398213881 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:47223) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl1_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.446689e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.456948e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.456948e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.444218e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.454634e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.454634e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060904e+00 +- 2.367377e+00 )  GeV^-4
-TOTAL       :     1.139250 sec
-     2,593,107,501      cycles:u                  #    2.267 GHz                    
-     5,891,695,224      instructions:u            #    2.27  insn per cycle         
-       1.146288258 seconds time elapsed
+TOTAL       :     1.141376 sec
+     2,594,908,653      cycles:u                  #    2.265 GHz                    
+     5,891,695,632      instructions:u            #    2.27  insn per cycle         
+       1.148731537 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:40035) (512y:   28) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl1_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.276324e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.284318e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.284318e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.276501e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.284596e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.284596e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060905e+00 +- 2.367378e+00 )  GeV^-4
-TOTAL       :     1.290835 sec
-     2,043,474,342      cycles:u                  #    1.578 GHz                    
-     3,102,668,963      instructions:u            #    1.52  insn per cycle         
-       1.297935535 seconds time elapsed
+TOTAL       :     1.290707 sec
+     2,043,053,146      cycles:u                  #    1.577 GHz                    
+     3,102,669,498      instructions:u            #    1.52  insn per cycle         
+       1.298147043 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 4086) (512y:    6) (512z:38137)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl1_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl1_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_manu/log_ggttgg_manu_f_inl1_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl1_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg'
 
-DATE: 2022-05-09_18:41:21
+DATE: 2022-05-10_22:15:34
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 5.875098e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.927639e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.931990e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.893590e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.946888e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.952130e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059596e+00 +- 2.368053e+00 )  GeV^-4
-TOTAL       :     0.312096 sec
-       153,267,086      cycles:u                  #    0.317 GHz                    
-       200,738,893      instructions:u            #    1.31  insn per cycle         
-       0.601793895 seconds time elapsed
+TOTAL       :     0.570539 sec
+       151,655,472      cycles:u                  #    0.186 GHz                    
+       195,031,255      instructions:u            #    1.29  insn per cycle         
+       0.874734729 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=1] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.113258e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.169062e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.171524e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.110841e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.166106e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.168536e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.664703e+00 +- 5.072736e+00 )  GeV^-4
-TOTAL       :     2.054814 sec
-     1,510,316,762      cycles:u                  #    0.657 GHz                    
-     3,118,878,603      instructions:u            #    2.07  insn per cycle         
-       2.357264467 seconds time elapsed
+TOTAL       :     2.055983 sec
+     1,463,609,660      cycles:u                  #    0.636 GHz                    
+     3,107,076,420      instructions:u            #    2.12  insn per cycle         
+       2.358402362 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.186242e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.187099e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.187099e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.176281e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.177114e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.177114e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059969e+00 +- 2.367799e+00 )  GeV^-4
-TOTAL       :    39.181595 sec
-   104,543,729,579      cycles:u                  #    2.668 GHz                    
-   173,555,699,508      instructions:u            #    1.66  insn per cycle         
-      39.189843217 seconds time elapsed
+TOTAL       :    39.274620 sec
+   104,678,729,568      cycles:u                  #    2.665 GHz                    
+   173,555,700,056      instructions:u            #    1.66  insn per cycle         
+      39.281832049 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6110) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.none_f_inl1_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.780992e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.803553e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.803553e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.766194e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.788722e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.788722e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.059962e+00 +- 2.367792e+00 )  GeV^-4
-TOTAL       :     2.423918 sec
-     6,473,899,683      cycles:u                  #    2.666 GHz                    
-    20,332,612,306      instructions:u            #    3.14  insn per cycle         
-       2.430945623 seconds time elapsed
+TOTAL       :     2.429299 sec
+     6,476,949,898      cycles:u                  #    2.662 GHz                    
+    20,332,611,652      instructions:u            #    3.14  insn per cycle         
+       2.436499629 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:69555) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.sse4_f_inl1_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.198979e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.206030e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.206030e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.199620e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.206687e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.206687e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060904e+00 +- 2.367377e+00 )  GeV^-4
-TOTAL       :     1.373268 sec
-     3,122,162,085      cycles:u                  #    2.266 GHz                    
-     6,749,882,668      instructions:u            #    2.16  insn per cycle         
-       1.380470532 seconds time elapsed
+TOTAL       :     1.372552 sec
+     3,118,588,887      cycles:u                  #    2.265 GHz                    
+     6,749,882,402      instructions:u            #    2.16  insn per cycle         
+       1.379671762 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:46100) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.avx2_f_inl1_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.454806e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.465412e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.465412e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.454142e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.464766e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.464766e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060904e+00 +- 2.367377e+00 )  GeV^-4
-TOTAL       :     1.132768 sec
-     2,574,138,069      cycles:u                  #    2.265 GHz                    
-     5,857,085,060      instructions:u            #    2.28  insn per cycle         
-       1.139753160 seconds time elapsed
+TOTAL       :     1.133268 sec
+     2,573,980,063      cycles:u                  #    2.262 GHz                    
+     5,857,085,677      instructions:u            #    2.28  insn per cycle         
+       1.140444171 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:39266) (512y:   16) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512y_f_inl1_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=1] [
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.277595e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.285595e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.285595e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.279116e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.287187e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.287187e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 4.060905e+00 +- 2.367378e+00 )  GeV^-4
-TOTAL       :     1.289321 sec
-     2,038,052,103      cycles:u                  #    1.576 GHz                    
-     3,083,345,775      instructions:u            #    1.51  insn per cycle         
-       1.297079138 seconds time elapsed
+TOTAL       :     1.287871 sec
+     2,036,309,229      cycles:u                  #    1.576 GHz                    
+     3,083,344,864      instructions:u            #    1.51  insn per cycle         
+       1.295113922 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 3278) (512y:    2) (512z:37798)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg/SubProcesses/P1_Sigma_sm_gg_ttxgg/build.512z_f_inl1_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-05-09_18:02:31
+DATE: 2022-05-10_21:36:29
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.748778e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.749331e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.749679e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.759847e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.760382e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.760611e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.939086 sec
-     1,252,216,444      cycles:u                  #    0.612 GHz                    
-     2,401,720,882      instructions:u            #    1.92  insn per cycle         
-       2.475828736 seconds time elapsed
+TOTAL       :     1.808732 sec
+     1,216,818,578      cycles:u                  #    0.595 GHz                    
+     2,498,664,421      instructions:u            #    2.05  insn per cycle         
+       2.451834910 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.118136e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.118503e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.118537e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.123493e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.123839e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.123880e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856249e-04 +- 8.329951e-05 )  GeV^-6
-TOTAL       :     3.503292 sec
-     2,846,302,370      cycles:u                  #    0.741 GHz                    
-     6,121,611,028      instructions:u            #    2.15  insn per cycle         
-       3.900030096 seconds time elapsed
+TOTAL       :     3.502647 sec
+     2,876,082,590      cycles:u                  #    0.749 GHz                    
+     6,097,783,707      instructions:u            #    2.12  insn per cycle         
+       3.900024286 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.203941e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.204443e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.204443e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.192474e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.192974e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.192974e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     3.778094 sec
-    10,074,207,002      cycles:u                  #    2.664 GHz                    
-    28,667,877,466      instructions:u            #    2.85  insn per cycle         
-       3.879935157 seconds time elapsed
+TOTAL       :     3.784510 sec
+    10,087,303,770      cycles:u                  #    2.662 GHz                    
+    28,667,877,477      instructions:u            #    2.84  insn per cycle         
+       3.907758535 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6603) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.298530e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.298692e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.298692e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.312609e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.312778e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.312778e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     2.096866 sec
-     5,585,558,176      cycles:u                  #    2.658 GHz                    
-    15,180,789,777      instructions:u            #    2.72  insn per cycle         
-       2.194186468 seconds time elapsed
+TOTAL       :     2.074420 sec
+     5,518,282,067      cycles:u                  #    2.655 GHz                    
+    15,180,789,940      instructions:u            #    2.75  insn per cycle         
+       2.168268164 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:64007) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.620170e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.620864e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.620864e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.618308e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.618970e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.618970e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.040434 sec
-     2,362,006,552      cycles:u                  #    2.260 GHz                    
-     5,281,011,904      instructions:u            #    2.24  insn per cycle         
-       1.176285686 seconds time elapsed
+TOTAL       :     1.041111 sec
+     2,362,636,403      cycles:u                  #    2.259 GHz                    
+     5,281,011,988      instructions:u            #    2.24  insn per cycle         
+       1.112129345 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50386) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.906766e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.907590e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.907590e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.900058e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.900873e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.900873e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.938123 sec
-     2,129,133,376      cycles:u                  #    2.259 GHz                    
-     4,763,894,709      instructions:u            #    2.24  insn per cycle         
-       1.078990069 seconds time elapsed
+TOTAL       :     0.940216 sec
+     2,131,977,353      cycles:u                  #    2.255 GHz                    
+     4,763,895,172      instructions:u            #    2.23  insn per cycle         
+       1.059328553 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50733) (512y:   40) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.930326e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.931200e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.931200e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.927990e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.928791e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.928791e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.931548 sec
-     1,463,096,394      cycles:u                  #    1.562 GHz                    
-     2,390,728,252      instructions:u            #    1.63  insn per cycle         
-       1.025095257 seconds time elapsed
+TOTAL       :     0.932059 sec
+     1,463,776,714      cycles:u                  #    1.562 GHz                    
+     2,390,728,537      instructions:u            #    1.63  insn per cycle         
+       1.076116412 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1313) (512y:   49) (512z:50087)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_d_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_d_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-05-09_18:03:54
+DATE: 2022-05-10_21:37:51
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.737363e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.737862e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.738024e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.734741e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.735239e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.735411e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.880729 sec
-     1,270,887,595      cycles:u                  #    0.617 GHz                    
-     2,485,617,861      instructions:u            #    1.96  insn per cycle         
-       2.448703160 seconds time elapsed
+TOTAL       :     1.769107 sec
+     1,253,719,849      cycles:u                  #    0.610 GHz                    
+     2,441,816,849      instructions:u            #    1.95  insn per cycle         
+       2.358214285 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.125062e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.125399e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.125437e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.120399e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.120714e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.120754e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856249e-04 +- 8.329951e-05 )  GeV^-6
-TOTAL       :     3.250512 sec
-     2,730,600,581      cycles:u                  #    0.776 GHz                    
-     6,167,615,788      instructions:u            #    2.26  insn per cycle         
-       3.652076227 seconds time elapsed
+TOTAL       :     3.500422 sec
+     2,851,845,953      cycles:u                  #    0.742 GHz                    
+     6,041,643,593      instructions:u            #    2.12  insn per cycle         
+       3.899980548 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.143757e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.144265e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.144265e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.163830e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.164328e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.164328e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     3.809456 sec
-    10,160,202,748      cycles:u                  #    2.664 GHz                    
-    28,627,627,354      instructions:u            #    2.82  insn per cycle         
-       3.860755749 seconds time elapsed
+TOTAL       :     3.798807 sec
+    10,131,900,814      cycles:u                  #    2.664 GHz                    
+    28,627,627,165      instructions:u            #    2.83  insn per cycle         
+       3.871000068 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6584) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_d_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 1.311435e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.311600e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.311600e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.311206e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.311376e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.311376e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     2.075922 sec
-     5,537,542,325      cycles:u                  #    2.662 GHz                    
-    15,173,203,735      instructions:u            #    2.74  insn per cycle         
-       2.170784866 seconds time elapsed
+TOTAL       :     2.076325 sec
+     5,535,505,744      cycles:u                  #    2.660 GHz                    
+    15,173,204,020      instructions:u            #    2.74  insn per cycle         
+       2.271326071 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:63920) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_d_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.595585e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.596245e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.596245e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.602444e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.603111e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.603111e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     1.050036 sec
-     2,381,297,709      cycles:u                  #    2.258 GHz                    
-     5,269,430,934      instructions:u            #    2.21  insn per cycle         
-       1.139315012 seconds time elapsed
+TOTAL       :     1.047250 sec
+     2,375,474,968      cycles:u                  #    2.258 GHz                    
+     5,269,431,040      instructions:u            #    2.22  insn per cycle         
+       1.181292550 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50095) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_d_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.854430e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.855213e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.855213e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.851996e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.852790e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.852790e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.955100 sec
-     2,162,741,133      cycles:u                  #    2.253 GHz                    
-     4,762,882,670      instructions:u            #    2.20  insn per cycle         
-       1.065075144 seconds time elapsed
+TOTAL       :     0.955832 sec
+     2,165,259,975      cycles:u                  #    2.254 GHz                    
+     4,762,882,273      instructions:u            #    2.20  insn per cycle         
+       1.083765512 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50388) (512y:  174) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_d_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.922995e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.923814e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.923814e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.922703e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.923508e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.923508e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064592e-05 +- 1.952360e-05 )  GeV^-6
-TOTAL       :     0.933078 sec
-     1,462,032,341      cycles:u                  #    1.559 GHz                    
-     2,388,802,325      instructions:u            #    1.63  insn per cycle         
-       0.989202901 seconds time elapsed
+TOTAL       :     0.933396 sec
+     1,464,514,970      cycles:u                  #    1.561 GHz                    
+     2,388,802,542      instructions:u            #    1.63  insn per cycle         
+       1.016036092 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:  722) (512y:  140) (512z:50289)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_d_inl0_hrd1/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_f_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_f_inl0_hrd0.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd0_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-05-09_18:05:17
+DATE: 2022-05-10_21:39:20
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.687526e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.688792e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.689214e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.700153e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.701464e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.701917e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064444e-05 +- 1.952232e-05 )  GeV^-6
-TOTAL       :     1.311776 sec
-       815,303,007      cycles:u                  #    0.528 GHz                    
-     1,641,694,742      instructions:u            #    2.01  insn per cycle         
-       1.761228850 seconds time elapsed
+TOTAL       :     1.517821 sec
+       851,004,456      cycles:u                  #    0.551 GHz                    
+     1,630,056,393      instructions:u            #    1.92  insn per cycle         
+       2.064404286 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.623222e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.624191e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.624336e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.636218e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.637194e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.637344e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856835e-04 +- 8.333436e-05 )  GeV^-6
-TOTAL       :     1.854230 sec
-     1,396,386,133      cycles:u                  #    0.658 GHz                    
-     2,769,314,014      instructions:u            #    1.98  insn per cycle         
-       2.179816008 seconds time elapsed
+TOTAL       :     1.849783 sec
+     1,431,998,789      cycles:u                  #    0.676 GHz                    
+     2,796,793,740      instructions:u            #    1.95  insn per cycle         
+       2.176317753 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd0/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.880120e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.880633e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.880633e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.871682e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.872183e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.872183e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064526e-05 +- 1.952298e-05 )  GeV^-6
-TOTAL       :     3.453907 sec
-     9,218,732,648      cycles:u                  #    2.666 GHz                    
-    27,161,083,271      instructions:u            #    2.95  insn per cycle         
-       3.517970622 seconds time elapsed
+TOTAL       :     3.457333 sec
+     9,220,180,412      cycles:u                  #    2.664 GHz                    
+    27,161,083,156      instructions:u            #    2.95  insn per cycle         
+       3.531037994 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6154) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.921365e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.922076e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.922076e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.924184e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.924890e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.924890e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064524e-05 +- 1.952297e-05 )  GeV^-6
-TOTAL       :     0.933224 sec
-     2,488,385,186      cycles:u                  #    2.653 GHz                    
-     7,760,769,271      instructions:u            #    3.12  insn per cycle         
-       1.008138921 seconds time elapsed
+TOTAL       :     0.932294 sec
+     2,486,120,195      cycles:u                  #    2.654 GHz                    
+     7,760,769,315      instructions:u            #    3.12  insn per cycle         
+       1.047052394 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:64505) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_f_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.216918e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.219239e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.219239e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.213728e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.215906e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.215906e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064830e-05 +- 1.952605e-05 )  GeV^-6
-TOTAL       :     0.523730 sec
-     1,188,903,508      cycles:u                  #    2.250 GHz                    
-     2,657,578,795      instructions:u            #    2.24  insn per cycle         
-       0.724385648 seconds time elapsed
+TOTAL       :     0.523945 sec
+     1,190,435,827      cycles:u                  #    2.249 GHz                    
+     2,657,578,446      instructions:u            #    2.23  insn per cycle         
+       0.666568561 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50622) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_f_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.759440e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.762076e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.762076e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.693691e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.696237e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.696237e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064830e-05 +- 1.952605e-05 )  GeV^-6
-TOTAL       :     0.474550 sec
-     1,078,412,205      cycles:u                  #    2.250 GHz                    
-     2,398,252,474      instructions:u            #    2.22  insn per cycle         
-       0.571452491 seconds time elapsed
+TOTAL       :     0.480276 sec
+     1,088,977,304      cycles:u                  #    2.243 GHz                    
+     2,398,252,826      instructions:u            #    2.20  insn per cycle         
+       0.576870542 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50962) (512y:   22) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_f_inl0_hrd0/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.861301e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.864049e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.864049e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.859792e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.862602e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.862602e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064831e-05 +- 1.952606e-05 )  GeV^-6
-TOTAL       :     0.466731 sec
-       734,768,322      cycles:u                  #    1.558 GHz                    
-     1,205,536,641      instructions:u            #    1.64  insn per cycle         
-       0.537112448 seconds time elapsed
+TOTAL       :     0.467122 sec
+       733,401,002      cycles:u                  #    1.555 GHz                    
+     1,205,536,726      instructions:u            #    1.64  insn per cycle         
+       0.580307397 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1590) (512y:    7) (512z:50184)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_f_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_f_inl0_hrd1.txt
+++ b/epochX/cudacpp/tput/logs_ggttggg_manu/log_ggttggg_manu_f_inl0_hrd1.txt
@@ -68,7 +68,7 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all.512z_f_inl0_hrd1_hasCurand'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg'
 
-DATE: 2022-05-09_18:06:19
+DATE: 2022-05-10_21:40:24
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -76,14 +76,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.528503e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.530033e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.530497e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.538721e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.540011e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.540427e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064444e-05 +- 1.952232e-05 )  GeV^-6
-TOTAL       :     1.290962 sec
-       857,366,038      cycles:u                  #    0.549 GHz                    
-     1,627,668,830      instructions:u            #    1.90  insn per cycle         
-       1.619221213 seconds time elapsed
+TOTAL       :     1.290204 sec
+       884,852,312      cycles:u                  #    0.568 GHz                    
+     1,657,885,288      instructions:u            #    1.87  insn per cycle         
+       1.617043267 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -91,14 +91,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=1]
 Workflow summary            = CUD:FLT+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 2.644326e+04                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.645358e+04                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.645525e+04                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.621116e+04                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.622086e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.622204e+04                 )  sec^-1
 MeanMatrixElemValue         = ( 1.856835e-04 +- 8.333436e-05 )  GeV^-6
-TOTAL       :     1.851764 sec
-     1,368,411,092      cycles:u                  #    0.645 GHz                    
-     2,724,934,534      instructions:u            #    1.99  insn per cycle         
-       2.179289668 seconds time elapsed
+TOTAL       :     1.859550 sec
+     1,364,337,806      cycles:u                  #    0.640 GHz                    
+     2,815,445,487      instructions:u            #    2.06  insn per cycle         
+       2.197198250 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd1/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd1/fgcheck.exe 2 64 2
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 7.853159e+01                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.853663e+01                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.853663e+01                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.879820e+01                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.880343e+01                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.880343e+01                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064526e-05 +- 1.952298e-05 )  GeV^-6
-TOTAL       :     3.465527 sec
-     9,243,964,758      cycles:u                  #    2.664 GHz                    
-    27,120,762,964      instructions:u            #    2.93  insn per cycle         
-       3.472414575 seconds time elapsed
+TOTAL       :     3.453762 sec
+     9,212,663,825      cycles:u                  #    2.664 GHz                    
+    27,120,763,003      instructions:u            #    2.94  insn per cycle         
+       3.461000147 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 6238) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.none_f_inl0_hrd1/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 2.911772e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 2.912506e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 2.912506e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 2.914051e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 2.914786e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.914786e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064524e-05 +- 1.952297e-05 )  GeV^-6
-TOTAL       :     0.936173 sec
-     2,497,306,056      cycles:u                  #    2.655 GHz                    
-     7,744,839,978      instructions:u            #    3.10  insn per cycle         
-       0.943006044 seconds time elapsed
+TOTAL       :     0.935414 sec
+     2,495,660,714      cycles:u                  #    2.656 GHz                    
+     7,744,840,218      instructions:u            #    3.10  insn per cycle         
+       0.942137966 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:64401) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.sse4_f_inl0_hrd1/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.169940e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.172162e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.172162e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.165280e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.167515e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.167515e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064830e-05 +- 1.952605e-05 )  GeV^-6
-TOTAL       :     0.528346 sec
-     1,198,959,664      cycles:u                  #    2.252 GHz                    
-     2,654,153,154      instructions:u            #    2.21  insn per cycle         
-       0.535300236 seconds time elapsed
+TOTAL       :     0.528804 sec
+     1,200,421,045      cycles:u                  #    2.250 GHz                    
+     2,654,153,310      instructions:u            #    2.21  insn per cycle         
+       0.536032196 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:50827) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.avx2_f_inl0_hrd1/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.673027e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.675599e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.675599e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.675927e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.678502e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.678502e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064830e-05 +- 1.952605e-05 )  GeV^-6
-TOTAL       :     0.481674 sec
-     1,093,234,576      cycles:u                  #    2.250 GHz                    
-     2,399,076,223      instructions:u            #    2.19  insn per cycle         
-       0.488335117 seconds time elapsed
+TOTAL       :     0.481432 sec
+     1,092,100,347      cycles:u                  #    2.248 GHz                    
+     2,399,076,200      instructions:u            #    2.20  insn per cycle         
+       0.488591165 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:51221) (512y:    8) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512y_f_inl0_hrd1/runTest.exe
@@ -212,14 +212,14 @@ Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] 
 Workflow summary            = CPP:FLT+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = FLOAT (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[16] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 5.811992e+02                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 5.814662e+02                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 5.814662e+02                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 5.846333e+02                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 5.849141e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.849141e+02                 )  sec^-1
 MeanMatrixElemValue         = ( 2.064831e-05 +- 1.952606e-05 )  GeV^-6
-TOTAL       :     0.470782 sec
-       739,463,750      cycles:u                  #    1.557 GHz                    
-     1,206,178,982      instructions:u            #    1.63  insn per cycle         
-       0.477504992 seconds time elapsed
+TOTAL       :     0.468020 sec
+       735,742,054      cycles:u                  #    1.558 GHz                    
+     1,206,179,102      instructions:u            #    1.64  insn per cycle         
+       0.474760924 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1615) (512y:    2) (512z:50549)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg/SubProcesses/P1_Sigma_sm_gg_ttxggg/build.512z_f_inl0_hrd1/runTest.exe


### PR DESCRIPTION
This contains two small fixes for EFT in clang:
- a followup to #446 and #449: in clang, there is no bracket operator [] returning a reference in SIMD vectors, so I had to modify the patch for float vectors in EFT
- a followup to #358: I added a small patch using constexpr to remove a build warning if nparf=1, ie for 2 to 1 processes