### PR TITLE
Remove helicity filtering from cudacpp ME timers in (c/g)madevent

### DIFF
--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
@@ -1,5 +1,5 @@
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
-index 1734289b..48414a39 100644
+index 1734289b..78bd19ba 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 @@ -76,13 +76,13 @@ C     Keep track of whether cuts already calculated for this event
@@ -46,7 +46,7 @@ index 1734289b..48414a39 100644
        INCLUDE 'maxamps.inc'
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
        DOUBLE PRECISION HEL_RAND(NB_PAGE_MAX)
-@@ -462,22 +463,66 @@ C
+@@ -462,22 +463,74 @@ C
        DOUBLE PRECISION JAMP2_MULTI(0:MAXFLOW, NB_PAGE_MAX)
  
        INTEGER IVEC
@@ -61,6 +61,10 @@ index 1734289b..48414a39 100644
 +      INTEGER*4 NWARNINGS
 +      SAVE NWARNINGS
 +      DATA NWARNINGS/0/
++      
++      LOGICAL FIRST
++      SAVE FIRST
++      DATA FIRST/.TRUE./
 +      
 +      IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 +#endif
@@ -84,6 +88,10 @@ index 1734289b..48414a39 100644
 +      ENDIF
  
 +      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
++        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
++          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
++          FIRST = .FALSE.
++        ENDIF
 +        call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
 +        CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
 +        call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -50,7 +50,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0070455074310302734 [0m
+[1;32mDEBUG: model prefixing  takes 0.006928682327270508 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -83,7 +83,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f5f6c664130> [1;30m[export_v4.py at line 6107][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f4706d0e130> [1;30m[export_v4.py at line 6107][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -109,19 +109,19 @@ DATA em2/1*1D0/ [1;30m[export_v4.py at line 1866][0m [0m
 INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.102 s
+Wrote files for 8 helas calls in 0.101 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.244 s
+ALOHA: aloha creates 3 routines in  0.239 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.308 s
+ALOHA: aloha creates 7 routines in  0.305 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV2
@@ -147,6 +147,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m3.378s
-user	0m2.874s
-sys	0m0.467s
+real	0m3.486s
+user	0m2.966s
+sys	0m0.488s

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -489,6 +489,10 @@ C
       SAVE NWARNINGS
       DATA NWARNINGS/0/
       
+      LOGICAL FIRST
+      SAVE FIRST
+      DATA FIRST/.TRUE./
+      
       IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 #endif
         call counters_smatrix1multi_start( -1, nb_page_loop ) ! fortran=-1
@@ -511,6 +515,10 @@ c!$OMP END PARALLEL
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
+          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
+          FIRST = .FALSE.
+        ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069179534912109375 [0m
+[1;32mDEBUG: model prefixing  takes 0.006901264190673828 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -86,7 +86,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f898fd06550> [1;30m[export_v4.py at line 6107][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f48fb55f550> [1;30m[export_v4.py at line 6107][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -115,11 +115,11 @@ DATA g2/1*1D0/ [1;30m[export_v4.py at line 1866][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.117 s
+Wrote files for 10 helas calls in 0.116 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.173 s
+ALOHA: aloha creates 2 routines in  0.174 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
@@ -146,6 +146,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m3.142s
-user	0m2.646s
-sys	0m0.469s
+real	0m3.213s
+user	0m2.739s
+sys	0m0.454s

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -475,6 +475,10 @@ C
       SAVE NWARNINGS
       DATA NWARNINGS/0/
       
+      LOGICAL FIRST
+      SAVE FIRST
+      DATA FIRST/.TRUE./
+      
       IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 #endif
         call counters_smatrix1multi_start( -1, nb_page_loop ) ! fortran=-1
@@ -497,6 +501,10 @@ c!$OMP END PARALLEL
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
+          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
+          FIRST = .FALSE.
+        ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068056583404541016 [0m
+[1;32mDEBUG: model prefixing  takes 0.006958961486816406 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -86,7 +86,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f64f00c4280> [1;30m[export_v4.py at line 6107][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd88a4ff280> [1;30m[export_v4.py at line 6107][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -117,14 +117,14 @@ DATA g2/1*1D0/ [1;30m[export_v4.py at line 1866][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g WEIGHTED<=3 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxg 
 Generated helas calls for 1 subprocesses (16 diagrams) in 0.050 s
-Wrote files for 36 helas calls in 0.185 s
+Wrote files for 36 helas calls in 0.186 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.396 s
+ALOHA: aloha creates 5 routines in  0.393 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -132,7 +132,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.373 s
+ALOHA: aloha creates 10 routines in  0.375 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -159,6 +159,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m3.823s
-user	0m3.320s
-sys	0m0.453s
+real	0m3.891s
+user	0m3.380s
+sys	0m0.479s

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -475,6 +475,10 @@ C
       SAVE NWARNINGS
       DATA NWARNINGS/0/
       
+      LOGICAL FIRST
+      SAVE FIRST
+      DATA FIRST/.TRUE./
+      
       IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 #endif
         call counters_smatrix1multi_start( -1, nb_page_loop ) ! fortran=-1
@@ -497,6 +501,10 @@ c!$OMP END PARALLEL
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
+          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
+          FIRST = .FALSE.
+        ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069315433502197266 [0m
+[1;32mDEBUG: model prefixing  takes 0.00684666633605957 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.210 s
+1 processes with 123 diagrams generated in 0.208 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -86,7 +86,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fa8aa8cffa0> [1;30m[export_v4.py at line 6107][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd1cbf29fa0> [1;30m[export_v4.py at line 6107][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -118,15 +118,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 DATA g2/1*1D0/ [1;30m[export_v4.py at line 1866][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.578 s
-Wrote files for 222 helas calls in 0.928 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.574 s
+Wrote files for 222 helas calls in 0.929 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.385 s
+ALOHA: aloha creates 5 routines in  0.383 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -164,6 +164,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m5.514s
-user	0m4.973s
-sys	0m0.485s
+real	0m5.524s
+user	0m5.018s
+sys	0m0.486s

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -475,6 +475,10 @@ C
       SAVE NWARNINGS
       DATA NWARNINGS/0/
       
+      LOGICAL FIRST
+      SAVE FIRST
+      DATA FIRST/.TRUE./
+      
       IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 #endif
         call counters_smatrix1multi_start( -1, nb_page_loop ) ! fortran=-1
@@ -497,6 +501,10 @@ c!$OMP END PARALLEL
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
+          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
+          FIRST = .FALSE.
+        ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -50,7 +50,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068814754486083984 [0m
+[1;32mDEBUG: model prefixing  takes 0.006840705871582031 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 INFO: Change particles name to pass to MG5 convention 
 Defined multiparticle p = g u c d s u~ c~ d~ s~
@@ -65,7 +65,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.454 s
+1 processes with 1240 diagrams generated in 2.463 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -88,7 +88,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f4fe83e81f0> [1;30m[export_v4.py at line 6107][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fed5ec4b1f0> [1;30m[export_v4.py at line 6107][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1165][0m [0m
 FileWriter <class 'PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_CPPWriter'> for ././CPPProcess.h
@@ -122,15 +122,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 DATA g2/1*1D0/ [1;30m[export_v4.py at line 1866][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 8.982 s
-Wrote files for 2281 helas calls in 54.603 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.997 s
+Wrote files for 2281 helas calls in 54.902 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.389 s
+ALOHA: aloha creates 5 routines in  0.386 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 177][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -138,7 +138,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.379 s
+ALOHA: aloha creates 10 routines in  0.373 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -168,6 +168,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m12.281s
-user	1m10.678s
-sys	0m1.552s
+real	1m12.613s
+user	1m10.906s
+sys	0m1.592s

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -475,6 +475,10 @@ C
       SAVE NWARNINGS
       DATA NWARNINGS/0/
       
+      LOGICAL FIRST
+      SAVE FIRST
+      DATA FIRST/.TRUE./
+      
       IF( FBRIDGE_MODE .LE. 0 ) THEN ! (FortranOnly=0 or BothQuiet=-1 or BothDebug=-2)
 #endif
         call counters_smatrix1multi_start( -1, nb_page_loop ) ! fortran=-1
@@ -497,6 +501,10 @@ c!$OMP END PARALLEL
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
+          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
+          FIRST = .FALSE.
+        ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2)
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-21_00:20:22
+DATE: 2022-05-22_14:06:15
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 0.1027
- [COUNTERS] PROGRAM TOTAL          :    0.0292s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0165s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0127s for     2080 events => throughput is 1.64E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0295s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0166s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 0.1027
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 4.4e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -1.1e-17 +- 3.7e-18
- [COUNTERS] PROGRAM TOTAL          :    0.0357s
+ [COUNTERS] PROGRAM TOTAL          :    0.0359s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0203s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0150s for     2080 events => throughput is 1.39E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 4.72E+06 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0152s for     2080 events => throughput is 1.37E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 5.33E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.724524e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.747465e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.249867e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.250477e+06                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 0.2477
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.249867e+06                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 4.4e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -1e-16 +- 4.5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.2005s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1874s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2048 events => throughput is 1.60E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0003s for     2048 events => throughput is 6.23E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.2178s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2046s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.47E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.964716e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.752869e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.501007e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.596439e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-21_00:20:23
+DATE: 2022-05-22_13:56:10
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 435.3
- [COUNTERS] PROGRAM TOTAL          :    1.0345s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7514s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2830s for    16416 events => throughput is 5.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0421s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7586s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2835s for    16416 events => throughput is 5.79E+04 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 435.3
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000527 = 1 + 5.3e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.5e-05 +- 2.6e-07
- [COUNTERS] PROGRAM TOTAL          :    1.1252s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8037s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2802s for    16416 events => throughput is 5.86E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1336s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8103s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2821s for    16416 events => throughput is 5.82E+04 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0413s for    16416 events => throughput is 3.98E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.207648e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.204899e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.304379e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.286110e+05                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 448.3
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.304379e+05                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000531 = 1 + 5.3e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.5e-05 +- 2.5e-07
- [COUNTERS] PROGRAM TOTAL          :    1.1902s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.9029s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2862s for    16384 events => throughput is 5.72E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0011s for    16384 events => throughput is 1.47E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.2109s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.9255s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2846s for    16384 events => throughput is 5.76E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.965446e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.922359e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.114831e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.742003e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-22_13:56:10
+DATE: 2022-05-22_14:06:16
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 435.3
- [COUNTERS] PROGRAM TOTAL          :    1.0421s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7586s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2835s for    16416 events => throughput is 5.79E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0412s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7565s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2847s for    16416 events => throughput is 5.77E+04 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 435.3
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000527 = 1 + 5.3e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.5e-05 +- 2.6e-07
- [COUNTERS] PROGRAM TOTAL          :    1.1336s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8103s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2821s for    16416 events => throughput is 5.82E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0413s for    16416 events => throughput is 3.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1307s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8089s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2806s for    16416 events => throughput is 5.85E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0412s for    16416 events => throughput is 3.99E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.204899e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.210578e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.286110e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.286714e+05                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 448.3
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.286110e+05                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000531 = 1 + 5.3e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.5e-05 +- 2.5e-07
- [COUNTERS] PROGRAM TOTAL          :    1.2109s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.9255s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.2846s for    16384 events => throughput is 5.76E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1979s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.9113s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.2858s for    16384 events => throughput is 5.73E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.922359e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.997137e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.742003e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.277936e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-21_00:20:27
+DATE: 2022-05-22_14:06:20
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 420.9
- [COUNTERS] PROGRAM TOTAL          :    0.8778s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3016s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4128 events => throughput is 7.16E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8799s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3044s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5754s for     4128 events => throughput is 7.17E+03 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 420.9
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00555897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.4e-05 +- 2.2e-06
- [COUNTERS] PROGRAM TOTAL          :    0.9438s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3242s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5739s for     4128 events => throughput is 7.19E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9573s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3282s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5833s for     4128 events => throughput is 7.08E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0457s for     4128 events => throughput is 9.03E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.936973e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.895941e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.962214e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.436851e+04                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 504.1
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.962214e+04                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00485078 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.5e-05 +- 2.4e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0559s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4827s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5706s for     4096 events => throughput is 7.18E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0025s for     4096 events => throughput is 1.62E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0554s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4812s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5729s for     4096 events => throughput is 7.15E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.24E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.389996e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.382907e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.202912e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.225369e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-21_00:20:30
+DATE: 2022-05-22_14:06:23
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 651.1
- [COUNTERS] PROGRAM TOTAL          :    1.0757s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1731s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9025s for      544 events => throughput is 6.03E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0706s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1682s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9024s for      544 events => throughput is 6.03E+02 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 651.1
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00126901 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 3.9e-05 +- 4.9e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1545s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1735s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9064s for      544 events => throughput is 6.00E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0746s for      544 events => throughput is 7.29E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1645s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1818s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9101s for      544 events => throughput is 5.98E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0726s for      544 events => throughput is 7.50E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.586049e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.567865e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.417203e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.578205e+03                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 730.5
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.417203e+03                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00210748 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.1e-05 +- 6.1e-06
- [COUNTERS] PROGRAM TOTAL          :    1.2341s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3494s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8498s for      512 events => throughput is 6.03E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0349s for      512 events => throughput is 1.47E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.2589s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3872s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8564s for      512 events => throughput is 5.98E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0153s for      512 events => throughput is 3.34E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.331937e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.569626e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 4.415746e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.752995e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,15 +1,15 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-05-21_00:20:35
+DATE: 2022-05-22_14:06:28
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
 *** EXECUTE MADEVENT (create results.dat) ***
  [XSECTION] Cross section = 80.03
- [COUNTERS] PROGRAM TOTAL          :    3.8459s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2543s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.5915s for       96 events => throughput is 2.67E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.8690s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2538s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6152s for       96 events => throughput is 2.66E+01 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 80.03
@@ -17,20 +17,20 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00014921 = 1 + 0.00015
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-05 +- 2.9e-06
- [COUNTERS] PROGRAM TOTAL          :    4.2679s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2751s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6041s for       96 events => throughput is 2.66E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3887s for       96 events => throughput is 2.47E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.5175s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4516s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7333s for       96 events => throughput is 2.57E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3326s for       96 events => throughput is 2.89E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.899370e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.891759e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.900533e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.895414e+02                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
  [XSECTION] Cross section = 404.9
@@ -38,19 +38,19 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.900533e+02                 )  sec^-1
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00007834 = 1 + 7.8e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.1e-05 +- 2.9e-06
- [COUNTERS] PROGRAM TOTAL          :    3.5877s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4945s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4008s for       64 events => throughput is 2.67E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.6924s for       64 events => throughput is 9.24E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9412s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1635s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4934s for       64 events => throughput is 2.57E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2842s for       64 events => throughput is 2.25E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.032825e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.030810e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.367772e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.366721e+02                 )  sec^-1
 
 TEST COMPLETED


### PR DESCRIPTION
This is a PR addressing #461 - I observed a difference in cudacpp ME throughputs when computed in standalone mode (even in bridge mode) and within cmadevent/gmadevent.

The largest part of the difference (a factor 2, because I only do one iteration in these tests) is due to the fact that I was not removing helicity filtering in the cudacpp timers. So Fortran MEs includes only one ME calculation, while cudacpp includes two (the first one for helicity filtering, the second one for real ME calculation).

This is now fixed in this PR.