### PR TITLE
Enable properly running alphas again (variable renormalization scale) + Makefile fixes

### DIFF
--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.makefile
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.makefile
@@ -1,5 +1,5 @@
 diff --git a/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile b/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
-index cce95279..6639b814 100644
+index cce95279..87613763 100644
 --- a/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
 +++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
 @@ -1,6 +1,17 @@
@@ -36,7 +36,7 @@ index cce95279..6639b814 100644
 +PLUGIN_MAKEFILE = Makefile
 +PLUGINLIBS = $(LIBDIR)/lib$(PLUGIN_CXXLIB).so $(LIBDIR)/lib$(PLUGIN_CULIB).so
 +
-+LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS)$(LIBDIR)/lib $(PLUGINLIBS)
++LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS) $(PLUGINLIBS)
  
  # Source files
  
@@ -71,7 +71,7 @@ index cce95279..6639b814 100644
 +
 +$(LIBS): .libs
 +
-+.libs:
++.libs: ../../Cards/param_card.dat ../../Cards/run_card.dat
 +	cd ../../Source; make
 +ifneq (,$(wildcard fbridge.inc))
 +	$(MAKE) -f $(PLUGIN_MAKEFILE)

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -126,11 +126,6 @@ function codeGenAndDiff()
     cat ${OUTDIR}/${proc}.${autosuffix}/Cards/me5_configuration.txt | sed 's/mg5_path/#mg5_path/' > ${OUTDIR}/${proc}.${autosuffix}/Cards/me5_configuration.txt.new
     \mv ${OUTDIR}/${proc}.${autosuffix}/Cards/me5_configuration.txt.new ${OUTDIR}/${proc}.${autosuffix}/Cards/me5_configuration.txt
   fi
-  # Temporarely use a fixed renormalization scale (#417) and improve formatting of fixed factorization scale
-  if [ "${OUTBCK}" == "madonly" ] || [ "${OUTBCK}" == "mad" ] || [ "${OUTBCK}" == "madcpp" ] || [ "${OUTBCK}" == "madgpu" ]; then
-    cat ${OUTDIR}/${proc}.${autosuffix}/Cards/run_card.dat | sed 's/False = fixed_ren_scale/True = fixed_ren_scale/' | sed 's/    False = fixed_fac_scale/False = fixed_fac_scale/' > ${OUTDIR}/${proc}.${autosuffix}/Cards/run_card.dat.new
-    \mv ${OUTDIR}/${proc}.${autosuffix}/Cards/run_card.dat.new ${OUTDIR}/${proc}.${autosuffix}/Cards/run_card.dat
-  fi
   # Add a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/2
   if [ "${OUTBCK}" == "madonly" ] || [ "${OUTBCK}" == "mad" ] || [ "${OUTBCK}" == "madcpp" ] || [ "${OUTBCK}" == "madgpu" ]; then
     cat ${OUTDIR}/${proc}.${autosuffix}/Cards/ident_card.dat | head -3 > ${OUTDIR}/${proc}.${autosuffix}/Cards/ident_card.dat.new

--- a/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.auto/CODEGEN_cudacpp_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006958961486816406 [0m
+[1;32mDEBUG: model prefixing  takes 0.006896495819091797 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -94,14 +94,14 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
-Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
+Generated helas calls for 1 subprocesses (2 diagrams) in 0.004 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 4 routines in  0.320 s
+ALOHA: aloha creates 4 routines in  0.323 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -128,5 +128,5 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_ee_mu
 quit
 
 real	0m1.077s
-user	0m0.914s
-sys	0m0.140s
+user	0m0.924s
+sys	0m0.128s

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069370269775390625 [0m
+[1;32mDEBUG: model prefixing  takes 0.00690770149230957 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -83,7 +83,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f753f4fcac0> [1;30m[export_v4.py at line 5955][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f1aea59eac0> [1;30m[export_v4.py at line 5955][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -108,7 +108,7 @@ INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 [1;32mDEBUG:  done [1;30m[madgraph_interface.py at line 8458][0m [0m
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.104 s
+Wrote files for 8 helas calls in 0.105 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
@@ -126,7 +126,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.306 s
+ALOHA: aloha creates 7 routines in  0.309 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -160,6 +160,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.600s
-user	0m2.232s
-sys	0m0.351s
+real	0m2.601s
+user	0m2.260s
+sys	0m0.328s

--- a/epochX/cudacpp/ee_mumu.mad/Cards/run_card.dat
+++ b/epochX/cudacpp/ee_mumu.mad/Cards/run_card.dat
@@ -55,8 +55,8 @@
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- True = fixed_ren_scale  ! if .true. use fixed ren scale
- False = fixed_fac_scale  ! if .true. use fixed fac scale
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+     False = fixed_fac_scale  ! if .true. use fixed fac scale
  91.188  = scale            ! fixed ren scale
  91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
  91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2

--- a/epochX/cudacpp/ee_mumu.mad/Source/run_card.inc
+++ b/epochX/cudacpp/ee_mumu.mad/Source/run_card.inc
@@ -36,7 +36,7 @@
 
       LHAID = 230000
 
-      FIXED_REN_SCALE = .TRUE.
+      FIXED_REN_SCALE = .FALSE.
 
       FIXED_FAC_SCALE1 = .FALSE.
 

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/makefile
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/makefile
@@ -45,7 +45,7 @@ PLUGIN_CULIB = mg5amc_$(processid_short)_cuda
 PLUGIN_MAKEFILE = Makefile
 PLUGINLIBS = $(LIBDIR)/lib$(PLUGIN_CXXLIB).so $(LIBDIR)/lib$(PLUGIN_CULIB).so
 
-LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS)$(LIBDIR)/lib $(PLUGINLIBS)
+LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS) $(PLUGINLIBS)
 
 # Source files
 
@@ -78,7 +78,7 @@ $(PROG): $(PROCESS) $(DSIG) auto_dsig.o $(LIBS) $(MATRIX) counters.o
 
 $(LIBS): .libs
 
-.libs:
+.libs: ../../Cards/param_card.dat ../../Cards/run_card.dat
 	cd ../../Source; make
 ifneq (,$(wildcard fbridge.inc))
 	$(MAKE) -f $(PLUGIN_MAKEFILE)

--- a/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.auto/CODEGEN_cudacpp_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006921052932739258 [0m
+[1;32mDEBUG: model prefixing  takes 0.0069119930267333984 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -122,6 +122,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m0.940s
-user	0m0.778s
-sys	0m0.132s
+real	0m0.909s
+user	0m0.774s
+sys	0m0.118s

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069293975830078125 [0m
+[1;32mDEBUG: model prefixing  takes 0.006928205490112305 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -86,7 +86,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fec1149aa00> [1;30m[export_v4.py at line 5955][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fe0dea4da00> [1;30m[export_v4.py at line 5955][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -114,11 +114,11 @@ INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 [1;32mDEBUG:  done [1;30m[madgraph_interface.py at line 8458][0m [0m
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.120 s
+Wrote files for 10 helas calls in 0.122 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.175 s
+ALOHA: aloha creates 2 routines in  0.174 s
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
@@ -127,7 +127,7 @@ ALOHA: aloha creates 2 routines in  0.175 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.161 s
+ALOHA: aloha creates 4 routines in  0.160 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -153,6 +153,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.395s
-user	0m2.066s
-sys	0m0.312s
+real	0m3.482s
+user	0m2.058s
+sys	0m0.360s

--- a/epochX/cudacpp/gg_tt.mad/Cards/run_card.dat
+++ b/epochX/cudacpp/gg_tt.mad/Cards/run_card.dat
@@ -51,7 +51,7 @@
 # Renormalization and factorization scales                           *
 #*********************************************************************
  False = fixed_ren_scale  ! if .true. use fixed ren scale
- False = fixed_fac_scale  ! if .true. use fixed fac scale
+     False = fixed_fac_scale  ! if .true. use fixed fac scale
  91.188  = scale            ! fixed ren scale
  91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
  91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2

--- a/epochX/cudacpp/gg_tt.mad/Cards/run_card.dat
+++ b/epochX/cudacpp/gg_tt.mad/Cards/run_card.dat
@@ -50,7 +50,7 @@
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- True = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
  False = fixed_fac_scale  ! if .true. use fixed fac scale
  91.188  = scale            ! fixed ren scale
  91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1

--- a/epochX/cudacpp/gg_tt.mad/Source/run_card.inc
+++ b/epochX/cudacpp/gg_tt.mad/Source/run_card.inc
@@ -36,7 +36,7 @@
 
       LHAID = 230000
 
-      FIXED_REN_SCALE = .TRUE.
+      FIXED_REN_SCALE = .FALSE.
 
       FIXED_FAC_SCALE1 = .FALSE.
 

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
@@ -45,7 +45,7 @@ PLUGIN_CULIB = mg5amc_$(processid_short)_cuda
 PLUGIN_MAKEFILE = Makefile
 PLUGINLIBS = $(LIBDIR)/lib$(PLUGIN_CXXLIB).so $(LIBDIR)/lib$(PLUGIN_CULIB).so
 
-LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS)$(LIBDIR)/lib $(PLUGINLIBS)
+LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS) $(PLUGINLIBS)
 
 # Source files
 

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/makefile
@@ -78,7 +78,7 @@ $(PROG): $(PROCESS) $(DSIG) auto_dsig.o $(LIBS) $(MATRIX) counters.o
 
 $(LIBS): .libs
 
-.libs:
+.libs: ../../Cards/param_card.dat ../../Cards/run_card.dat
 	cd ../../Source; make
 ifneq (,$(wildcard fbridge.inc))
 	$(MAKE) -f $(PLUGIN_MAKEFILE)

--- a/epochX/cudacpp/gg_tt.madonly/CODEGEN_madonly_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.madonly/CODEGEN_madonly_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006906986236572266 [0m
+[1;32mDEBUG: model prefixing  takes 0.006916999816894531 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -84,7 +84,7 @@ Wrote files for 10 helas calls in 0.096 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.173 s
+ALOHA: aloha creates 2 routines in  0.172 s
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
 [1;32mDEBUG:  language = [0m fortran [1;30m[aloha_writers.py at line 2451][0m [0m
@@ -100,6 +100,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.091s
-user	0m1.753s
-sys	0m0.305s
+real	0m2.094s
+user	0m1.748s
+sys	0m0.312s

--- a/epochX/cudacpp/gg_tt.madonly/Cards/run_card.dat
+++ b/epochX/cudacpp/gg_tt.madonly/Cards/run_card.dat
@@ -50,8 +50,8 @@
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- True = fixed_ren_scale  ! if .true. use fixed ren scale
- False = fixed_fac_scale  ! if .true. use fixed fac scale
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+     False = fixed_fac_scale  ! if .true. use fixed fac scale
  91.188  = scale            ! fixed ren scale
  91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
  91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2

--- a/epochX/cudacpp/gg_tt.madonly/Source/run_card.inc
+++ b/epochX/cudacpp/gg_tt.madonly/Source/run_card.inc
@@ -36,7 +36,7 @@
 
       LHAID = 230000
 
-      FIXED_REN_SCALE = .TRUE.
+      FIXED_REN_SCALE = .FALSE.
 
       FIXED_FAC_SCALE1 = .FALSE.
 

--- a/epochX/cudacpp/gg_tt.madonly/SubProcesses/makefile
+++ b/epochX/cudacpp/gg_tt.madonly/SubProcesses/makefile
@@ -45,7 +45,7 @@ PLUGIN_CULIB = mg5amc_$(processid_short)_cuda
 PLUGIN_MAKEFILE = Makefile
 PLUGINLIBS = $(LIBDIR)/lib$(PLUGIN_CXXLIB).so $(LIBDIR)/lib$(PLUGIN_CULIB).so
 
-LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS)$(LIBDIR)/lib $(PLUGINLIBS)
+LIBS = $(LIBDIR)libbias.$(libext) $(LIBDIR)libdhelas.$(libext) $(LIBDIR)libdsample.$(libext) $(LIBDIR)libgeneric.$(libext) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libmodel.$(libext) $(LIBDIR)libcernlib.$(libext) $(MADLOOP_LIB) $(LOOP_LIBS) $(PLUGINLIBS)
 
 # Source files
 
@@ -78,7 +78,7 @@ $(PROG): $(PROCESS) $(DSIG) auto_dsig.o $(LIBS) $(MATRIX) counters.o
 
 $(LIBS): .libs
 
-.libs:
+.libs: ../../Cards/param_card.dat ../../Cards/run_card.dat
 	cd ../../Source; make
 ifneq (,$(wildcard fbridge.inc))
 	$(MAKE) -f $(PLUGIN_MAKEFILE)

--- a/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.auto/CODEGEN_cudacpp_gg_ttg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006898403167724609 [0m
+[1;32mDEBUG: model prefixing  takes 0.006972789764404297 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -101,7 +101,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
-Generated helas calls for 1 subprocesses (16 diagrams) in 0.049 s
+Generated helas calls for 1 subprocesses (16 diagrams) in 0.050 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -109,7 +109,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.393 s
+ALOHA: aloha creates 5 routines in  0.389 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -137,6 +137,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m1.264s
-user	0m1.120s
-sys	0m0.120s
+real	0m1.236s
+user	0m1.097s
+sys	0m0.123s

--- a/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.auto/CODEGEN_cudacpp_gg_ttgg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006883144378662109 [0m
+[1;32mDEBUG: model prefixing  takes 0.0069751739501953125 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.210 s
+1 processes with 123 diagrams generated in 0.208 s
 Total: 1 processes with 123 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttgg
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -103,7 +103,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.574 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.575 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -111,7 +111,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.384 s
+ALOHA: aloha creates 5 routines in  0.383 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 [1;32mDEBUG:  language = [0m <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_ALOHAWriter'> [1;30m[aloha_writers.py at line 2451][0m [0m
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
@@ -145,6 +145,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m2.146s
-user	0m1.996s
-sys	0m0.126s
+real	0m2.144s
+user	0m1.983s
+sys	0m0.131s

--- a/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.auto/CODEGEN_cudacpp_gg_ttggg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006926298141479492 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068895816802978516 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.488 s
+1 processes with 1240 diagrams generated in 2.490 s
 Total: 1 processes with 1240 diagrams
 output standalone_cudacpp CODEGEN_cudacpp_gg_ttggg
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -105,7 +105,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory /data/avalassi/G
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_testxxx [1;30m[model_handling.py at line 1234][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memorybuffers [1;30m[model_handling.py at line 1245][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.edit_memoryaccesscouplings [1;30m[model_handling.py at line 1256][0m [0m
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.024 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.999 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -147,6 +147,6 @@ INFO: /data/avalassi/GPU2020/MG5aMC/3.1.1_lo_vectorization/CODEGEN_cudacpp_gg_tt
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.finalize [1;30m[output.py at line 186][0m [0m
 quit
 
-real	0m17.469s
-user	0m17.258s
-sys	0m0.187s
+real	0m17.473s
+user	0m17.281s
+sys	0m0.175s


### PR DESCRIPTION
This is a PR for #373 and specifically #417.

We can now finally use the full running alphas machinery and get the same physics results in fortran and cudacpp

It also includes a few bug fixes in Makefiles, for bugs I introduced in the previous PR #452