### PR TITLE
First attempt to produce cross sections and events using cudacpp MEs (debug common blocks behind SMATRIX1: add RESET_CUMULATIVE_VARIABLE call)

### DIFF
--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.P1
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.P1
@@ -206,10 +206,10 @@ index 104747ce9..0f522165f 100644
              ALL_P1(2,I,IVEC)=-ALL_P1(2,I,IVEC)
              ALL_P1(3,I,IVEC)=-ALL_P1(3,I,IVEC)
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
-index 91e1f5b4e..455d6e33a 100644
+index 91e1f5b4e..1e70e9881 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
-@@ -71,13 +71,41 @@ c      double precision xsec,xerr
+@@ -71,13 +71,42 @@ c      double precision xsec,xerr
  c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
  c      common/to_colstats/ncols,ncolflow,ncolalt,ic
  
@@ -234,6 +234,7 @@ index 91e1f5b4e..455d6e33a 100644
 +#else
 +      NB_PAGE_LOOP = 32
 +#endif
++      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
 +      if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
 +        write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
 +        STOP
@@ -251,7 +252,7 @@ index 91e1f5b4e..455d6e33a 100644
  c
  c     Read process number
  c
-@@ -132,7 +160,8 @@ c   If CKKW-type matching, read IS Sudakov grid
+@@ -132,7 +161,8 @@ c   If CKKW-type matching, read IS Sudakov grid
            exit
   30       issgridfile='../'//issgridfile
            if(i.eq.5)then
@@ -261,7 +262,7 @@ index 91e1f5b4e..455d6e33a 100644
              stop
            endif
          enddo
-@@ -199,8 +228,33 @@ c      call sample_result(xsec,xerr)
+@@ -199,8 +229,33 @@ c      call sample_result(xsec,xerr)
  c      write(*,*) 'Final xsec: ',xsec
  
        rewind(lun)
@@ -296,7 +297,7 @@ index 91e1f5b4e..455d6e33a 100644
        end
  
  c     $B$ get_user_params $B$ ! tag for MadWeight
-@@ -378,7 +432,7 @@ c
+@@ -378,7 +433,7 @@ c
        fopened=.false.
        tempname=filename 	 
        fine=index(tempname,' ') 	 

--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.P1
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.P1
@@ -206,10 +206,10 @@ index 104747ce9..0f522165f 100644
              ALL_P1(2,I,IVEC)=-ALL_P1(2,I,IVEC)
              ALL_P1(3,I,IVEC)=-ALL_P1(3,I,IVEC)
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
-index 91e1f5b4e..1e70e9881 100644
+index 91e1f5b4e..9ed448453 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
-@@ -71,13 +71,42 @@ c      double precision xsec,xerr
+@@ -71,13 +71,44 @@ c      double precision xsec,xerr
  c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
  c      common/to_colstats/ncols,ncolflow,ncolalt,ic
  
@@ -229,6 +229,9 @@ index 91e1f5b4e..1e70e9881 100644
 +      CALL COUNTERS_INITIALISE()
 +
 +#ifdef MG5AMC_MEEXPORTER_CUDACPP
++      write(*,*) 'Enter fbridge_mode'
++      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
 +      write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
 +      read(*,*) nb_page_loop
 +#else
@@ -242,7 +245,6 @@ index 91e1f5b4e..1e70e9881 100644
 +
 +#ifdef MG5AMC_MEEXPORTER_CUDACPP
 +      CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 +      FBRIDGE_NCBYF1 = 0
 +      FBRIDGE_CBYF1SUM = 0
 +      FBRIDGE_CBYF1SUM2 = 0
@@ -252,7 +254,7 @@ index 91e1f5b4e..1e70e9881 100644
  c
  c     Read process number
  c
-@@ -132,7 +161,8 @@ c   If CKKW-type matching, read IS Sudakov grid
+@@ -132,7 +163,8 @@ c   If CKKW-type matching, read IS Sudakov grid
            exit
   30       issgridfile='../'//issgridfile
            if(i.eq.5)then
@@ -262,7 +264,7 @@ index 91e1f5b4e..1e70e9881 100644
              stop
            endif
          enddo
-@@ -199,8 +229,33 @@ c      call sample_result(xsec,xerr)
+@@ -199,8 +231,33 @@ c      call sample_result(xsec,xerr)
  c      write(*,*) 'Final xsec: ',xsec
  
        rewind(lun)
@@ -297,7 +299,7 @@ index 91e1f5b4e..1e70e9881 100644
        end
  
  c     $B$ get_user_params $B$ ! tag for MadWeight
-@@ -378,7 +433,7 @@ c
+@@ -378,7 +435,7 @@ c
        fopened=.false.
        tempname=filename 	 
        fine=index(tempname,' ') 	 

--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
@@ -1,5 +1,5 @@
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
-index 1734289bf..ca06f87bc 100644
+index 1734289bf..dfa970820 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 @@ -76,13 +76,13 @@ C     Keep track of whether cuts already calculated for this event
@@ -46,7 +46,7 @@ index 1734289bf..ca06f87bc 100644
        INCLUDE 'maxamps.inc'
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
        DOUBLE PRECISION HEL_RAND(NB_PAGE_MAX)
-@@ -462,22 +463,109 @@ C
+@@ -462,22 +463,115 @@ C
        DOUBLE PRECISION JAMP2_MULTI(0:MAXFLOW, NB_PAGE_MAX)
  
        INTEGER IVEC
@@ -96,7 +96,7 @@ index 1734289bf..ca06f87bc 100644
 +        call counters_smatrix1multi_stop( -1 ) ! fortran=-1
 +#ifdef MG5AMC_MEEXPORTER_CUDACPP
 +      ENDIF
-+
+ 
 +      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
 +        IF( LIMHEL.NE.0 ) THEN
 +          WRITE(6,*) 'ERROR! The cudacpp bridge only supports LIMHEL=0'
@@ -112,7 +112,7 @@ index 1734289bf..ca06f87bc 100644
 +     &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
 +        ELSE
 +          IF( SDE_STRAT.NE.1 ) THEN
-+            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
++            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
 +            STOP
 +          ENDIF
 +          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,
@@ -120,8 +120,8 @@ index 1734289bf..ca06f87bc 100644
 +        ENDIF
 +        call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
 +      ENDIF
- 
-+      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
++
++      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
 +        DO IVEC=1, NB_PAGE_LOOP
 +          CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
 +          FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -139,6 +139,12 @@ index 1734289bf..ca06f87bc 100644
 +     &        'WARNING! (', NWARNINGS, '/20) Deviation more than 5E-5',
 +     &        IVEC, OUT(IVEC), OUT2(IVEC), 1+CBYF1
 +          ENDIF
++        END DO
++      ENDIF
++
++      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
++        DO IVEC=1, NB_PAGE_LOOP
++          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
 +        END DO
 +      ENDIF
 +#endif

--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
@@ -1,5 +1,5 @@
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
-index 1734289bf..dfa970820 100644
+index 1734289bf..8ce665534 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 @@ -76,13 +76,13 @@ C     Keep track of whether cuts already calculated for this event
@@ -46,7 +46,7 @@ index 1734289bf..dfa970820 100644
        INCLUDE 'maxamps.inc'
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
        DOUBLE PRECISION HEL_RAND(NB_PAGE_MAX)
-@@ -462,22 +463,115 @@ C
+@@ -462,22 +463,119 @@ C
        DOUBLE PRECISION JAMP2_MULTI(0:MAXFLOW, NB_PAGE_MAX)
  
        INTEGER IVEC
@@ -105,6 +105,10 @@ index 1734289bf..dfa970820 100644
 +        IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
 +          CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
 +          FIRST = .FALSE.
++c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
++          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
++            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
++          ENDIF
 +        ENDIF
 +        call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
 +        IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -56,7 +56,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006854057312011719 [0m
+[1;32mDEBUG: model prefixing  takes 0.006863594055175781 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -167,7 +167,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fbc2e44e280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f24554da280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -199,12 +199,12 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.114 s
+Wrote files for 8 helas calls in 0.113 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.240 s
+ALOHA: aloha creates 3 routines in  0.239 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
@@ -237,6 +237,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.413s
-user	0m2.094s
-sys	0m0.299s
+real	0m2.373s
+user	0m2.087s
+sys	0m0.275s

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -56,7 +56,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068628787994384766 [0m
+[1;32mDEBUG: model prefixing  takes 0.006884336471557617 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -167,7 +167,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f1ba615c280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f9f99b4e280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -199,19 +199,19 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.113 s
+Wrote files for 8 helas calls in 0.115 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.238 s
+ALOHA: aloha creates 3 routines in  0.241 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.305 s
+ALOHA: aloha creates 7 routines in  0.309 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV2
@@ -237,6 +237,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.384s
-user	0m2.105s
-sys	0m0.267s
+real	0m2.399s
+user	0m2.102s
+sys	0m0.285s

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -56,7 +56,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006863594055175781 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068628787994384766 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -167,7 +167,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f24554da280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f1ba615c280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -204,7 +204,7 @@ ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.239 s
+ALOHA: aloha creates 3 routines in  0.238 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
@@ -237,6 +237,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.373s
-user	0m2.087s
-sys	0m0.275s
+real	0m2.384s
+user	0m2.105s
+sys	0m0.267s

--- a/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
+++ b/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
@@ -1747,6 +1747,8 @@ c-----
 c  Begin Code
 c-----
 
+      write(*,*) 'DEBUG_SAMPLE_PUT_POINT', wgt
+
       if (first_time) then
          first_time = .false.
          twgt1 = 0d0       !

--- a/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
+++ b/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
@@ -1926,7 +1926,9 @@ C
            call update_discrete_dimensions()
 
             mean=mean*dble(events)/dble(non_zero)
+            write(*,*) 'DEBUG_RMEAN(2a)', non_zero, events, rmean 
             rmean=rmean*dble(events)/dble(non_zero)
+            write(*,*) 'DEBUG_RMEAN(2b)', non_zero, events, rmean 
             twgt1=twgt1*dble(events)/dble(non_zero)
             sigma=sigma+twgt1**2    !This line for averaging over points
             if (non_zero .eq. 0) then
@@ -1937,7 +1939,9 @@ C
 c            mean = mean * itm                 !Used if don't have non_zero
             if (.true.) then
                mean = mean * itm *dble(non_zero)/dble(kn)
+               write(*,*) 'DEBUG_RMEAN(3a)', non_zero, kn, rmean 
                rmean = rmean * itm *dble(non_zero)/dble(kn)
+               write(*,*) 'DEBUG_RMEAN(3b)', non_zero, kn, rmean 
                knt = kn
             endif
 c

--- a/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
+++ b/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
@@ -1747,8 +1747,6 @@ c-----
 c  Begin Code
 c-----
 
-      write(*,*) 'DEBUG_SAMPLE_PUT_POINT', wgt
-
       if (first_time) then
          first_time = .false.
          twgt1 = 0d0       !
@@ -1819,7 +1817,6 @@ c        Add the current point to the DiscreteSamplerGrid
             non_zero = non_zero + 1
             mean = mean + dabs(wgt)
             rmean = rmean + wgt
-            write(*,*) 'DEBUG_RMEAN', non_zero, wgt, rmean 
             if (.true. ) then
 c               psect(ipole)=psect(ipole)+wgt*wgt/alpha(ipole)  !Ohl 
 c               psect(ipole)=1d0                 !Not doing multi_config
@@ -1928,9 +1925,7 @@ C
            call update_discrete_dimensions()
 
             mean=mean*dble(events)/dble(non_zero)
-            write(*,*) 'DEBUG_RMEAN(2a)', non_zero, events, rmean 
             rmean=rmean*dble(events)/dble(non_zero)
-            write(*,*) 'DEBUG_RMEAN(2b)', non_zero, events, rmean 
             twgt1=twgt1*dble(events)/dble(non_zero)
             sigma=sigma+twgt1**2    !This line for averaging over points
             if (non_zero .eq. 0) then
@@ -1941,9 +1936,7 @@ C
 c            mean = mean * itm                 !Used if don't have non_zero
             if (.true.) then
                mean = mean * itm *dble(non_zero)/dble(kn)
-               write(*,*) 'DEBUG_RMEAN(3a)', non_zero, kn, rmean 
                rmean = rmean * itm *dble(non_zero)/dble(kn)
-               write(*,*) 'DEBUG_RMEAN(3b)', non_zero, kn, rmean 
                knt = kn
             endif
 c

--- a/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
+++ b/epochX/cudacpp/ee_mumu.mad/Source/dsample.f
@@ -1817,6 +1817,7 @@ c        Add the current point to the DiscreteSamplerGrid
             non_zero = non_zero + 1
             mean = mean + dabs(wgt)
             rmean = rmean + wgt
+            write(*,*) 'DEBUG_RMEAN', non_zero, wgt, rmean 
             if (.true. ) then
 c               psect(ipole)=psect(ipole)+wgt*wgt/alpha(ipole)  !Ohl 
 c               psect(ipole)=1d0                 !Not doing multi_config

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -571,7 +571,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -539,7 +539,7 @@ c!$OMP END PARALLEL
      &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
         ELSE
           IF( SDE_STRAT.NE.1 ) THEN
-            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
+            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
             STOP
           ENDIF
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,
@@ -548,7 +548,7 @@ c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
       ENDIF
 
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
           FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -566,6 +566,12 @@ c!$OMP END PARALLEL
      &        'WARNING! (', NWARNINGS, '/20) Deviation more than 5E-5',
      &        IVEC, OUT(IVEC), OUT2(IVEC), 1+CBYF1
           ENDIF
+        END DO
+      ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        DO IVEC=1, NB_PAGE_LOOP
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -571,7 +571,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -532,6 +532,10 @@ c!$OMP END PARALLEL
         IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
           FIRST = .FALSE.
+c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
+          ENDIF
         ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
@@ -87,6 +87,9 @@ C-----
       CALL COUNTERS_INITIALISE()
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+      write(*,*) 'Enter fbridge_mode'
+      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
       write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
       read(*,*) nb_page_loop
 #else
@@ -100,7 +103,6 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
@@ -92,6 +92,7 @@ C-----
 #else
       NB_PAGE_LOOP = 32
 #endif
+      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
       if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
         write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
         STOP

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006869792938232422 [0m
+[1;32mDEBUG: model prefixing  takes 0.006872653961181641 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f32bbc27280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f638f0dd280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -209,7 +209,7 @@ Wrote files for 10 helas calls in 0.129 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.173 s
+ALOHA: aloha creates 2 routines in  0.171 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
@@ -236,6 +236,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.206s
-user	0m1.916s
-sys	0m0.263s
+real	0m2.196s
+user	0m1.893s
+sys	0m0.287s

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006872653961181641 [0m
+[1;32mDEBUG: model prefixing  takes 0.006853580474853516 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
 INFO: Process has 3 diagrams 
-1 processes with 3 diagrams generated in 0.010 s
+1 processes with 3 diagrams generated in 0.011 s
 Total: 1 processes with 3 diagrams
 output madevent CODEGEN_mad_gg_tt --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f638f0dd280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f84f56a6280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -205,7 +205,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.129 s
+Wrote files for 10 helas calls in 0.130 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
@@ -214,7 +214,7 @@ ALOHA: aloha creates 2 routines in  0.171 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.160 s
+ALOHA: aloha creates 4 routines in  0.159 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -236,6 +236,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.196s
-user	0m1.893s
-sys	0m0.287s
+real	0m2.202s
+user	0m1.917s
+sys	0m0.272s

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006853580474853516 [0m
+[1;32mDEBUG: model prefixing  takes 0.006881237030029297 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
 INFO: Process has 3 diagrams 
-1 processes with 3 diagrams generated in 0.011 s
+1 processes with 3 diagrams generated in 0.010 s
 Total: 1 processes with 3 diagrams
 output madevent CODEGEN_mad_gg_tt --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f84f56a6280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f95742b8280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -209,12 +209,12 @@ Wrote files for 10 helas calls in 0.130 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.171 s
+ALOHA: aloha creates 2 routines in  0.174 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.159 s
+ALOHA: aloha creates 4 routines in  0.161 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -236,6 +236,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.202s
-user	0m1.917s
-sys	0m0.272s
+real	0m2.241s
+user	0m1.914s
+sys	0m0.296s

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -554,6 +554,12 @@ c!$OMP END PARALLEL
           ENDIF
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN
+        DO IVEC=1, NB_PAGE_LOOP
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -534,7 +534,7 @@ c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
       ENDIF
 
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
           FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -555,7 +555,7 @@ c!$OMP END PARALLEL
         END DO
       ENDIF
 
-      IF( FBRIDGE_MODE .EQ. 1 ) THEN
+      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -525,7 +525,7 @@ c!$OMP END PARALLEL
      &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
         ELSE
           IF( SDE_STRAT.NE.1 ) THEN
-            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
+            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
             STOP
           ENDIF
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -518,6 +518,10 @@ c!$OMP END PARALLEL
         IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
           FIRST = .FALSE.
+c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
+          ENDIF
         ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -87,6 +87,9 @@ C-----
       CALL COUNTERS_INITIALISE()
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+      write(*,*) 'Enter fbridge_mode'
+      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
       write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
       read(*,*) nb_page_loop
 #else
@@ -100,7 +103,6 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -99,7 +99,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -92,6 +92,7 @@ C-----
 #else
       NB_PAGE_LOOP = 32
 #endif
+      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
       if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
         write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
         STOP

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -99,7 +99,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/matrix1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/matrix1.f
@@ -163,14 +163,17 @@ C     ----------
       IF ((ISHEL(IMIRROR).EQ.0.AND.ISUM_HEL.EQ.0)
      $ .OR.(DS_GET_DIM_STATUS('Helicity').EQ.0).OR.(HEL_PICKED.EQ.-1))
      $  THEN
+        write(6,*) 'DEBUG_SMATRIX1 #1'
         DO I=1,NCOMB
           IF (GOODHEL(I,IMIRROR) .OR. NTRY(IMIRROR)
      $     .LE.MAXTRIES.OR.(ISUM_HEL.NE.0).OR.THIS_NTRY(IMIRROR).LE.10)
      $      THEN
+            write(6,*) 'DEBUG_SMATRIX1 #1a'
             T=MATRIX1(P ,NHEL(1,I),JC(1),I,AMP2, JAMP2, IVEC)
 
             IF (ISUM_HEL.NE.0.AND.DS_GET_DIM_STATUS('Helicity')
      $       .EQ.0.AND.ALLOW_HELICITY_GRID_ENTRIES) THEN
+              write(6,*) 'DEBUG_SMATRIX1 #1b'
               CALL DS_ADD_ENTRY('Helicity',I,T)
             ENDIF
             ANS=ANS+DABS(T)
@@ -178,9 +181,11 @@ C     ----------
           ENDIF
         ENDDO
         IF(NTRY(IMIRROR).EQ.(MAXTRIES+1)) THEN
+          write(6,*) 'DEBUG_SMATRIX1 #2'
           CALL RESET_CUMULATIVE_VARIABLE()  ! avoid biais of the initialization
         ENDIF
         IF (ISUM_HEL.NE.0) THEN
+          write(6,*) 'DEBUG_SMATRIX1 #3'
             !         We set HEL_PICKED to -1 here so that later on, the call to DS_add_point in dsample.f does not add anything to the grid since it was already done here.
           HEL_PICKED = -1
             !         For safety, hardset the helicity sampling jacobian to 0.0d0 to make sure it is not .
@@ -195,8 +200,10 @@ C     ----------
             CALL DS_SET_GRID_MODE('Helicity','init')
           ENDIF
         ELSE
+          write(6,*) 'DEBUG_SMATRIX1 #4'
           JHEL(IMIRROR) = 1
           IF(NTRY(IMIRROR).LE.MAXTRIES.OR.THIS_NTRY(IMIRROR).LE.10)THEN
+            write(6,*) 'DEBUG_SMATRIX1 #4a'
             DO I=1,NCOMB
               IF(INIT_MODE) THEN
                 IF (DABS(TS(I)).GT.ANS*LIMHEL/NCOMB) THEN
@@ -214,10 +221,12 @@ C     ----------
             ENDDO
           ENDIF
           IF(NTRY(IMIRROR).EQ.MAXTRIES)THEN
+            write(6,*) 'DEBUG_SMATRIX1 #4b'
             ISHEL(IMIRROR)=MIN(ISUM_HEL,NGOOD(IMIRROR))
           ENDIF
         ENDIF
       ELSE IF (.NOT.INIT_MODE) THEN  ! random helicity 
+        write(6,*) 'DEBUG_SMATRIX1 #5'
 C       The helicity configuration was chosen already by genps and put
 C        in a common block defined in genps.inc.
         I = HEL_PICKED
@@ -232,11 +241,13 @@ C       Include the Jacobian from helicity sampling
 
         WRITE(HEL_BUFF,'(20i5)')(NHEL(II,I),II=1,NEXTERNAL)
       ELSE
+        write(6,*) 'DEBUG_SMATRIX1 #6'
         ANS = 1D0
         call counters_smatrix1_stop()
         RETURN
       ENDIF
       IF (ANS.NE.0D0.AND.(ISUM_HEL .NE. 1.OR.HEL_PICKED.EQ.-1)) THEN
+        write(6,*) 'DEBUG_SMATRIX1 #7'
 C       CALL RANMAR(R) ! rhel passed as input
         SUMHEL=0D0
         DO I=1,NCOMB
@@ -251,6 +262,7 @@ C           Set right sign for ANS, based on sign of chosen helicity
  10     CONTINUE
       ENDIF
       IF (MULTI_CHANNEL) THEN
+        write(6,*) 'DEBUG_SMATRIX1 #8'
         XTOT=0D0
         DO I=1,LMAXCONFIGS
           J = CONFSUB(1, I)

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/matrix1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/matrix1.f
@@ -163,17 +163,14 @@ C     ----------
       IF ((ISHEL(IMIRROR).EQ.0.AND.ISUM_HEL.EQ.0)
      $ .OR.(DS_GET_DIM_STATUS('Helicity').EQ.0).OR.(HEL_PICKED.EQ.-1))
      $  THEN
-        write(6,*) 'DEBUG_SMATRIX1 #1'
         DO I=1,NCOMB
           IF (GOODHEL(I,IMIRROR) .OR. NTRY(IMIRROR)
      $     .LE.MAXTRIES.OR.(ISUM_HEL.NE.0).OR.THIS_NTRY(IMIRROR).LE.10)
      $      THEN
-            write(6,*) 'DEBUG_SMATRIX1 #1a'
             T=MATRIX1(P ,NHEL(1,I),JC(1),I,AMP2, JAMP2, IVEC)
 
             IF (ISUM_HEL.NE.0.AND.DS_GET_DIM_STATUS('Helicity')
      $       .EQ.0.AND.ALLOW_HELICITY_GRID_ENTRIES) THEN
-              write(6,*) 'DEBUG_SMATRIX1 #1b'
               CALL DS_ADD_ENTRY('Helicity',I,T)
             ENDIF
             ANS=ANS+DABS(T)
@@ -181,11 +178,9 @@ C     ----------
           ENDIF
         ENDDO
         IF(NTRY(IMIRROR).EQ.(MAXTRIES+1)) THEN
-          write(6,*) 'DEBUG_SMATRIX1 #2'
           CALL RESET_CUMULATIVE_VARIABLE()  ! avoid biais of the initialization
         ENDIF
         IF (ISUM_HEL.NE.0) THEN
-          write(6,*) 'DEBUG_SMATRIX1 #3'
             !         We set HEL_PICKED to -1 here so that later on, the call to DS_add_point in dsample.f does not add anything to the grid since it was already done here.
           HEL_PICKED = -1
             !         For safety, hardset the helicity sampling jacobian to 0.0d0 to make sure it is not .
@@ -200,10 +195,8 @@ C     ----------
             CALL DS_SET_GRID_MODE('Helicity','init')
           ENDIF
         ELSE
-          write(6,*) 'DEBUG_SMATRIX1 #4'
           JHEL(IMIRROR) = 1
           IF(NTRY(IMIRROR).LE.MAXTRIES.OR.THIS_NTRY(IMIRROR).LE.10)THEN
-            write(6,*) 'DEBUG_SMATRIX1 #4a'
             DO I=1,NCOMB
               IF(INIT_MODE) THEN
                 IF (DABS(TS(I)).GT.ANS*LIMHEL/NCOMB) THEN
@@ -221,12 +214,10 @@ C     ----------
             ENDDO
           ENDIF
           IF(NTRY(IMIRROR).EQ.MAXTRIES)THEN
-            write(6,*) 'DEBUG_SMATRIX1 #4b'
             ISHEL(IMIRROR)=MIN(ISUM_HEL,NGOOD(IMIRROR))
           ENDIF
         ENDIF
       ELSE IF (.NOT.INIT_MODE) THEN  ! random helicity 
-        write(6,*) 'DEBUG_SMATRIX1 #5'
 C       The helicity configuration was chosen already by genps and put
 C        in a common block defined in genps.inc.
         I = HEL_PICKED
@@ -241,13 +232,11 @@ C       Include the Jacobian from helicity sampling
 
         WRITE(HEL_BUFF,'(20i5)')(NHEL(II,I),II=1,NEXTERNAL)
       ELSE
-        write(6,*) 'DEBUG_SMATRIX1 #6'
         ANS = 1D0
         call counters_smatrix1_stop()
         RETURN
       ENDIF
       IF (ANS.NE.0D0.AND.(ISUM_HEL .NE. 1.OR.HEL_PICKED.EQ.-1)) THEN
-        write(6,*) 'DEBUG_SMATRIX1 #7'
 C       CALL RANMAR(R) ! rhel passed as input
         SUMHEL=0D0
         DO I=1,NCOMB
@@ -262,7 +251,6 @@ C           Set right sign for ANS, based on sign of chosen helicity
  10     CONTINUE
       ENDIF
       IF (MULTI_CHANNEL) THEN
-        write(6,*) 'DEBUG_SMATRIX1 #8'
         XTOT=0D0
         DO I=1,LMAXCONFIGS
           J = CONFSUB(1, I)

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006856203079223633 [0m
+[1;32mDEBUG: model prefixing  takes 0.006813526153564453 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f4c0a65b280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fcb0c5a4280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -214,7 +214,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.389 s
+ALOHA: aloha creates 5 routines in  0.391 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -222,7 +222,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.371 s
+ALOHA: aloha creates 10 routines in  0.378 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -249,6 +249,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.838s
-user	0m2.545s
-sys	0m0.278s
+real	0m2.859s
+user	0m2.560s
+sys	0m0.284s

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006886482238769531 [0m
+[1;32mDEBUG: model prefixing  takes 0.006856203079223633 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f7c75f4a280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f4c0a65b280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -207,14 +207,14 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: g g > t t~ g WEIGHTED<=3 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxg 
 Generated helas calls for 1 subprocesses (16 diagrams) in 0.050 s
-Wrote files for 36 helas calls in 0.204 s
+Wrote files for 36 helas calls in 0.200 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.390 s
+ALOHA: aloha creates 5 routines in  0.389 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -222,7 +222,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.370 s
+ALOHA: aloha creates 10 routines in  0.371 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -249,6 +249,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.969s
-user	0m2.549s
-sys	0m0.277s
+real	0m2.838s
+user	0m2.545s
+sys	0m0.278s

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006833076477050781 [0m
+[1;32mDEBUG: model prefixing  takes 0.006886482238769531 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=3: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g WEIGHTED<=3 @1  
 INFO: Process has 16 diagrams 
-1 processes with 16 diagrams generated in 0.028 s
+1 processes with 16 diagrams generated in 0.029 s
 Total: 1 processes with 16 diagrams
 output madevent CODEGEN_mad_gg_ttg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fae059ad280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f7c75f4a280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -207,14 +207,14 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: g g > t t~ g WEIGHTED<=3 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxg 
 Generated helas calls for 1 subprocesses (16 diagrams) in 0.050 s
-Wrote files for 36 helas calls in 0.201 s
+Wrote files for 36 helas calls in 0.204 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.393 s
+ALOHA: aloha creates 5 routines in  0.390 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -222,7 +222,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.376 s
+ALOHA: aloha creates 10 routines in  0.370 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -249,6 +249,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.850s
-user	0m2.553s
-sys	0m0.288s
+real	0m2.969s
+user	0m2.549s
+sys	0m0.277s

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -525,7 +525,7 @@ c!$OMP END PARALLEL
      &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
         ELSE
           IF( SDE_STRAT.NE.1 ) THEN
-            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
+            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
             STOP
           ENDIF
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,
@@ -534,7 +534,7 @@ c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
       ENDIF
 
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
           FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -552,6 +552,12 @@ c!$OMP END PARALLEL
      &        'WARNING! (', NWARNINGS, '/20) Deviation more than 5E-5',
      &        IVEC, OUT(IVEC), OUT2(IVEC), 1+CBYF1
           ENDIF
+        END DO
+      ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        DO IVEC=1, NB_PAGE_LOOP
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -518,6 +518,10 @@ c!$OMP END PARALLEL
         IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
           FIRST = .FALSE.
+c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
+          ENDIF
         ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
@@ -87,6 +87,9 @@ C-----
       CALL COUNTERS_INITIALISE()
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+      write(*,*) 'Enter fbridge_mode'
+      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
       write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
       read(*,*) nb_page_loop
 #else
@@ -100,7 +103,6 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
@@ -92,6 +92,7 @@ C-----
 #else
       NB_PAGE_LOOP = 32
 #endif
+      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
       if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
         write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
         STOP

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006893634796142578 [0m
+[1;32mDEBUG: model prefixing  takes 0.0069141387939453125 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.207 s
+1 processes with 123 diagrams generated in 0.212 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd0579ab700> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f3d467fe700> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -208,15 +208,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.573 s
-Wrote files for 222 helas calls in 1.286 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.584 s
+Wrote files for 222 helas calls in 0.949 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.386 s
+ALOHA: aloha creates 5 routines in  0.388 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -224,7 +224,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.378 s
+ALOHA: aloha creates 10 routines in  0.377 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -254,6 +254,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m4.848s
-user	0m4.200s
-sys	0m0.301s
+real	0m4.579s
+user	0m4.248s
+sys	0m0.281s

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069141387939453125 [0m
+[1;32mDEBUG: model prefixing  takes 0.006845951080322266 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.212 s
+1 processes with 123 diagrams generated in 0.207 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f3d467fe700> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f740fd72700> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -208,15 +208,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.584 s
-Wrote files for 222 helas calls in 0.949 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.578 s
+Wrote files for 222 helas calls in 0.945 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.388 s
+ALOHA: aloha creates 5 routines in  0.386 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -224,7 +224,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.377 s
+ALOHA: aloha creates 10 routines in  0.379 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -254,6 +254,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m4.579s
-user	0m4.248s
-sys	0m0.281s
+real	0m4.527s
+user	0m4.208s
+sys	0m0.308s

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006883382797241211 [0m
+[1;32mDEBUG: model prefixing  takes 0.006893634796142578 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.210 s
+1 processes with 123 diagrams generated in 0.207 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f10f61ec700> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd0579ab700> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -208,15 +208,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.577 s
-Wrote files for 222 helas calls in 0.946 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.573 s
+Wrote files for 222 helas calls in 1.286 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.384 s
+ALOHA: aloha creates 5 routines in  0.386 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -224,7 +224,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.375 s
+ALOHA: aloha creates 10 routines in  0.378 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -254,6 +254,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m4.533s
-user	0m4.205s
-sys	0m0.308s
+real	0m4.848s
+user	0m4.200s
+sys	0m0.301s

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -508,6 +508,11 @@ c!$OMP END DO
 c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( -1 ) ! fortran=-1
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+        DO IVEC=1, NB_PAGE_LOOP
+          DO I=1,MAXFLOW
+           JAMP2_MULTI(I,IVEC)=0
+          ENDDO
+        ENDDO
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -525,7 +525,7 @@ c!$OMP END PARALLEL
      &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
         ELSE
           IF( SDE_STRAT.NE.1 ) THEN
-            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
+            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
             STOP
           ENDIF
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,
@@ -534,7 +534,7 @@ c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
       ENDIF
 
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
           FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -552,6 +552,12 @@ c!$OMP END PARALLEL
      &        'WARNING! (', NWARNINGS, '/20) Deviation more than 5E-5',
      &        IVEC, OUT(IVEC), OUT2(IVEC), 1+CBYF1
           ENDIF
+        END DO
+      ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        DO IVEC=1, NB_PAGE_LOOP
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -518,6 +518,10 @@ c!$OMP END PARALLEL
         IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
           FIRST = .FALSE.
+c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
+          ENDIF
         ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -508,11 +508,6 @@ c!$OMP END DO
 c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( -1 ) ! fortran=-1
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
-        DO IVEC=1, NB_PAGE_LOOP
-          DO I=1,MAXFLOW
-           JAMP2_MULTI(I,IVEC)=0
-          ENDDO
-        ENDDO
       ENDIF
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
@@ -87,6 +87,9 @@ C-----
       CALL COUNTERS_INITIALISE()
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+      write(*,*) 'Enter fbridge_mode'
+      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
       write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
       read(*,*) nb_page_loop
 #else
@@ -100,7 +103,6 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
@@ -92,6 +92,7 @@ C-----
 #else
       NB_PAGE_LOOP = 32
 #endif
+      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
       if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
         write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
         STOP

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006867408752441406 [0m
+[1;32mDEBUG: model prefixing  takes 0.006860017776489258 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.459 s
+1 processes with 1240 diagrams generated in 2.463 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -172,7 +172,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f41ed700280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f61b5f54280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -212,7 +212,7 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.016 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.999 s
 Wrote files for 2281 helas calls in 54.457 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -258,6 +258,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m11.119s
-user	1m9.847s
-sys	0m1.253s
+real	1m11.681s
+user	1m9.745s
+sys	0m1.391s

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006911039352416992 [0m
+[1;32mDEBUG: model prefixing  takes 0.006867408752441406 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.462 s
+1 processes with 1240 diagrams generated in 2.459 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -172,7 +172,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f8a05698280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f41ed700280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -212,15 +212,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.002 s
-Wrote files for 2281 helas calls in 54.583 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 9.016 s
+Wrote files for 2281 helas calls in 54.457 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.398 s
+ALOHA: aloha creates 5 routines in  0.383 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -228,7 +228,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.378 s
+ALOHA: aloha creates 10 routines in  0.375 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -258,6 +258,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m11.291s
-user	1m9.705s
-sys	0m1.510s
+real	1m11.119s
+user	1m9.847s
+sys	0m1.253s

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0069179534912109375 [0m
+[1;32mDEBUG: model prefixing  takes 0.006911039352416992 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.466 s
+1 processes with 1240 diagrams generated in 2.462 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -172,7 +172,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f114d3b0280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f8a05698280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -212,15 +212,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.008 s
-Wrote files for 2281 helas calls in 54.545 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 9.002 s
+Wrote files for 2281 helas calls in 54.583 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.385 s
+ALOHA: aloha creates 5 routines in  0.398 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -228,7 +228,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.375 s
+ALOHA: aloha creates 10 routines in  0.378 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -258,6 +258,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m11.332s
-user	1m10.017s
-sys	0m1.290s
+real	1m11.291s
+user	1m9.705s
+sys	0m1.510s

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -525,7 +525,7 @@ c!$OMP END PARALLEL
      &      P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled
         ELSE
           IF( SDE_STRAT.NE.1 ) THEN
-            WRITE(6,*) 'ERROR! The cudacpp bridge in multichannel mode requires SDE=1'
+            WRITE(6,*) 'ERROR! The cudacpp bridge requires SDE=1' ! multi channel single-diagram enhancement strategy
             STOP
           ENDIF
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE,
@@ -534,7 +534,7 @@ c!$OMP END PARALLEL
         call counters_smatrix1multi_stop( 0 ) ! cudacpp=0
       ENDIF
 
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+      IF( FBRIDGE_MODE .LT. 0 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
           CBYF1 = OUT2(IVEC)/OUT(IVEC) - 1
           FBRIDGE_NCBYF1 = FBRIDGE_NCBYF1 + 1
@@ -552,6 +552,12 @@ c!$OMP END PARALLEL
      &        'WARNING! (', NWARNINGS, '/20) Deviation more than 5E-5',
      &        IVEC, OUT(IVEC), OUT2(IVEC), 1+CBYF1
           ENDIF
+        END DO
+      ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
+        DO IVEC=1, NB_PAGE_LOOP
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -518,6 +518,10 @@ c!$OMP END PARALLEL
         IF ( FIRST ) THEN ! exclude first pass (helicity filtering) from timers (#461)
           CALL FBRIDGESEQUENCE(FBRIDGE_PBRIDGE, P_MULTI, ALL_G, OUT2, 0) ! 0: multi channel disabled for helicity filtering
           FIRST = .FALSE.
+c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
+          ENDIF
         ENDIF
         call counters_smatrix1multi_start( 0, nb_page_loop ) ! cudacpp=0
         IF ( .NOT. MULTI_CHANNEL ) THEN

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -557,7 +557,7 @@ c!$OMP END PARALLEL
 
       IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
         DO IVEC=1, NB_PAGE_LOOP
-          OUT(IVEC) = 2*OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
+          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
@@ -87,6 +87,9 @@ C-----
       CALL COUNTERS_INITIALISE()
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
+      write(*,*) 'Enter fbridge_mode'
+      read(*,*) FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      write(*,'(a16,i6)') ' FBRIDGE_MODE = ', FBRIDGE_MODE
       write(*,*) 'Enter #events in a vector loop (max=',nb_page_max,',)'
       read(*,*) nb_page_loop
 #else
@@ -100,7 +103,6 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
@@ -92,6 +92,7 @@ C-----
 #else
       NB_PAGE_LOOP = 32
 #endif
+      write(*,'(a16,i6)') ' NB_PAGE_LOOP = ', NB_PAGE_LOOP
       if( nb_page_loop.gt.nb_page_max .or. nb_page_loop.le.0 ) then
         write(*,*) 'ERROR! Invalid nb_page_loop = ', nb_page_loop
         STOP

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/driver.f
@@ -100,7 +100,7 @@ C-----
 
 #ifdef MG5AMC_MEEXPORTER_CUDACPP
       CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, NB_PAGE_LOOP, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_MODE = -1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+      FBRIDGE_MODE = 1 ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       FBRIDGE_NCBYF1 = 0
       FBRIDGE_CBYF1SUM = 0
       FBRIDGE_CBYF1SUM2 = 0

--- a/epochX/cudacpp/tmad/allTees.sh
+++ b/epochX/cudacpp/tmad/allTees.sh
@@ -2,6 +2,7 @@
 
 short=0
 makeclean=
+keeprdat=-keeprdat
 
 while [ "$1" != "" ]; do
   if [ "$1" == "-short" ]; then
@@ -17,7 +18,7 @@ while [ "$1" != "" ]; do
 done
 
 if [ "$short" == "1" ]; then
-  ./tmad/teeMadX.sh -eemumu -ggtt -ggttg -ggttgg $makeclean
+  ./tmad/teeMadX.sh -eemumu -ggtt -ggttg -ggttgg $makeclean $keeprdat
 else
-  ./tmad/teeMadX.sh -eemumu -ggtt -ggttg -ggttgg -ggttggg $makeclean
+  ./tmad/teeMadX.sh -eemumu -ggtt -ggttg -ggttgg -ggttggg $makeclean $keeprdat
 fi

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,11 +1,11 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_11:16:39
+DATE: 2022-06-14_13:41:51
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
-*** EXECUTE MADEVENT (create results.dat) ***
+*** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -19,11 +19,11 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0296s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0167s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0301s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0169s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
 
-*** EXECUTE MADEVENT (create events.lhe) ***
+*** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -38,13 +38,13 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1463s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1332s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1467s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1334s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -62,13 +62,13 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
  [COUNTERS] PROGRAM TOTAL          :    0.0359s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0202s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0153s for     2080 events => throughput is 1.36E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 5.02E+06 events/s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0203s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0152s for     2080 events => throughput is 1.37E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 4.82E+06 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -86,22 +86,81 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1472s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1331s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.03E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1461s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1323s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.07E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.564703e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.699385e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.193130e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.185144e+06                 )  sec^-1
 
-*** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+2048 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.09017
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.5252s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.5088s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.57E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0031s for     2080 events => throughput is 6.72E+05 events/s
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+2048 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.09017
+ [UNWEIGHT] Wrote 1009 events (found 1010 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.6410s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6243s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.06E+05 events/s
+
+*** EXECUTE GCHECK -p 64 32 1 --bridge ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.937523e+07                 )  sec^-1
+
+*** EXECUTE GCHECK -p 64 32 1 ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.453235e+07                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
 2048 ! Number of events in a single CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
@@ -120,12 +179,12 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5237s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5106s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.48E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.5208s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.5077s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.42E+07 events/s
 
-*** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
 2048 ! Number of events in a single CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
@@ -145,19 +204,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5780s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5648s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.46E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.5695s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.5561s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2048 events => throughput is 1.54E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.54E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.902762e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.922987e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.375662e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.046033e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:03:56
+DATE: 2022-06-14_16:12:12
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0303s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0175s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0300s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0127s for     2080 events => throughput is 1.63E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,11 +38,11 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
+ [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1462s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1331s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1455s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1323s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1465s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1326s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1568s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1430s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.01E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.352765e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.416657e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.055732e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.941830e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6556s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6389s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.93E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6436s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6268s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.56E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.97E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.755333e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.000391e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.378585e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.581535e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.2175
+ [XSECTION] Cross section = 0.2175 [0.21754196695805308]
  [UNWEIGHT] Wrote 966 events (found 967 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6320s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6190s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.54E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6341s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6210s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.37E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.950755e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.036676e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.881171e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.561102e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:56:18
+DATE: 2022-06-15_10:52:42
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0301s
+ [COUNTERS] PROGRAM TOTAL          :    0.0303s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1466s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1333s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1454s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,30 +58,35 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1330s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.1462s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.1321s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0009s for     2080 events => throughput is 2.22E+06 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.304106e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.685793e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.182660e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.208751e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,30 +96,35 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.182660e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6293s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6260s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.15E+05 events/s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.7213s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7045s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.925952e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.930618e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.114322e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.769053e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 2048 ! Number of events in a single CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -124,25 +134,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.114322e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 2048
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.2175 [0.21754196695805308]
  [UNWEIGHT] Wrote 966 events (found 967 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6173s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6172s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.53E+07 events/s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.6350s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6219s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.57E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.927384e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.933863e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.278155e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.349195e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:52:42
+DATE: 2022-06-15_10:56:18
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0303s
+ [COUNTERS] PROGRAM TOTAL          :    0.0301s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1454s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1466s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1333s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1462s
+ [COUNTERS] PROGRAM TOTAL          :    0.1330s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.1321s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0009s for     2080 events => throughput is 2.22E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.685793e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.304106e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.208751e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.182660e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.208751e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.7213s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7045s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6293s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6260s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.15E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.930618e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.925952e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.769053e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.114322e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 2048 ! Number of events in a single CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.769053e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 2048
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.2175 [0.21754196695805308]
  [UNWEIGHT] Wrote 966 events (found 967 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6350s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6219s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6173s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6172s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.53E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.933863e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.927384e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.349195e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.278155e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:12:12
+DATE: 2022-06-14_18:34:40
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -15,14 +15,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0300s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0127s for     2080 events => throughput is 1.63E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0304s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,18 +35,20 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1455s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1323s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1450s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1320s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -55,6 +58,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -65,23 +69,24 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1568s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1430s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.01E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1458s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1319s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.04E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.416657e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.679864e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.941830e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.811314e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,6 +96,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 5.941830e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -101,23 +107,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6436s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6268s
+ [COUNTERS] PROGRAM TOTAL          :    0.6459s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6290s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.97E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 6.02E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.000391e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.950142e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.581535e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.291370e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 2048 ! Number of events in a single CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -127,6 +134,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.581535e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 2048
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -137,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6341s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6210s
+ [COUNTERS] PROGRAM TOTAL          :    0.6336s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6205s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.37E+07 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.036676e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.810691e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.561102e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.788849e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:33:32
+DATE: 2022-06-14_16:03:56
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0300s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0127s for     2080 events => throughput is 1.64E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0303s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0175s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,8 +40,8 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1451s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1320s
+ [COUNTERS] PROGRAM TOTAL          :    0.1462s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1331s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.1803
- [UNWEIGHT] Wrote 1031 events (found 1388 events)
+ [XSECTION] Cross section = 0.09017
+ [UNWEIGHT] Wrote 1009 events (found 1010 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1777s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1640s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.09E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1465s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1326s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.689490e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.352765e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.188153e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.055732e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.1803
- [UNWEIGHT] Wrote 1031 events (found 1388 events)
+ [XSECTION] Cross section = 0.09017
+ [UNWEIGHT] Wrote 1009 events (found 1010 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6833s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6664s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.55E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6556s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6389s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.93E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.947472e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.755333e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.417871e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.378585e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.4351
- [UNWEIGHT] Wrote 1000 events (found 1340 events)
+ [XSECTION] Cross section = 0.2175
+ [UNWEIGHT] Wrote 966 events (found 967 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6648s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6514s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2048 events => throughput is 1.55E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.38E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6320s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6190s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.54E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.854384e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.950755e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.742033e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.881171e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_13:41:51
+DATE: 2022-06-14_15:00:40
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -19,9 +19,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0301s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0169s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0298s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0168s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -39,32 +39,8 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
  [COUNTERS] PROGRAM TOTAL          :    0.1467s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1334s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
-
-*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-2048 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.0359s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0203s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0152s for     2080 events => throughput is 1.37E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 4.82E+06 events/s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1335s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -86,44 +62,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1461s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1323s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.07E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1579s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1440s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.09E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.699385e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.597479e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.185144e+06                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-2048 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5252s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5088s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0031s for     2080 events => throughput is 6.72E+05 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 5.994737e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,44 +97,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6410s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6243s
+ [COUNTERS] PROGRAM TOTAL          :    0.6521s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6354s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.06E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.97E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.937523e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.913429e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.453235e+07                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-2048 ! Number of events in a single CUDA iteration (nb_page_loop)
-2048 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.2175
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5208s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5077s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.42E+07 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 7.447273e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -199,24 +127,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.2175
- [UNWEIGHT] Wrote 426 events (found 431 events)
+ [UNWEIGHT] Wrote 966 events (found 967 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5695s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5561s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2048 events => throughput is 1.54E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.54E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6288s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6155s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.56E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.50E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.922987e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.001779e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.046033e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.593904e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_09:15:12
+DATE: 2022-06-14_11:16:39
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -14,14 +14,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.Mtu6cI9mKV_fortran > /tmp/avalassi/tmp.Gr88HggzQl'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0929s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0799s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0296s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0167s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -32,15 +32,15 @@ Executing ' ./madevent < /tmp/avalassi/tmp.Mtu6cI9mKV_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.JISGDOO4Ob_fortran > /tmp/avalassi/tmp.wjo37p6G1k'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1453s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1321s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1463s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1332s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -52,7 +52,7 @@ Executing ' ./madevent < /tmp/avalassi/tmp.JISGDOO4Ob_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.XSxpVMdZiZ_cuda > /tmp/avalassi/tmp.YijW1c1KEr'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -61,10 +61,10 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.XSxpVMdZiZ_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.0364s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0207s
+ [COUNTERS] PROGRAM TOTAL          :    0.0359s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0202s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0153s for     2080 events => throughput is 1.36E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 4.77E+06 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0004s for     2080 events => throughput is 5.02E+06 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -76,7 +76,7 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.XSxpVMdZiZ_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.4GLOu1JvmF_cuda > /tmp/avalassi/tmp.EwqsKwjybQ'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -86,20 +86,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.4GLOu1JvmF_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1487s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1347s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.61E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.09E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1472s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1331s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.03E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.696912e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.564703e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.891661e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.193130e+06                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -111,7 +111,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 5.891661e+06                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.vdvavm2wTk_cuda > /tmp/avalassi/tmp.snjPyOq310'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -120,10 +120,10 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.vdvavm2wTk_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5767s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5635s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.53E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.5237s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.5106s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.48E+07 events/s
 
 *** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -135,7 +135,7 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.vdvavm2wTk_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.Y5Fc8ACwIY_cuda > /tmp/avalassi/tmp.VySfKElcPw'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.Y5Fc8ACwIY_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.5748s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.5615s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.48E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.5780s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.5648s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.46E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.904160e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.902762e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.448356e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.375662e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_18:34:40
+DATE: 2022-06-15_10:52:42
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0304s
+ [COUNTERS] PROGRAM TOTAL          :    0.0303s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1450s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1320s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1454s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1458s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1319s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.04E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1462s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1321s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.679864e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.685793e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.811314e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.208751e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6459s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6290s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 6.02E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7213s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7045s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.950142e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.930618e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.291370e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.769053e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6336s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6205s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6350s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6219s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.57E+05 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.810691e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.933863e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.788849e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.349195e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:18:21
+DATE: 2022-06-14_15:26:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -22,7 +22,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Cross section = 0.09017
  [COUNTERS] PROGRAM TOTAL          :    0.0302s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1462s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1332s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1453s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,21 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
- [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1475s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1337s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.07E+06 events/s
+ [XSECTION] Cross section = 0.09066
+ [UNWEIGHT] Wrote 998 events (found 999 events)
+ [COUNTERS] PROGRAM TOTAL          :    0.1320s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1310s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2048 events => throughput is 2.14E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.670162e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.450781e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.021457e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.896461e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +90,21 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017
- [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6475s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6308s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.92E+05 events/s
+ [XSECTION] Cross section = 0.09066
+ [UNWEIGHT] Wrote 998 events (found 999 events)
+ [COUNTERS] PROGRAM TOTAL          :    0.6284s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6251s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0033s for     2048 events => throughput is 6.14E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.946324e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.864972e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.593059e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.709972e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +121,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.2175
+ [XSECTION] Cross section = 0.08975
  [UNWEIGHT] Wrote 966 events (found 967 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6323s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6193s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.59E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.43E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6193s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6192s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.50E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.733111e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.837463e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.531073e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.527751e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:00:40
+DATE: 2022-06-14_15:18:21
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -15,13 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0298s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0168s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0302s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -33,14 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1467s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1335s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1462s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1332s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -53,6 +55,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -62,20 +65,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1579s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1440s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.09E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1475s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1337s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.07E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.597479e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.670162e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.994737e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.021457e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -88,6 +91,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 5.994737e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -97,20 +101,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6521s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6354s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6475s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6308s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.57E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.92E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.913429e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.946324e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.447273e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.593059e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,6 +127,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.447273e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
+ [XSECTION] nb_page_loop = 2048
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -132,19 +137,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6288s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6155s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.50E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6323s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6193s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2048 events => throughput is 1.59E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.43E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.001779e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.733111e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.593904e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.531073e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:26:00
+DATE: 2022-06-14_15:33:32
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0302s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0300s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0127s for     2080 events => throughput is 1.64E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1453s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1451s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1320s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,21 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09066
- [UNWEIGHT] Wrote 998 events (found 999 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1320s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1310s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2048 events => throughput is 2.14E+06 events/s
+ [XSECTION] Cross section = 0.1803
+ [UNWEIGHT] Wrote 1031 events (found 1388 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.1777s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1640s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.09E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.450781e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.689490e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.896461e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.188153e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,21 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09066
- [UNWEIGHT] Wrote 998 events (found 999 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6284s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6251s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0033s for     2048 events => throughput is 6.14E+05 events/s
+ [XSECTION] Cross section = 0.1803
+ [UNWEIGHT] Wrote 1031 events (found 1388 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.6833s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6664s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.55E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.864972e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.947472e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.709972e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.417871e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -121,20 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08975
- [UNWEIGHT] Wrote 966 events (found 967 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6193s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6192s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.50E+07 events/s
+ [XSECTION] Cross section = 0.4351
+ [UNWEIGHT] Wrote 1000 events (found 1340 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
+ [COUNTERS] PROGRAM TOTAL          :    0.6648s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6514s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2048 events => throughput is 1.55E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.38E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.837463e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.854384e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.527751e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.742033e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_13:41:58
+DATE: 2022-06-14_15:00:46
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -19,9 +19,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1058s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7414s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1137s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7505s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3632s for    16416 events => throughput is 4.52E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,33 +38,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4096s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0450s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
-
-*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-16384 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.2109s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8040s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.94E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4133s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0473s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3661s for    16416 events => throughput is 4.48E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -86,44 +62,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5186s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1112s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16416 events => throughput is 4.49E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5561s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1480s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3663s for    16416 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.189298e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.184291e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.260924e+05                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-16384 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.7012s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2531s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3680s for    16416 events => throughput is 4.46E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0802s for    16416 events => throughput is 2.05E+05 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 6.235442e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,44 +97,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0091s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5575s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3682s for    16416 events => throughput is 4.46E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0834s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0141s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5620s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3693s for    16416 events => throughput is 4.44E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0828s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.986440e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.183164e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.600525e+07                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-16384 ! Number of events in a single CUDA iteration (nb_page_loop)
-16384 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 47.67
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.6002s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2340s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 8.941523e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -199,24 +127,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67
- [UNWEIGHT] Wrote 799 events (found 2238 events)
+ [UNWEIGHT] Wrote 804 events (found 2280 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8851s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5193s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3650s for    16384 events => throughput is 4.49E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8820s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5157s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16384 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.11E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.919978e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.184797e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.933576e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.822263e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:18:27
+DATE: 2022-06-14_15:26:06
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1161s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7432s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3729s for    16416 events => throughput is 4.40E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1105s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7457s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3648s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4041s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0395s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4092s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0390s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3703s for    16416 events => throughput is 4.43E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,21 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
- [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5111s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1012s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3681s for    16416 events => throughput is 4.46E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
+ [XSECTION] Cross section = 45.84
+ [UNWEIGHT] Wrote 798 events (found 2234 events)
+ [COUNTERS] PROGRAM TOTAL          :    1.1340s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0924s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16384 events => throughput is 3.94E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.169135e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.128797e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.225665e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.270631e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +90,21 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
- [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0360s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5823s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3707s for    16416 events => throughput is 4.43E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0830s for    16416 events => throughput is 1.98E+05 events/s
+ [XSECTION] Cross section = 45.84
+ [UNWEIGHT] Wrote 798 events (found 2234 events)
+ [COUNTERS] PROGRAM TOTAL          :    1.6254s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5430s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0824s for    16384 events => throughput is 1.99E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.929214e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.155357e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.868536e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.664703e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +121,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 47.67
+ [XSECTION] Cross section = 47.62
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8908s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5245s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5225s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5217s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.928549e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.154634e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.892941e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.057688e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,11 +1,11 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_11:16:43
+DATE: 2022-06-14_13:41:58
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
-*** EXECUTE MADEVENT (create results.dat) ***
+*** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -19,11 +19,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1088s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3650s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1058s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7414s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.50E+04 events/s
 
-*** EXECUTE MADEVENT (create events.lhe) ***
+*** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -38,13 +38,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4113s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0451s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3662s for    16416 events => throughput is 4.48E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4096s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0450s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -61,14 +61,14 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.2099s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8063s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3620s for    16416 events => throughput is 4.54E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.95E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.2109s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8040s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.94E+05 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -86,22 +86,81 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5122s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1032s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3672s for    16416 events => throughput is 4.47E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5186s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1112s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16416 events => throughput is 4.49E+04 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.180340e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.189298e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.267150e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.260924e+05                 )  sec^-1
 
-*** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+16384 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 45.91
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    1.7012s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2531s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3680s for    16416 events => throughput is 4.46E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0802s for    16416 events => throughput is 2.05E+05 events/s
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+16384 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 45.91
+ [UNWEIGHT] Wrote 788 events (found 2238 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    2.0091s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5575s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3682s for    16416 events => throughput is 4.46E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0834s for    16416 events => throughput is 1.97E+05 events/s
+
+*** EXECUTE GCHECK -p 512 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 2.986440e+07                 )  sec^-1
+
+*** EXECUTE GCHECK -p 512 32 1 ***
+Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 8.600525e+07                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
@@ -120,12 +179,12 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.6062s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2398s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6002s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2340s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16384 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
 
-*** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
@@ -145,19 +204,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8899s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5208s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3684s for    16384 events => throughput is 4.45E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.22E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8851s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5193s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3650s for    16384 events => throughput is 4.49E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.921541e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.919978e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.916851e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.933576e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:26:06
+DATE: 2022-06-14_15:33:37
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1105s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7457s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3648s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1063s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7434s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3630s for    16416 events => throughput is 4.52E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4092s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0390s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3703s for    16416 events => throughput is 4.43E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4039s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0385s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,21 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.84
- [UNWEIGHT] Wrote 798 events (found 2234 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1340s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0924s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16384 events => throughput is 3.94E+05 events/s
+ [XSECTION] Cross section = 91.83
+ [UNWEIGHT] Wrote 809 events (found 3156 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    1.6225s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2152s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3654s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.128797e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.184540e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.270631e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.233088e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,21 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.84
- [UNWEIGHT] Wrote 798 events (found 2234 events)
- [COUNTERS] PROGRAM TOTAL          :    1.6254s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5430s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0824s for    16384 events => throughput is 1.99E+05 events/s
+ [XSECTION] Cross section = 91.83
+ [UNWEIGHT] Wrote 809 events (found 3156 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    2.1180s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6611s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3737s for    16416 events => throughput is 4.39E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0832s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.155357e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.077628e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.664703e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.958880e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -121,20 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 47.62
- [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5225s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5217s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
+ [XSECTION] Cross section = 95.34
+ [UNWEIGHT] Wrote 817 events (found 3166 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    1.9984s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6335s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16384 events => throughput is 4.50E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.14E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.154634e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.094655e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.057688e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.015374e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:00:46
+DATE: 2022-06-14_15:18:27
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -15,13 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1137s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7505s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3632s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1161s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7432s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3729s for    16416 events => throughput is 4.40E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -33,14 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4133s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0473s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3661s for    16416 events => throughput is 4.48E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4041s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0395s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -53,6 +55,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -62,20 +65,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5561s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1480s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3663s for    16416 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5111s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1012s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3681s for    16416 events => throughput is 4.46E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.184291e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.169135e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.235442e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.225665e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -88,6 +91,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.235442e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -97,20 +101,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0141s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5620s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3693s for    16416 events => throughput is 4.44E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0828s for    16416 events => throughput is 1.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0360s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5823s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3707s for    16416 events => throughput is 4.43E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0830s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.183164e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.929214e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.941523e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.868536e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,6 +127,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.941523e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
+ [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -132,19 +137,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8820s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5157s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.11E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8908s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5245s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16384 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.184797e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.928549e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.822263e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.892941e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:52:48
+DATE: 2022-06-15_10:56:24
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1100s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7458s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3642s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1103s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7457s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3645s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4062s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0422s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4162s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3726s for    16416 events => throughput is 4.41E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5161s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1098s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.51E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1356s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0939s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.166394e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.146045e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.218249e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.242277e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.218249e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0160s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5648s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3686s for    16416 events => throughput is 4.45E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6323s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5497s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0826s for    16416 events => throughput is 1.99E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.119312e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.903379e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.780467e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.543434e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.780467e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8929s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5253s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3669s for    16384 events => throughput is 4.47E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.21E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5256s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5248s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.22E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.127965e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.924633e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.730683e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.959860e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_18:34:45
+DATE: 2022-06-15_10:52:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1237s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7465s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3772s for    16416 events => throughput is 4.35E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1100s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7458s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3642s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4083s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0401s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3683s for    16416 events => throughput is 4.46E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4062s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0422s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5107s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1034s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16416 events => throughput is 4.49E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0417s for    16416 events => throughput is 3.93E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5161s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1098s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.204293e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.166394e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.268097e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.218249e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0200s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5653s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3713s for    16416 events => throughput is 4.42E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0834s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0160s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5648s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3686s for    16416 events => throughput is 4.45E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0826s for    16416 events => throughput is 1.99E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.897505e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.119312e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.535778e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.780467e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8967s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5306s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.13E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8929s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5253s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3669s for    16384 events => throughput is 4.47E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.21E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.037089e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.127965e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.771817e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.730683e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:33:37
+DATE: 2022-06-14_16:04:01
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1063s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7434s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3630s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1098s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7443s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16416 events => throughput is 4.49E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,8 +40,8 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4039s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0385s
+ [COUNTERS] PROGRAM TOTAL          :    1.4255s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0602s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 91.83
- [UNWEIGHT] Wrote 809 events (found 3156 events)
+ [XSECTION] Cross section = 45.91
+ [UNWEIGHT] Wrote 788 events (found 2238 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.6225s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2152s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3654s for    16416 events => throughput is 4.49E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5108s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0999s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3691s for    16416 events => throughput is 4.45E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.184540e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.146766e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.233088e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.254664e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 91.83
- [UNWEIGHT] Wrote 809 events (found 3156 events)
+ [XSECTION] Cross section = 45.91
+ [UNWEIGHT] Wrote 788 events (found 2238 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.1180s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6611s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3737s for    16416 events => throughput is 4.39E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0832s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0016s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5493s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3687s for    16416 events => throughput is 4.45E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0835s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.077628e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.125346e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.958880e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.674704e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 95.34
- [UNWEIGHT] Wrote 817 events (found 3166 events)
+ [XSECTION] Cross section = 47.67
+ [UNWEIGHT] Wrote 804 events (found 2280 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.9984s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6335s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16384 events => throughput is 4.50E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.14E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8992s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5303s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3681s for    16384 events => throughput is 4.45E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.12E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.094655e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.102278e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.015374e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.841401e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:56:24
+DATE: 2022-06-15_10:52:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1103s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7457s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3645s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1100s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7458s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3642s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4162s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3726s for    16416 events => throughput is 4.41E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4062s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0422s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,30 +58,35 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1356s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0939s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    1.5161s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1098s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.146045e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.166394e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.242277e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.218249e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,30 +96,35 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.242277e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.6323s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5497s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    2.0160s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5648s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3686s for    16416 events => throughput is 4.45E+04 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0826s for    16416 events => throughput is 1.99E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.903379e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.119312e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.543434e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.780467e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -124,25 +134,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.543434e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5256s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5248s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.22E+07 events/s
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
+ [COUNTERS] PROGRAM TOTAL          :    1.8929s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5253s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3669s for    16384 events => throughput is 4.47E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.21E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.924633e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.127965e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.959860e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.730683e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_09:15:16
+DATE: 2022-06-14_11:16:43
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -14,14 +14,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.ZbjhmcVUnF_fortran > /tmp/avalassi/tmp.HUo2mLBkfi'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1966s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8314s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3652s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1088s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3650s for    16416 events => throughput is 4.50E+04 events/s
 
 *** EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -32,15 +32,15 @@ Executing ' ./madevent < /tmp/avalassi/tmp.ZbjhmcVUnF_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.L27e7n3X8j_fortran > /tmp/avalassi/tmp.LzbJQSWuEd'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4112s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0480s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3633s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4113s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0451s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3662s for    16416 events => throughput is 4.48E+04 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -52,7 +52,7 @@ Executing ' ./madevent < /tmp/avalassi/tmp.L27e7n3X8j_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.Rqiwdrb5rL_cuda > /tmp/avalassi/tmp.SWNqRy33Df'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -61,10 +61,10 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.Rqiwdrb5rL_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.2113s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8078s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3624s for    16416 events => throughput is 4.53E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0411s for    16416 events => throughput is 4.00E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.2099s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8063s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3620s for    16416 events => throughput is 4.54E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.95E+05 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -76,7 +76,7 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.Rqiwdrb5rL_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.I0CxuVqR91_cuda > /tmp/avalassi/tmp.sW44JCBuc0'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -86,20 +86,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.I0CxuVqR91_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5095s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1029s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3649s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5122s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1032s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3672s for    16416 events => throughput is 4.47E+04 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.192723e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.180340e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.252708e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.267150e+05                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -111,7 +111,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.252708e+05                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.9xQEZNwGyL_cuda > /tmp/avalassi/tmp.LusgeKCVYI'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -120,10 +120,10 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.9xQEZNwGyL_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.6112s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2441s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3664s for    16384 events => throughput is 4.47E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.18E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6062s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2398s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16384 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
 
 *** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -135,7 +135,7 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.9xQEZNwGyL_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.RaKB0FBSjC_cuda > /tmp/avalassi/tmp.JbpZntuV6T'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.RaKB0FBSjC_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8954s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5288s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3659s for    16384 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8899s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5208s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3684s for    16384 events => throughput is 4.45E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.22E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.900834e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.921541e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.955991e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.916851e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:04:01
+DATE: 2022-06-14_16:12:17
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1098s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7443s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3655s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1066s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7432s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3634s for    16416 events => throughput is 4.52E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,11 +38,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
+ [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4255s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0602s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4104s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0457s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3647s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
+ [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5108s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0999s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3691s for    16416 events => throughput is 4.45E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.93E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5205s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1125s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3662s for    16416 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.146766e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.170971e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.254664e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.224769e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91
+ [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0016s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5493s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3687s for    16416 events => throughput is 4.45E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0835s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0186s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5655s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3704s for    16416 events => throughput is 4.43E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0827s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.125346e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.180982e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.674704e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.787060e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 47.67
+ [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8992s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5303s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3681s for    16384 events => throughput is 4.45E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.12E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8950s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5233s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3709s for    16384 events => throughput is 4.42E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.102278e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.121446e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.841401e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.418370e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:12:17
+DATE: 2022-06-14_18:34:45
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -15,14 +15,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1066s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7432s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3634s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1237s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7465s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3772s for    16416 events => throughput is 4.35E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,18 +35,20 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4104s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0457s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3647s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4083s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0401s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3683s for    16416 events => throughput is 4.46E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -55,6 +58,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -65,23 +69,24 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5205s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1125s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3662s for    16416 events => throughput is 4.48E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5107s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1034s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3656s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0417s for    16416 events => throughput is 3.93E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.170971e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.204293e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.224769e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.268097e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,6 +96,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.224769e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -101,23 +107,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0186s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5655s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3704s for    16416 events => throughput is 4.43E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0827s for    16416 events => throughput is 1.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0200s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5653s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3713s for    16416 events => throughput is 4.42E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0834s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.180982e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.897505e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.787060e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.535778e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -127,6 +134,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.787060e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -137,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8950s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5233s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3709s for    16384 events => throughput is 4.42E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.16E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8967s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5306s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16384 events => throughput is 4.48E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.13E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.121446e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.037089e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.418370e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.771817e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:00:58
+DATE: 2022-06-14_15:18:39
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -15,13 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8884s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3073s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5810s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8879s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3041s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5838s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -33,14 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9549s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3728s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5821s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9589s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3725s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5865s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -53,6 +55,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -62,20 +65,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0415s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4119s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0217s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3929s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.884625e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.899294e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.909066e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.918154e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -88,6 +91,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.909066e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -97,20 +101,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5372s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8696s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5354s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8683s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5811s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.423661e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.376807e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.980444e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.020793e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,6 +127,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 5.980444e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
+ [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -132,19 +137,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4416s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8641s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4439s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8680s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5746s for     4096 events => throughput is 7.13E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.390139e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.357682e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.012097e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.941450e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_09:15:27
+DATE: 2022-06-14_11:16:54
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -14,14 +14,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.2nWXrMEchw_fortran > /tmp/avalassi/tmp.7zusRa37pp'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.9622s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3814s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5808s for     4128 events => throughput is 7.11E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8884s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3059s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5825s for     4128 events => throughput is 7.09E+03 events/s
 
 *** EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -32,15 +32,15 @@ Executing ' ./madevent < /tmp/avalassi/tmp.2nWXrMEchw_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.ph6FRMiHzj_fortran > /tmp/avalassi/tmp.o82TdSIthp'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9689s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3862s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9529s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3697s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5832s for     4128 events => throughput is 7.08E+03 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -52,7 +52,7 @@ Executing ' ./madevent < /tmp/avalassi/tmp.ph6FRMiHzj_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.H3hwJwxyPn_cuda > /tmp/avalassi/tmp.6HS22Mu9my'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -61,10 +61,10 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.H3hwJwxyPn_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    0.9532s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3254s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5810s for     4128 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.83E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9516s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3236s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5813s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0467s for     4128 events => throughput is 8.83E+04 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -76,7 +76,7 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.H3hwJwxyPn_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.rZvEe5mls1_cuda > /tmp/avalassi/tmp.6n6YIv1zFV'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -86,20 +86,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.rZvEe5mls1_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0238s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3936s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5833s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0236s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3940s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5826s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.911804e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.886987e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.910096e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.903653e+04                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -111,7 +111,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.910096e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.SJFVQM6E90_cuda > /tmp/avalassi/tmp.jyXaudyKBO'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -120,10 +120,10 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.SJFVQM6E90_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.3929s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8150s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5766s for     4096 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.23E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.3877s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8108s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5756s for     4096 events => throughput is 7.12E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
 
 *** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -135,7 +135,7 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.SJFVQM6E90_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.rPj42wMJh6_cuda > /tmp/avalassi/tmp.oZBo6Pylx9'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.rPj42wMJh6_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4472s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8684s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5775s for     4096 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.17E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4426s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8658s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5755s for     4096 events => throughput is 7.12E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.22E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.403760e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.373026e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.016442e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.012892e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:04:13
+DATE: 2022-06-14_16:12:29
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8921s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3046s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5875s for     4128 events => throughput is 7.03E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8897s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3050s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5847s for     4128 events => throughput is 7.06E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,11 +38,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
+ [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9570s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3703s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5867s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9588s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3718s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5870s for     4128 events => throughput is 7.03E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0204s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3915s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5822s for     4128 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0466s for     4128 events => throughput is 8.85E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0224s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3933s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5823s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.83E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.892130e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.898048e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.925979e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.899988e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5367s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8656s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5412s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8678s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5875s for     4128 events => throughput is 7.03E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.80E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.372942e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.428984e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.026489e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.007116e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08402
+ [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
  [UNWEIGHT] Wrote 16 events (found 397 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4405s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8622s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5769s for     4096 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.17E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4425s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8613s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5799s for     4096 events => throughput is 7.06E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.399853e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.389314e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.014375e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.014507e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:56:34
+DATE: 2022-06-15_10:53:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8890s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3053s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5837s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8925s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9556s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3693s
+ [COUNTERS] PROGRAM TOTAL          :    0.9572s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3709s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,21 +58,106 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttg_cpp
-   ...
-d R # 3  >    -0.0     0.0     0.0
-d R # 4  >    -0.0    -0.0     0.0
-s min # 3>     0.0119716.0     0.0
-s min # 4>     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0
- RESET CUMULATIVE VARIABLE
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           1
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
+ [UNWEIGHT] Wrote 56 events (found 449 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.0292s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3943s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5881s for     4128 events => throughput is 7.02E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
+
+*** EXECUTE CHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 9.603134e+04                 )  sec^-1
+
+*** EXECUTE CHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 9.827705e+04                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
+ [UNWEIGHT] Wrote 56 events (found 449 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.5562s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8876s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5827s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+
+*** EXECUTE GCHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 3.404555e+06                 )  sec^-1
+
+*** EXECUTE GCHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 6.006376e+06                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+4096 ! Number of events in a single CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 4096
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
+ [UNWEIGHT] Wrote 16 events (found 397 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.4447s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8672s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
+
+*** EXECUTE GCHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 3.389550e+06                 )  sec^-1
+
+*** EXECUTE GCHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 6.008826e+06                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_13:42:15
+DATE: 2022-06-14_15:00:58
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -19,9 +19,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8860s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3043s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5817s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8884s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3073s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5810s for     4128 events => throughput is 7.10E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,33 +38,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9528s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3690s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5838s for     4128 events => throughput is 7.07E+03 events/s
-
-*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    0.9517s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3241s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5809s for     4128 events => throughput is 7.11E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0467s for     4128 events => throughput is 8.83E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9549s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3728s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5821s for     4128 events => throughput is 7.09E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -86,44 +62,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0179s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3895s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5815s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0415s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4119s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4128 events => throughput is 7.08E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.874233e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.884625e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.917587e+04                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4696s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8022s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0856s for     4128 events => throughput is 4.82E+04 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 9.909066e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,44 +97,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5392s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8694s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5839s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5372s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8696s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.10E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.342732e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.423661e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.021289e+06                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-4096 ! Number of events in a single CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08402
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.3963s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8118s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5833s for     4096 events => throughput is 7.02E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.22E+06 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 5.980444e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -199,24 +127,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08402
- [UNWEIGHT] Wrote 22 events (found 386 events)
+ [UNWEIGHT] Wrote 16 events (found 397 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4493s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8652s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4096 events => throughput is 7.03E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.22E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4416s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8641s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.379995e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.390139e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.016398e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.012097e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:12:29
+DATE: 2022-06-14_18:34:57
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -15,14 +15,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8897s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3050s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5847s for     4128 events => throughput is 7.06E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8924s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3071s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,18 +35,20 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9588s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3718s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5870s for     4128 events => throughput is 7.03E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9566s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3707s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5859s for     4128 events => throughput is 7.05E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -55,6 +58,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -65,23 +69,24 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0224s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3933s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5823s for     4128 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.83E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0209s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3922s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5819s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.898048e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.894759e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.899988e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.899449e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,6 +96,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.899988e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -101,23 +107,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5412s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8678s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5875s for     4128 events => throughput is 7.03E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5423s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8735s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.428984e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.357583e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.007116e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.013607e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 4096 ! Number of events in a single CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -127,6 +134,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.007116e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -137,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4425s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8613s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5799s for     4096 events => throughput is 7.06E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4502s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8726s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5764s for     4096 events => throughput is 7.11E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.389314e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.374871e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.014507e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.015046e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:00
+DATE: 2022-06-15_10:56:34
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8925s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8890s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3053s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5837s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9572s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3709s
+ [COUNTERS] PROGRAM TOTAL          :    0.9556s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3693s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,106 +58,21 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
- [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0292s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3943s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5881s for     4128 events => throughput is 7.02E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
-
-*** EXECUTE CHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.603134e+04                 )  sec^-1
-
-*** EXECUTE CHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.827705e+04                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
- [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5562s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8876s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5827s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
-
-*** EXECUTE GCHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.404555e+06                 )  sec^-1
-
-*** EXECUTE GCHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.006376e+06                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-4096 ! Number of events in a single CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 4096
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
- [UNWEIGHT] Wrote 16 events (found 397 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4447s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8672s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
-
-*** EXECUTE GCHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.389550e+06                 )  sec^-1
-
-*** EXECUTE GCHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.008826e+06                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttg_cpp
+   ...
+d R # 3  >    -0.0     0.0     0.0
+d R # 4  >    -0.0    -0.0     0.0
+s min # 3>     0.0119716.0     0.0
+s min # 4>     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0
+ RESET CUMULATIVE VARIABLE
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           1
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:33:50
+DATE: 2022-06-14_16:04:13
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8887s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3035s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8921s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3046s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5875s for     4128 events => throughput is 7.03E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9547s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3686s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5861s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9570s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3703s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5867s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.1609
- [UNWEIGHT] Wrote 51 events (found 619 events)
+ [XSECTION] Cross section = 0.08045
+ [UNWEIGHT] Wrote 56 events (found 449 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0484s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4175s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5840s for     4128 events => throughput is 7.07E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0204s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3915s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5822s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0466s for     4128 events => throughput is 8.85E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.769695e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.892130e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.898318e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.925979e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.1609
- [UNWEIGHT] Wrote 51 events (found 619 events)
+ [XSECTION] Cross section = 0.08045
+ [UNWEIGHT] Wrote 56 events (found 449 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5640s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8900s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5880s for     4128 events => throughput is 7.02E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5367s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8656s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.386084e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.372942e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.874937e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.026489e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.168
- [UNWEIGHT] Wrote 13 events (found 549 events)
+ [XSECTION] Cross section = 0.08402
+ [UNWEIGHT] Wrote 16 events (found 397 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4584s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8819s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5752s for     4096 events => throughput is 7.12E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.18E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4405s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8622s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5769s for     4096 events => throughput is 7.10E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.17E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.359836e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.399853e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.939339e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.014375e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:26:16
+DATE: 2022-06-14_15:33:50
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8867s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3028s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5839s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8887s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3035s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9599s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3703s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5896s for     4128 events => throughput is 7.00E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9547s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3686s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5861s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,16 +59,97 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttg_cpp
-   ...
-   xqcut:      0.0     0.0     0.0
-d R # 3  >    -0.0     0.0     0.0
-d R # 4  >    -0.0    -0.0     0.0
-s min # 3>     0.0119716.0     0.0
-s min # 4>     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           1
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 0.1609
+ [UNWEIGHT] Wrote 51 events (found 619 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.0484s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4175s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5840s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
+
+*** EXECUTE CHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 9.769695e+04                 )  sec^-1
+
+*** EXECUTE CHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 9.898318e+04                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.1609
+ [UNWEIGHT] Wrote 51 events (found 619 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.5640s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8900s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5880s for     4128 events => throughput is 7.02E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
+
+*** EXECUTE GCHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 3.386084e+06                 )  sec^-1
+
+*** EXECUTE GCHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 5.874937e+06                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+4096 ! Number of events in a single CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
+ [XSECTION] nb_page_loop = 4096
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.168
+ [UNWEIGHT] Wrote 13 events (found 549 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.4584s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8819s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5752s for     4096 events => throughput is 7.12E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.18E+06 events/s
+
+*** EXECUTE GCHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 3.359836e+06                 )  sec^-1
+
+*** EXECUTE GCHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 5.939339e+06                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_18:34:57
+DATE: 2022-06-15_10:53:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8924s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3071s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5852s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8925s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9566s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3707s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5859s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9572s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3709s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0209s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3922s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5819s for     4128 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0292s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3943s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5881s for     4128 events => throughput is 7.02E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.894759e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.603134e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.899449e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.827705e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5423s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8735s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5562s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8876s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5827s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.357583e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.404555e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.013607e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.006376e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4502s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8726s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5764s for     4096 events => throughput is 7.11E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4447s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8672s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.374871e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.389550e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.015046e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.008826e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:18:39
+DATE: 2022-06-14_15:26:16
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8879s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3041s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5838s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8867s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3028s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5839s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9589s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3725s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5865s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9599s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3703s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5896s for     4128 events => throughput is 7.00E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,97 +59,16 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
- [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0217s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3929s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
-
-*** EXECUTE CHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.899294e+04                 )  sec^-1
-
-*** EXECUTE CHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.918154e+04                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045
- [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5354s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8683s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5811s for     4128 events => throughput is 7.10E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
-
-*** EXECUTE GCHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.376807e+06                 )  sec^-1
-
-*** EXECUTE GCHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.020793e+06                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-4096 ! Number of events in a single CUDA iteration (nb_page_loop)
-4096 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
- [XSECTION] nb_page_loop = 4096
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08402
- [UNWEIGHT] Wrote 16 events (found 397 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4439s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8680s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5746s for     4096 events => throughput is 7.13E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
-
-*** EXECUTE GCHECK -p 128 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.357682e+06                 )  sec^-1
-
-*** EXECUTE GCHECK -p 128 32 1 ***
-Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.941450e+06                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttg_cpp
+   ...
+   xqcut:      0.0     0.0     0.0
+d R # 3  >    -0.0     0.0     0.0
+d R # 4  >    -0.0    -0.0     0.0
+s min # 3>     0.0119716.0     0.0
+s min # 4>     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           1
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,11 +1,11 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_11:16:54
+DATE: 2022-06-14_13:42:15
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
-*** EXECUTE MADEVENT (create results.dat) ***
+*** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -19,11 +19,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8884s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3059s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5825s for     4128 events => throughput is 7.09E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8860s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3043s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5817s for     4128 events => throughput is 7.10E+03 events/s
 
-*** EXECUTE MADEVENT (create events.lhe) ***
+*** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -38,13 +38,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9529s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3697s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5832s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9528s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3690s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5838s for     4128 events => throughput is 7.07E+03 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -61,14 +61,14 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    0.9516s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3236s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5813s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9517s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3241s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5809s for     4128 events => throughput is 7.11E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0467s for     4128 events => throughput is 8.83E+04 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -86,22 +86,81 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0236s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3940s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5826s for     4128 events => throughput is 7.09E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0179s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3895s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5815s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.82E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.886987e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.874233e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.903653e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.917587e+04                 )  sec^-1
 
-*** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.08045
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.4696s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8022s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5818s for     4128 events => throughput is 7.10E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0856s for     4128 events => throughput is 4.82E+04 events/s
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+4096 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.08045
+ [UNWEIGHT] Wrote 56 events (found 449 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.5392s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8694s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5839s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+
+*** EXECUTE GCHECK -p 128 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 3.342732e+06                 )  sec^-1
+
+*** EXECUTE GCHECK -p 128 32 1 ***
+Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 6.021289e+06                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
 4096 ! Number of events in a single CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
@@ -120,12 +179,12 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.3877s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8108s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5756s for     4096 events => throughput is 7.12E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.3963s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8118s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5833s for     4096 events => throughput is 7.02E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.22E+06 events/s
 
-*** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
 4096 ! Number of events in a single CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
@@ -145,19 +204,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4426s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8658s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5755s for     4096 events => throughput is 7.12E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4493s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8652s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5828s for     4096 events => throughput is 7.03E+03 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.22E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.373026e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.379995e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.012892e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.016398e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:01:08
+DATE: 2022-06-14_15:18:49
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -15,13 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0873s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1673s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9200s for      544 events => throughput is 5.91E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0993s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9333s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -33,14 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.0997s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1779s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9218s for      544 events => throughput is 5.90E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1126s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9329s for      544 events => throughput is 5.83E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -53,6 +55,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -62,20 +65,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1882s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1985s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9134s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0763s for      544 events => throughput is 7.13E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1773s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1903s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0747s for      544 events => throughput is 7.28E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.538649e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.532350e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.539446e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.536778e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -88,6 +91,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.539446e+03                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -97,20 +101,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8557s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7248s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9170s for      544 events => throughput is 5.93E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2140s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8454s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7197s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9115s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2142s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756318e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757123e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977836e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975961e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,6 +127,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.977836e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
+ [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -132,19 +137,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6284s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7512s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8594s for      512 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6206s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7459s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8568s for      512 events => throughput is 5.98E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758682e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756918e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.981751e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980430e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_13:42:30
+DATE: 2022-06-14_15:01:08
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -19,9 +19,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0866s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1664s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9202s for      544 events => throughput is 5.91E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0873s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1673s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9200s for      544 events => throughput is 5.91E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,33 +38,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1017s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1802s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9215s for      544 events => throughput is 5.90E+02 events/s
-
-*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1662s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1777s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9136s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0997s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1779s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9218s for      544 events => throughput is 5.90E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -86,44 +62,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1812s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1919s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9144s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1882s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1985s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9134s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0763s for      544 events => throughput is 7.13E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.534697e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.538649e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.552250e+03                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8341s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7063s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9140s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2139s for      544 events => throughput is 2.54E+03 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 7.539446e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,44 +97,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8457s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7195s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2138s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8557s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7248s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9170s for      544 events => throughput is 5.93E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2140s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756895e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756318e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980790e+04                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-512 ! Number of events in a single CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002221
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6119s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7349s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8592s for      512 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977836e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -199,24 +127,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221
- [UNWEIGHT] Wrote 6 events (found 66 events)
+ [UNWEIGHT] Wrote 7 events (found 79 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6359s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7546s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8636s for      512 events => throughput is 5.93E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6284s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7512s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8594s for      512 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.760762e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758682e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.982875e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981751e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_18:35:07
+DATE: 2022-06-15_10:53:10
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1031s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1664s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9367s for      544 events => throughput is 5.81E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0994s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9335s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1119s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1773s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9347s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1194s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9397s for      544 events => throughput is 5.79E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1805s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1910s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9147s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.2001s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1898s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9354s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.547784e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.519028e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.537440e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.533124e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8481s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7202s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9138s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2140s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8701s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9371s for      544 events => throughput is 5.81E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2143s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758506e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756425e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.984678e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978130e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6248s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7474s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8595s for      512 events => throughput is 5.96E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6406s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8790s for      512 events => throughput is 5.82E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757615e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756175e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.983536e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980393e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:18:49
+DATE: 2022-06-14_15:26:19
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0993s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9333s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0995s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1658s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9337s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1126s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9329s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1125s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1783s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9341s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,97 +59,16 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
- [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1773s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1903s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0747s for      544 events => throughput is 7.28E+03 events/s
-
-*** EXECUTE CHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.532350e+03                 )  sec^-1
-
-*** EXECUTE CHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.536778e+03                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
- [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8454s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7197s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9115s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2142s for      544 events => throughput is 2.54E+03 events/s
-
-*** EXECUTE GCHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757123e+04                 )  sec^-1
-
-*** EXECUTE GCHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975961e+04                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-512 ! Number of events in a single CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
- [XSECTION] nb_page_loop = 512
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002221
- [UNWEIGHT] Wrote 7 events (found 79 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6206s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7459s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8568s for      512 events => throughput is 5.98E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
-
-*** EXECUTE GCHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756918e+04                 )  sec^-1
-
-*** EXECUTE GCHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980430e+04                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttgg_cpp
+   ...
+d R # 5  >    -0.0    -0.0    -0.0     0.4
+s min # 3>     0.0119716.0 29929.0     0.0
+s min # 4>     0.0     0.0 29929.0     0.0
+s min # 5>     0.0     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0     0.0
+xqcutij # 5>     0.0     0.0     0.0     0.0
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           2
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:56:37
+DATE: 2022-06-15_10:53:10
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1017s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1669s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9348s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0994s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9335s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1127s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1783s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9344s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1194s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9397s for      544 events => throughput is 5.79E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,21 +58,106 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttgg_cpp
-   ...
-s min # 3>     0.0119716.0 29929.0     0.0
-s min # 4>     0.0     0.0 29929.0     0.0
-s min # 5>     0.0     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0     0.0
-xqcutij # 5>     0.0     0.0     0.0     0.0
- RESET CUMULATIVE VARIABLE
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           2
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
+ [UNWEIGHT] Wrote 4 events (found 74 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.2001s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1898s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9354s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
+
+*** EXECUTE CHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.519028e+03                 )  sec^-1
+
+*** EXECUTE CHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.533124e+03                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
+ [UNWEIGHT] Wrote 4 events (found 74 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.8701s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9371s for      544 events => throughput is 5.81E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2143s for      544 events => throughput is 2.54E+03 events/s
+
+*** EXECUTE GCHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756425e+04                 )  sec^-1
+
+*** EXECUTE GCHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978130e+04                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+512 ! Number of events in a single CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 512
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
+ [UNWEIGHT] Wrote 7 events (found 79 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.6406s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8790s for      512 events => throughput is 5.82E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
+
+*** EXECUTE GCHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756175e+04                 )  sec^-1
+
+*** EXECUTE GCHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980393e+04                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:04:23
+DATE: 2022-06-14_16:12:39
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1006s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1655s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9351s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0991s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1652s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9339s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,11 +38,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
+ [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1141s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1786s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9355s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1153s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1810s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9344s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1739s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1876s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9113s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1796s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1936s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9111s for      544 events => throughput is 5.97E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.545424e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.519100e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.533785e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.539141e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8449s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9111s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2150s for      544 events => throughput is 2.53E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8440s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7177s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9121s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2141s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758768e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758381e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978919e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980385e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002221
+ [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6232s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7452s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8603s for      512 events => throughput is 5.95E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6183s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7430s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8576s for      512 events => throughput is 5.97E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758408e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.755883e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.974133e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980899e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:12:39
+DATE: 2022-06-14_18:35:07
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -15,14 +15,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0991s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1652s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9339s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1031s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1664s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9367s for      544 events => throughput is 5.81E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,18 +35,20 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1153s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1810s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9344s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1119s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1773s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9347s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -55,6 +58,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -65,23 +69,24 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1796s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1936s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9111s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1805s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1910s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9147s for      544 events => throughput is 5.95E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.519100e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.547784e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.539141e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.537440e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,6 +96,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.539141e+03                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -101,23 +107,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8440s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7177s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9121s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2141s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8481s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7202s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9138s for      544 events => throughput is 5.95E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2140s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758381e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758506e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980385e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.984678e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 512 ! Number of events in a single CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -127,6 +134,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.980385e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -137,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6183s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7430s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8576s for      512 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6248s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7474s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8595s for      512 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.755883e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757615e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980899e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.983536e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:26:19
+DATE: 2022-06-14_15:34:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0995s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1658s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9337s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0990s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1638s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9352s for      544 events => throughput is 5.82E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1125s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1783s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9341s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1104s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1775s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9329s for      544 events => throughput is 5.83E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,16 +59,97 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttgg_cpp
-   ...
-d R # 5  >    -0.0    -0.0    -0.0     0.4
-s min # 3>     0.0119716.0 29929.0     0.0
-s min # 4>     0.0     0.0 29929.0     0.0
-s min # 5>     0.0     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0     0.0
-xqcutij # 5>     0.0     0.0     0.0     0.0
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           2
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 0.0002577
+ [UNWEIGHT] Wrote 8 events (found 102 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.1825s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1957s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9119s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0750s for      544 events => throughput is 7.26E+03 events/s
+
+*** EXECUTE CHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.540909e+03                 )  sec^-1
+
+*** EXECUTE CHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.532131e+03                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0002577
+ [UNWEIGHT] Wrote 8 events (found 102 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.8547s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7282s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9114s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2152s for      544 events => throughput is 2.53E+03 events/s
+
+*** EXECUTE GCHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.750572e+04                 )  sec^-1
+
+*** EXECUTE GCHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.983460e+04                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+512 ! Number of events in a single CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
+ [XSECTION] nb_page_loop = 512
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0004442
+ [UNWEIGHT] Wrote 7 events (found 96 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.6216s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7473s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8565s for      512 events => throughput is 5.98E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+
+*** EXECUTE GCHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.749354e+04                 )  sec^-1
+
+*** EXECUTE GCHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980994e+04                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,11 +1,11 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_11:17:03
+DATE: 2022-06-14_13:42:30
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
-*** EXECUTE MADEVENT (create results.dat) ***
+*** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -19,11 +19,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0867s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9207s for      544 events => throughput is 5.91E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0866s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1664s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9202s for      544 events => throughput is 5.91E+02 events/s
 
-*** EXECUTE MADEVENT (create events.lhe) ***
+*** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -38,13 +38,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1025s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9228s for      544 events => throughput is 5.90E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1017s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1802s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9215s for      544 events => throughput is 5.90E+02 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -61,14 +61,14 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1680s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1799s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9132s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1662s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1777s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9136s for      544 events => throughput is 5.95E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -86,22 +86,81 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1783s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1910s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9124s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0750s for      544 events => throughput is 7.25E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1812s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1919s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9144s for      544 events => throughput is 5.95E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.539624e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.534697e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.537693e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.552250e+03                 )  sec^-1
 
-*** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0001289
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.8341s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7063s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9140s for      544 events => throughput is 5.95E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2139s for      544 events => throughput is 2.54E+03 events/s
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+512 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 2
+ [XSECTION] Cross section = 0.0001289
+ [UNWEIGHT] Wrote 4 events (found 74 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
+ [COUNTERS] PROGRAM TOTAL          :    1.8457s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7195s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2138s for      544 events => throughput is 2.54E+03 events/s
+
+*** EXECUTE GCHECK -p 16 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756895e+04                 )  sec^-1
+
+*** EXECUTE GCHECK -p 16 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980790e+04                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
 512 ! Number of events in a single CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
@@ -120,12 +179,12 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6104s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7338s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8588s for      512 events => throughput is 5.96E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6119s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7349s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8592s for      512 events => throughput is 5.96E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
-*** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
 512 ! Number of events in a single CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
@@ -145,19 +204,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6203s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7434s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8591s for      512 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6359s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7546s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8636s for      512 events => throughput is 5.93E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758645e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.760762e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.981106e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.982875e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:10
+DATE: 2022-06-15_10:56:37
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0994s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9335s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1017s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1669s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9348s for      544 events => throughput is 5.82E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1194s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9397s for      544 events => throughput is 5.79E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1127s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1783s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9344s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,106 +58,21 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
- [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.2001s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1898s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9354s for      544 events => throughput is 5.82E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
-
-*** EXECUTE CHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.519028e+03                 )  sec^-1
-
-*** EXECUTE CHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.533124e+03                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
- [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8701s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9371s for      544 events => throughput is 5.81E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2143s for      544 events => throughput is 2.54E+03 events/s
-
-*** EXECUTE GCHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756425e+04                 )  sec^-1
-
-*** EXECUTE GCHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978130e+04                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-512 ! Number of events in a single CUDA iteration (nb_page_loop)
-512 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 512
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
- [UNWEIGHT] Wrote 7 events (found 79 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6406s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8790s for      512 events => throughput is 5.82E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
-
-*** EXECUTE GCHECK -p 16 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756175e+04                 )  sec^-1
-
-*** EXECUTE GCHECK -p 16 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980393e+04                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttgg_cpp
+   ...
+s min # 3>     0.0119716.0 29929.0     0.0
+s min # 4>     0.0     0.0 29929.0     0.0
+s min # 5>     0.0     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0     0.0
+xqcutij # 5>     0.0     0.0     0.0     0.0
+ RESET CUMULATIVE VARIABLE
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           2
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_09:15:36
+DATE: 2022-06-14_11:17:03
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -14,14 +14,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.eL43j9TTO2_fortran > /tmp/avalassi/tmp.Er2E67Bb5V'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1766s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2555s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9211s for      544 events => throughput is 5.91E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0867s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9207s for      544 events => throughput is 5.91E+02 events/s
 
 *** EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -32,15 +32,15 @@ Executing ' ./madevent < /tmp/avalassi/tmp.eL43j9TTO2_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.6OMKcfQyTP_fortran > /tmp/avalassi/tmp.MgWeK6BTQc'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1210s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1974s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9236s for      544 events => throughput is 5.89E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1025s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9228s for      544 events => throughput is 5.90E+02 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -52,7 +52,7 @@ Executing ' ./madevent < /tmp/avalassi/tmp.6OMKcfQyTP_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.b1h3spAZEy_cuda > /tmp/avalassi/tmp.qvoN5w5Ftd'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -61,10 +61,10 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.b1h3spAZEy_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1707s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1823s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9135s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1680s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1799s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9132s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -76,7 +76,7 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.b1h3spAZEy_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.vq3P5EVtxg_cuda > /tmp/avalassi/tmp.LdKRVual18'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -86,20 +86,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.vq3P5EVtxg_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1825s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1939s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9137s for      544 events => throughput is 5.95E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1783s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1910s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9124s for      544 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0750s for      544 events => throughput is 7.25E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.546028e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.539624e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.544091e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.537693e+03                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -111,7 +111,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.544091e+03                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.iU9g3JuJAr_cuda > /tmp/avalassi/tmp.uUqxP4EhLc'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -120,10 +120,10 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.iU9g3JuJAr_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6127s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7364s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8584s for      512 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6104s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7338s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8588s for      512 events => throughput is 5.96E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -135,7 +135,7 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.iU9g3JuJAr_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.aBzxC3W6ce_cuda > /tmp/avalassi/tmp.li7V7EwQb5'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.aBzxC3W6ce_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6262s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7471s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8612s for      512 events => throughput is 5.94E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6203s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7434s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8591s for      512 events => throughput is 5.96E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757507e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758645e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.985018e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981106e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:34:00
+DATE: 2022-06-14_16:04:23
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0990s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1638s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9352s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1006s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1655s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9351s for      544 events => throughput is 5.82E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1104s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1775s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9329s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1141s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1786s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9355s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002577
- [UNWEIGHT] Wrote 8 events (found 102 events)
+ [XSECTION] Cross section = 0.0001289
+ [UNWEIGHT] Wrote 4 events (found 74 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1825s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1957s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9119s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0750s for      544 events => throughput is 7.26E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1739s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1876s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9113s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.540909e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.545424e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.532131e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.533785e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002577
- [UNWEIGHT] Wrote 8 events (found 102 events)
+ [XSECTION] Cross section = 0.0001289
+ [UNWEIGHT] Wrote 4 events (found 74 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8547s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7282s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9114s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2152s for      544 events => throughput is 2.53E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8449s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9111s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2150s for      544 events => throughput is 2.53E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.750572e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758768e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.983460e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978919e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0004442
- [UNWEIGHT] Wrote 7 events (found 96 events)
+ [XSECTION] Cross section = 0.0002221
+ [UNWEIGHT] Wrote 7 events (found 79 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6216s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7473s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8565s for      512 events => throughput is 5.98E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6232s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7452s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8603s for      512 events => throughput is 5.95E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.749354e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758408e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980994e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.974133e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,11 +1,11 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_11:17:14
+DATE: 2022-06-14_13:42:46
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
-*** EXECUTE MADEVENT (create results.dat) ***
+*** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -19,11 +19,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9019s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2449s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6569s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.8862s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2450s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6412s for       96 events => throughput is 2.64E+01 events/s
 
-*** EXECUTE MADEVENT (create events.lhe) ***
+*** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -38,13 +38,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9039s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2484s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6555s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9009s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2493s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6515s for       96 events => throughput is 2.63E+01 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -61,14 +61,14 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5065s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4466s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6586s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.4013s for       96 events => throughput is 2.39E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4970s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4440s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6560s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3969s for       96 events => throughput is 2.42E+02 events/s
 
-*** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
+*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-32 ! Number of events in a single C++ iteration (nb_page_loop)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
 0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
@@ -86,22 +86,81 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4954s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4480s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6475s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3999s for       96 events => throughput is 2.40E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.5139s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4493s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6662s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3983s for       96 events => throughput is 2.41E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.831264e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.832113e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.823893e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.837245e+02                 )  sec^-1
 
-*** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 3.447e-07
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    6.0262s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5074s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6459s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 3.447e-07
+ [UNWEIGHT] Wrote 4 events (found 15 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    6.0137s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5028s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6394s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8715s for       96 events => throughput is 1.10E+02 events/s
+
+*** EXECUTE GCHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764303e+02                 )  sec^-1
+
+*** EXECUTE GCHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977983e+02                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
 64 ! Number of events in a single CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
@@ -120,12 +179,12 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4528s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6478s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4381s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4349s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6401s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4285s for       64 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
 
-*** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
 64 ! Number of events in a single CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
@@ -145,19 +204,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4427s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6412s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4352s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4409s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6421s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4326s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3661s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.763672e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764068e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978593e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977356e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:56:39
+DATE: 2022-06-15_10:53:21
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9604s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2434s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7170s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9445s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2448s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6997s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9639s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7158s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9511s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2467s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7044s for       96 events => throughput is 2.59E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
-+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,21 +58,106 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = 1
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttggg_cpp
-   ...
-s min # 5>     0.0     0.0     0.0     0.0     0.0
-s min # 6>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 5>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 6>     0.0     0.0     0.0     0.0     0.0
- RESET CUMULATIVE VARIABLE
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           1
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
+ [UNWEIGHT] Wrote 4 events (found 15 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    4.5336s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4476s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6945s for       96 events => throughput is 2.60E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3915s for       96 events => throughput is 2.45E+02 events/s
+
+*** EXECUTE CHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 2.839455e+02                 )  sec^-1
+
+*** EXECUTE CHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 2.834996e+02                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
+ [UNWEIGHT] Wrote 4 events (found 15 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    5.7932s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2535s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6680s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8718s for       96 events => throughput is 1.10E+02 events/s
+
+*** EXECUTE GCHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765302e+02                 )  sec^-1
+
+*** EXECUTE GCHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975554e+02                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+64 ! Number of events in a single CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
+ [XSECTION] fbridge_mode = -1
+ [XSECTION] nb_page_loop = 64
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
+ [UNWEIGHT] Wrote 2 events (found 11 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
+ [COUNTERS] PROGRAM TOTAL          :    4.4515s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6433s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4417s for       64 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
+
+*** EXECUTE GCHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.762918e+02                 )  sec^-1
+
+*** EXECUTE GCHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975020e+02                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:21
+DATE: 2022-06-15_10:56:39
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9445s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2448s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6997s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9604s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2434s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7170s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9511s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2467s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7044s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9639s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7158s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,106 +58,21 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
- [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5336s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4476s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6945s for       96 events => throughput is 2.60E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3915s for       96 events => throughput is 2.45E+02 events/s
-
-*** EXECUTE CHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.839455e+02                 )  sec^-1
-
-*** EXECUTE CHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.834996e+02                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
- [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    5.7932s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2535s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6680s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8718s for       96 events => throughput is 1.10E+02 events/s
-
-*** EXECUTE GCHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.765302e+02                 )  sec^-1
-
-*** EXECUTE GCHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975554e+02                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-64 ! Number of events in a single CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 64
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
- [UNWEIGHT] Wrote 2 events (found 11 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4515s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6433s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4417s for       64 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
-
-*** EXECUTE GCHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.762918e+02                 )  sec^-1
-
-*** EXECUTE GCHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975020e+02                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttggg_cpp
+   ...
+s min # 5>     0.0     0.0     0.0     0.0     0.0
+s min # 6>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 5>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 6>     0.0     0.0     0.0     0.0     0.0
+ RESET CUMULATIVE VARIABLE
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           1
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_18:35:18
+DATE: 2022-06-15_10:53:21
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9481s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2438s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7043s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9445s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2448s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6997s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9564s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2478s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7086s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9511s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2467s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7044s for       96 events => throughput is 2.59E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4989s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4487s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6503s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3998s for       96 events => throughput is 2.40E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.5336s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4476s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6945s for       96 events => throughput is 2.60E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3915s for       96 events => throughput is 2.45E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.830163e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.839455e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.839610e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.834996e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0361s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5049s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6583s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8728s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    5.7932s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.2535s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6680s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8718s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761467e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765302e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.976099e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975554e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4512s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6430s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4414s for       64 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3668s for       64 events => throughput is 1.74E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4515s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6433s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4417s for       64 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.765847e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.762918e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975788e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975020e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:01:19
+DATE: 2022-06-14_15:19:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -15,13 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.8908s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2453s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6455s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9699s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2446s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7253s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -33,14 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.8912s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2478s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6434s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9750s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2484s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7266s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -53,6 +55,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -62,20 +65,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5054s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4485s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6610s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3959s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4878s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4488s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6424s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.832367e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.836730e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.837784e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.837190e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -88,6 +91,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.837784e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -97,20 +101,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0403s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5257s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6417s for       96 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0308s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5053s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6526s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8730s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.763895e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764172e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978007e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.979228e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,6 +127,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.978007e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
+ [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -132,19 +137,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4568s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6588s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4317s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4440s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6414s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4368s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3657s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764127e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765364e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.976529e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.979379e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:34:11
+DATE: 2022-06-14_16:04:34
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9734s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2426s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7308s for       96 events => throughput is 2.57E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9723s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2428s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7295s for       96 events => throughput is 2.57E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9902s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2472s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7430s for       96 events => throughput is 2.56E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9681s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2447s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7234s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 6.894e-07
- [UNWEIGHT] Wrote 4 events (found 18 events)
+ [XSECTION] Cross section = 3.447e-07
+ [UNWEIGHT] Wrote 4 events (found 15 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4976s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4484s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6539s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3952s for       96 events => throughput is 2.43E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4728s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4456s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6303s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3968s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.834266e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.831583e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.828874e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838793e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 6.894e-07
- [UNWEIGHT] Wrote 4 events (found 18 events)
+ [XSECTION] Cross section = 3.447e-07
+ [UNWEIGHT] Wrote 4 events (found 15 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    5.9139s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.3849s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6562s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0284s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5196s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6360s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8728s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764743e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765969e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977431e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978133e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 4.015e-06
- [UNWEIGHT] Wrote 2 events (found 14 events)
+ [XSECTION] Cross section = 2.008e-06
+ [UNWEIGHT] Wrote 2 events (found 11 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4535s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6523s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4352s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3660s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4603s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6607s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4333s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3662s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764241e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.766213e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977968e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981144e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:19:00
+DATE: 2022-06-14_15:26:21
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9699s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2446s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7253s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9639s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2445s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7194s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9750s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2484s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7266s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9667s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2475s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7191s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,97 +59,16 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
- [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4878s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4488s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6424s for       96 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
-
-*** EXECUTE CHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.836730e+02                 )  sec^-1
-
-*** EXECUTE CHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.837190e+02                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
- [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0308s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5053s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6526s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8730s for       96 events => throughput is 1.10E+02 events/s
-
-*** EXECUTE GCHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764172e+02                 )  sec^-1
-
-*** EXECUTE GCHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979228e+02                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
-64 ! Number of events in a single CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
- [XSECTION] nb_page_loop = 64
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 2.008e-06
- [UNWEIGHT] Wrote 2 events (found 11 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4440s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6414s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4368s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3657s for       64 events => throughput is 1.75E+02 events/s
-
-*** EXECUTE GCHECK -p 2 32 1 --bridge ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.765364e+02                 )  sec^-1
-
-*** EXECUTE GCHECK -p 2 32 1 ***
-Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979379e+02                 )  sec^-1
-
-TEST COMPLETED
+ [XSECTION] ERROR! No cross section in log file:
+   /tmp/avalassi/output_ggttggg_cpp
+   ...
+s min # 4>     0.0     0.0 29929.0 29929.0     0.0
+s min # 5>     0.0     0.0     0.0     0.0     0.0
+s min # 6>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 3>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 4>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 5>     0.0     0.0     0.0     0.0     0.0
+xqcutij # 6>     0.0     0.0     0.0     0.0     0.0
+ MULTI_CHANNEL = TRUE
+ CHANNEL_ID =           1
+ Error: failed to reduce to color indices:            1           1

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:12:50
+DATE: 2022-06-14_18:35:18
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -15,14 +15,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9644s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2418s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7226s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9481s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2438s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7043s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,18 +35,20 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+ [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9694s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2468s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7226s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9564s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2478s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7086s for       96 events => throughput is 2.59E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -55,6 +58,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -65,23 +69,24 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4928s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4451s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6520s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3957s for       96 events => throughput is 2.43E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4989s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4487s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6503s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3998s for       96 events => throughput is 2.40E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.829038e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.830163e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.838702e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.839610e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -91,6 +96,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.838702e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -101,23 +107,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0228s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5037s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6462s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0361s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5049s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6583s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8728s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761434e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761467e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977631e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.976099e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
+-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 64 ! Number of events in a single CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -127,6 +134,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.977631e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
+ [XSECTION] fbridge_mode = -1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
@@ -137,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4357s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4285s for       64 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4512s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6430s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4414s for       64 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3668s for       64 events => throughput is 1.74E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.763019e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765847e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.974671e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975788e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_09:15:47
+DATE: 2022-06-14_11:17:14
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -14,14 +14,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.GDtE1WuUTJ_fortran > /tmp/avalassi/tmp.HDzfguJVxu'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9644s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3138s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6506s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9019s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2449s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6569s for       96 events => throughput is 2.63E+01 events/s
 
 *** EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -32,15 +32,15 @@ Executing ' ./madevent < /tmp/avalassi/tmp.GDtE1WuUTJ_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/tmp.DQ8PX6JQke_fortran > /tmp/avalassi/tmp.x9Cu38dltO'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9315s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2798s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6517s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9039s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2484s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6555s for       96 events => throughput is 2.63E+01 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -52,7 +52,7 @@ Executing ' ./madevent < /tmp/avalassi/tmp.DQ8PX6JQke_fortran > /tmp/avalassi/tm
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.ubJGQY2q2L_cuda > /tmp/avalassi/tmp.DJXdXA5bm5'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -61,10 +61,10 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.ubJGQY2q2L_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5284s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4510s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6787s for       96 events => throughput is 2.61E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3987s for       96 events => throughput is 2.41E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.5065s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4466s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6586s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.4013s for       96 events => throughput is 2.39E+02 events/s
 
 *** EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -76,7 +76,7 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.ubJGQY2q2L_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.2ZLArH9vFm_cuda > /tmp/avalassi/tmp.Bh7g691YP2'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -86,20 +86,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/tmp.2ZLArH9vFm_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5183s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4511s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6690s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3983s for       96 events => throughput is 2.41E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4954s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4480s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6475s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3999s for       96 events => throughput is 2.40E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.824369e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.831264e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.819063e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.823893e+02                 )  sec^-1
 
 *** EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
 --------------------
@@ -111,7 +111,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.819063e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.YpSaNrg1C1_cuda > /tmp/avalassi/tmp.C0yTPvdhpX'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -120,10 +120,10 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.YpSaNrg1C1_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4482s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6479s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4340s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4528s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6478s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4381s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
 
 *** EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -135,7 +135,7 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.YpSaNrg1C1_cuda > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.tacjJdkG6m_cuda > /tmp/avalassi/tmp.3a7VmDkibV'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/tmp.tacjJdkG6m_cuda > /tmp/avala
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4407s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6480s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4261s for       64 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3665s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4427s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6412s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4352s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.766255e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.763672e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979091e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978593e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_16:04:34
+DATE: 2022-06-14_16:12:50
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9723s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2428s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7295s for       96 events => throughput is 2.57E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9644s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2418s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7226s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,11 +38,11 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
+ [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9681s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2447s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7234s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9694s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2468s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7226s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,26 +59,26 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4728s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4456s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6303s for       96 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3968s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4928s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4451s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6520s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3957s for       96 events => throughput is 2.43E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.831583e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.829038e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.838793e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838702e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -95,26 +95,26 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0284s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5196s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6360s for       96 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8728s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0228s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5037s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6462s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.765969e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761434e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978133e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977631e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,25 +131,25 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 2.008e-06
+ [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4603s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6607s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4333s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3662s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4357s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4285s for       64 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.766213e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.763019e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.981144e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.974671e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_15:26:21
+DATE: 2022-06-14_15:34:11
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -20,9 +20,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9639s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2445s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7194s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9734s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2426s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7308s for       96 events => throughput is 2.57E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -40,9 +40,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9667s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2475s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7191s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9902s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2472s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7430s for       96 events => throughput is 2.56E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -59,16 +59,97 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] ERROR! No cross section in log file:
-   /tmp/avalassi/output_ggttggg_cpp
-   ...
-s min # 4>     0.0     0.0 29929.0 29929.0     0.0
-s min # 5>     0.0     0.0     0.0     0.0     0.0
-s min # 6>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 3>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 4>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 5>     0.0     0.0     0.0     0.0     0.0
-xqcutij # 6>     0.0     0.0     0.0     0.0     0.0
- MULTI_CHANNEL = TRUE
- CHANNEL_ID =           1
- Error: failed to reduce to color indices:            1           1
+ [XSECTION] Cross section = 6.894e-07
+ [UNWEIGHT] Wrote 4 events (found 18 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    4.4976s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4484s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6539s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3952s for       96 events => throughput is 2.43E+02 events/s
+
+*** EXECUTE CHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 2.834266e+02                 )  sec^-1
+
+*** EXECUTE CHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 2.828874e+02                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 6.894e-07
+ [UNWEIGHT] Wrote 4 events (found 18 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
+ [COUNTERS] PROGRAM TOTAL          :    5.9139s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.3849s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6562s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+
+*** EXECUTE GCHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764743e+02                 )  sec^-1
+
+*** EXECUTE GCHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977431e+02                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
+64 ! Number of events in a single CUDA iteration (nb_page_loop)
+64 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
+ [XSECTION] nb_page_loop = 64
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 4.015e-06
+ [UNWEIGHT] Wrote 2 events (found 14 events)
+ [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
+ [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
+ [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
+ [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
+ [COUNTERS] PROGRAM TOTAL          :    4.4535s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6523s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4352s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3660s for       64 events => throughput is 1.75E+02 events/s
+
+*** EXECUTE GCHECK -p 2 32 1 --bridge ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764241e+02                 )  sec^-1
+
+*** EXECUTE GCHECK -p 2 32 1 ***
+Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977968e+02                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-14_13:42:46
+DATE: 2022-06-14_15:01:19
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -19,9 +19,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.8862s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2450s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6412s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.8908s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2453s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6455s for       96 events => throughput is 2.63E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -38,33 +38,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9009s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2493s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6515s for       96 events => throughput is 2.63E+01 events/s
-
-*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4970s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4440s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6560s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3969s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.8912s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2478s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6434s for       96 events => throughput is 2.63E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -86,44 +62,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5139s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4493s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6662s for       96 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3983s for       96 events => throughput is 2.41E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.5054s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4485s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6610s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3959s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.832113e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.832367e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.837245e+02                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0262s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5074s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6459s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 2.837784e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,44 +97,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0137s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5028s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6394s for       96 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8715s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0403s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5257s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6417s for       96 events => throughput is 2.64E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8729s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764303e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.763895e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977983e+02                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***
---------------------
-64 ! Number of events in a single CUDA iteration (nb_page_loop)
-64 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 2.008e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4349s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6401s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4285s for       64 events => throughput is 2.64E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978007e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -199,24 +127,24 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06
- [UNWEIGHT] Wrote 2 events (found 8 events)
+ [UNWEIGHT] Wrote 2 events (found 11 events)
  [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4409s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6421s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4326s for       64 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3661s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4568s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6588s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4317s for       64 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3663s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764068e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764127e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977356e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.976529e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -148,14 +148,14 @@ function getinputfile()
   elif [ "$1" == "-cuda" ]; then
     mv ${tmp} ${tmp}_cuda
     tmp=${tmp}_cuda
-    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     nloop=32768
     while [ $nloop -gt $nevt ]; do (( nloop = nloop / 2 )); done
     echo "${nloop} ! Number of events in a single CUDA iteration (nb_page_loop)" >> ${tmp}
   elif [ "$1" == "-cpp" ]; then
     mv ${tmp} ${tmp}_cpp
     tmp=${tmp}_cpp
-    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     echo "32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)" >> ${tmp}
   else
     echo "Usage: getinputfile <backend [-fortran][-cuda]-cpp]>"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -305,7 +305,7 @@ for suff in $suffs; do
     \cp -p results.dat results.dat.ref
   fi
   echo -e "\n*** (1) EXECUTE MADEVENT (create events.lhe) ***"
-  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
+  ${rdatcmd} | grep Modify | sed 's/Modify/results.dat /'
   \rm -f ftn26
   runmadevent ./madevent
 
@@ -317,7 +317,7 @@ for suff in $suffs; do
     runmadevent ./cmadevent_cudacpp
   fi
   echo -e "\n*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***"
-  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
+  ${rdatcmd} | grep Modify | sed 's/Modify/results.dat /'
   \rm -f ftn26
   runmadevent ./cmadevent_cudacpp
   runcheck ./check.exe
@@ -330,7 +330,7 @@ for suff in $suffs; do
     runmadevent ./gmadevent2_cudacpp # hack: run cuda gmadevent with cpp input file
   fi
   echo -e "\n*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***"
-  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
+  ${rdatcmd} | grep Modify | sed 's/Modify/results.dat /'
   \rm -f ftn26
   runmadevent ./gmadevent2_cudacpp # hack: run cuda gmadevent with cpp input file
   runcheck ./gcheck.exe
@@ -343,7 +343,7 @@ for suff in $suffs; do
     runmadevent ./gmadevent_cudacpp
   fi
   echo -e "\n*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***"
-  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
+  ${rdatcmd} | grep Modify | sed 's/Modify/results.dat /'
   \rm -f ftn26
   runmadevent ./gmadevent_cudacpp
   runcheck ./gcheck.exe

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -219,9 +219,11 @@ function runmadevent()
   fi
   $timecmd $cmd < ${tmpin} > ${tmp}
   if [ "$?" != "0" ]; then echo "ERROR! '$timecmd $cmd < ${tmpin} > ${tmp}' failed"; tail -10 $tmp; exit 1; fi
+  nbp=$(cat ${tmp} | grep --binary-files=text 'NB_PAGE_LOOP =' | awk '{print $NF}')
   mch=$(cat ${tmp} | grep --binary-files=text 'MULTI_CHANNEL =' | awk '{print $NF}')
   conf=$(cat ${tmp} | grep --binary-files=text 'Running Configuration Number:' | awk '{print $NF}')
   chid=$(cat ${tmp} | grep --binary-files=text 'CHANNEL_ID =' | awk '{print $NF}')
+  echo " [XSECTION] nb_page_loop = ${nbp}"
   echo " [XSECTION] MultiChannel = ${mch}"
   echo " [XSECTION] Configuration = ${conf}"
   echo " [XSECTION] ChannelId = ${chid}"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -148,12 +148,14 @@ function getinputfile()
   elif [ "$1" == "-cuda" ]; then
     mv ${tmp} ${tmp}_cuda
     tmp=${tmp}_cuda
+    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     nloop=32768
     while [ $nloop -gt $nevt ]; do (( nloop = nloop / 2 )); done
     echo "${nloop} ! Number of events in a single CUDA iteration (nb_page_loop)" >> ${tmp}
   elif [ "$1" == "-cpp" ]; then
     mv ${tmp} ${tmp}_cpp
     tmp=${tmp}_cpp
+    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     echo "32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)" >> ${tmp}
   else
     echo "Usage: getinputfile <backend [-fortran][-cuda]-cpp]>"
@@ -219,10 +221,12 @@ function runmadevent()
   fi
   $timecmd $cmd < ${tmpin} > ${tmp}
   if [ "$?" != "0" ]; then echo "ERROR! '$timecmd $cmd < ${tmpin} > ${tmp}' failed"; tail -10 $tmp; exit 1; fi
+  fbm=$(cat ${tmp} | grep --binary-files=text 'FBRIDGE_MODE =' | awk '{print $NF}')
   nbp=$(cat ${tmp} | grep --binary-files=text 'NB_PAGE_LOOP =' | awk '{print $NF}')
   mch=$(cat ${tmp} | grep --binary-files=text 'MULTI_CHANNEL =' | awk '{print $NF}')
   conf=$(cat ${tmp} | grep --binary-files=text 'Running Configuration Number:' | awk '{print $NF}')
   chid=$(cat ${tmp} | grep --binary-files=text 'CHANNEL_ID =' | awk '{print $NF}')
+  echo " [XSECTION] fbridge_mode = ${fbm}"
   echo " [XSECTION] nb_page_loop = ${nbp}"
   echo " [XSECTION] MultiChannel = ${mch}"
   echo " [XSECTION] Configuration = ${conf}"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -126,7 +126,22 @@ function getnevt()
 function getinputfile()
 {
   nevt=$(getnevt)
-  tmp=$(mktemp)
+  tmpdir=/tmp/$USER
+  mkdir -p $tmpdir
+  if [ "${eemumu}" == "1" ]; then 
+    tmp=$tmpdir/input_eemumu
+  elif [ "${ggtt}" == "1" ]; then 
+    tmp=$tmpdir/input_ggtt
+  elif [ "${ggttg}" == "1" ]; then 
+    tmp=$tmpdir/input_ggttg
+  elif [ "${ggttgg}" == "1" ]; then 
+    tmp=$tmpdir/input_ggttgg
+  elif [ "${ggttggg}" == "1" ]; then 
+    tmp=$tmpdir/input_ggttggg
+  else
+    echo "ERROR! cannot determine input file name"; exit 1
+  fi
+  \rm -f ${tmp}; touch ${tmp}
   if [ "$1" == "-fortran" ]; then
     mv ${tmp} ${tmp}_fortran
     tmp=${tmp}_fortran
@@ -137,8 +152,8 @@ function getinputfile()
     while [ $nloop -gt $nevt ]; do (( nloop = nloop / 2 )); done
     echo "${nloop} ! Number of events in a single CUDA iteration (nb_page_loop)" >> ${tmp}
   elif [ "$1" == "-cpp" ]; then
-    mv ${tmp} ${tmp}_cuda
-    tmp=${tmp}_cuda
+    mv ${tmp} ${tmp}_cpp
+    tmp=${tmp}_cpp
     echo "32 ! Number of events in a single C++ iteration (nb_page_loop)" >> ${tmp}
   else
     echo "Usage: getinputfile <backend [-fortran][-cuda]-cpp]>"
@@ -191,7 +206,8 @@ function runmadevent()
     tmpin=$(getinputfile -fortran)
   fi
   if [ ! -f $tmpin ]; then echo "ERROR! Missing input file $tmpin"; exit 1; fi
-  tmp=$(mktemp)
+  tmp=${tmpin/input/output}
+  \rm -f ${tmp}; touch ${tmp}  
   set +e # do not fail on error
   if [ "${debug}" == "1" ]; then
     echo "--------------------"; cat ${tmpin}; echo "--------------------"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -290,8 +290,8 @@ for suff in $suffs; do
   timecmd=
 
   # Show results.dat?
-  rdatcmd="stat results.dat"
-  ###rdatcmd="echo"
+  ###rdatcmd="stat results.dat"
+  rdatcmd="echo"
 
   # DEFAULT IMPLEMENTATION : compute cross section and then generate events
   cd $dir

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -289,6 +289,10 @@ for suff in $suffs; do
   ###timecmd=time
   timecmd=
 
+  # Show results.dat?
+  rdatcmd="stat results.dat"
+  ###rdatcmd="echo"
+
   # DEFAULT IMPLEMENTATION : compute cross section and then generate events
   cd $dir
 
@@ -300,6 +304,7 @@ for suff in $suffs; do
     runmadevent ./madevent
   fi
   echo -e "\n*** (1) EXECUTE MADEVENT (create events.lhe) ***"
+  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
   \rm -f ftn26
   runmadevent ./madevent
 
@@ -311,6 +316,7 @@ for suff in $suffs; do
     runmadevent ./cmadevent_cudacpp
   fi
   echo -e "\n*** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***"
+  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
   \rm -f ftn26
   runmadevent ./cmadevent_cudacpp
   runcheck ./check.exe
@@ -323,6 +329,7 @@ for suff in $suffs; do
     runmadevent ./gmadevent2_cudacpp # hack: run cuda gmadevent with cpp input file
   fi
   echo -e "\n*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***"
+  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
   \rm -f ftn26
   runmadevent ./gmadevent2_cudacpp # hack: run cuda gmadevent with cpp input file
   runcheck ./gcheck.exe
@@ -335,6 +342,7 @@ for suff in $suffs; do
     runmadevent ./gmadevent_cudacpp
   fi
   echo -e "\n*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***"
+  ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
   \rm -f ftn26
   runmadevent ./gmadevent_cudacpp
   runcheck ./gcheck.exe

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -228,7 +228,10 @@ function runmadevent()
   echo " [XSECTION] Configuration = ${conf}"
   echo " [XSECTION] ChannelId = ${chid}"
   xsec=$(cat ${tmp} | grep --binary-files=text 'Cross sec =' | awk '{print 0+$NF}')
-  if [ "${xsec}" != "" ]; then
+  xsec2=$(cat ${tmp} | grep --binary-files=text 'Actual xsec' | awk '{print $NF}')
+  if [ "${xsec2}" != "" ]; then
+    echo " [XSECTION] Cross section = ${xsec} [${xsec2}]"
+  elif [ "${xsec}" != "" ]; then
     echo " [XSECTION] Cross section = ${xsec}"
   else
     echo -e " [XSECTION] ERROR! No cross section in log file:\n   $tmp\n   ..."

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -302,6 +302,7 @@ for suff in $suffs; do
     echo -e "\n*** (1) EXECUTE MADEVENT (create results.dat) ***"
     \rm -f ftn26
     runmadevent ./madevent
+    \cp -p results.dat results.dat.ref
   fi
   echo -e "\n*** (1) EXECUTE MADEVENT (create events.lhe) ***"
   ${rdatcmd} | grep Change | sed 's/Change/results.dat /'
@@ -309,7 +310,7 @@ for suff in $suffs; do
   runmadevent ./madevent
 
   # (2) CMADEVENT_CUDACPP
-  if [ "${keeprdat}" == "0" ]; then \rm -f results.dat; fi
+  if [ "${keeprdat}" == "1" ]; then \cp -p results.dat.ref results.dat; else \rm -f results.dat; fi  
   if [ ! -f results.dat ]; then
     echo -e "\n*** (2) EXECUTE CMADEVENT_CUDACPP (create results.dat) ***"
     \rm -f ftn26
@@ -322,7 +323,7 @@ for suff in $suffs; do
   runcheck ./check.exe
 
   # (3a) GMADEVENT_CUDACPP
-  if [ "${keeprdat}" == "0" ]; then \rm -f results.dat; fi
+  if [ "${keeprdat}" == "1" ]; then \cp -p results.dat.ref results.dat; else \rm -f results.dat; fi  
   if [ ! -f results.dat ]; then
     echo -e "\n*** (3a) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***"
     \rm -f ftn26
@@ -335,7 +336,7 @@ for suff in $suffs; do
   runcheck ./gcheck.exe
 
   # (3b) GMADEVENT_CUDACPP
-  if [ "${keeprdat}" == "0" ]; then \rm -f results.dat; fi
+  if [ "${keeprdat}" == "1" ]; then \cp -p results.dat.ref results.dat; else \rm -f results.dat; fi  
   if [ ! -f results.dat ]; then
     echo -e "\n*** (3b) EXECUTE GMADEVENT_CUDACPP (create results.dat) ***"
     \rm -f ftn26
@@ -346,6 +347,9 @@ for suff in $suffs; do
   \rm -f ftn26
   runmadevent ./gmadevent_cudacpp
   runcheck ./gcheck.exe
+
+  # Cleanup
+  \rm results.dat.ref
 
 done
 printf "\nTEST COMPLETED\n"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -148,14 +148,14 @@ function getinputfile()
   elif [ "$1" == "-cuda" ]; then
     mv ${tmp} ${tmp}_cuda
     tmp=${tmp}_cuda
-    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     nloop=32768
     while [ $nloop -gt $nevt ]; do (( nloop = nloop / 2 )); done
     echo "${nloop} ! Number of events in a single CUDA iteration (nb_page_loop)" >> ${tmp}
   elif [ "$1" == "-cpp" ]; then
     mv ${tmp} ${tmp}_cpp
     tmp=${tmp}_cpp
-    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     echo "32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)" >> ${tmp}
   else
     echo "Usage: getinputfile <backend [-fortran][-cuda]-cpp]>"

--- a/epochX/cudacpp/tmad/teeMadX.sh
+++ b/epochX/cudacpp/tmad/teeMadX.sh
@@ -6,7 +6,7 @@ cd $scrdir
 
 function usage()
 {
-  echo "Usage: $0 <processes [-eemumu][-ggtt][-ggttg][-ggttgg][-ggttggg]> [-makeonly] [-makeclean]" > /dev/stderr
+  echo "Usage: $0 <processes [-eemumu][-ggtt][-ggttg][-ggttgg][-ggttggg]> [-makeonly] [-makeclean] [-keeprdat]" > /dev/stderr
   exit 1
 }
 
@@ -23,6 +23,8 @@ helinls="0"
 hrdcods="0"
 
 steps="make test"
+
+keeprdat=
 
 ###deb=
 deb=" -d" # optional debug mode
@@ -78,6 +80,8 @@ for arg in $*; do
     fi
   #elif [ "$arg" == "-makej" ]; then
   #  makej=-makej
+  elif [ "$arg" == "-keeprdat" ]; then
+    keeprdat=" -keeprdat"
   else
     echo "ERROR! Invalid option '$arg'"; usage
   fi  
@@ -98,7 +102,7 @@ for step in $steps; do
           inl=; if [ "${helinl}" == "1" ]; then inl=" -inlonly"; fi
           for hrdcod in $hrdcods; do
             hrd=; if [ "${hrdcod}" == "1" ]; then hrd=" -hrdonly"; fi
-            args="${proc}${flt}${inl}${hrd}${deb} ${dlp}"
+            args="${proc}${flt}${inl}${hrd}${deb}${keeprdat} ${dlp}"
             ###args="${args} -avxall" # avx, fptype, helinl and hrdcod are now supported for all processes
             if [ "${step}" == "makeclean" ]; then
               printf "\n%80s\n" |tr " " "*"


### PR DESCRIPTION
Hi @oliviermattelaer @roiser 

This WIP PR is a first attempt to produce cross sections and unweighted events using the madevent sampling plus the cudacpp MEs.

A first milestone has been achieved! If I compute BOTH the Fortran and cudacpp MEs (FBRIDGE_MODE=-1), and then I simply replace the Fortran ME by the cudacpp ME, I do get the correct cross sections and numbers of unweighted events (I have not compared event files yet). This was quite trivial to do , I just needed to add one line copying OUT=OUT2 which replaces the fortran ME by the cudacpp ME.

There is still a problem however: if I ONLY compute the cudacpp ME and I skip the Fortran ME calculation (i.e. if I skip SMATRIX1 calls, this is FBRIDGE_MODE=1), then I get several problems: 
- the cross sections in fortran and cudacpp differ (?!)
- the numbers of unweighted events generated differ in fortran and cudacpp
- the unweighted event generation fails with some processes again with 'Error: failed to reduce to color indices', see https://github.com/oliviermattelaer/mg5amc_test/issues/14

TODO:
- fix the issues above, one should be able to only run the cudacpp ME (is one output argument of SMATRIX1 needed that is not computed by the bridge? or is there more fundsamentally some commob block lurking somewhere with info produced by SMATRIX1?)
- in parallel, start comparing the event files when both cudacpp and fortran MEs are computed: I expect that the color and helicity info should be different, or missing?
- in parallel also, try to increase the precision with which the cross section is disaplayed: in principle, we do get E-3 differences, so it is kind of surprising that I get exactly the same results (#476)... note in any case that I tested using OUT=2*OUT2, and I do get a cross section multiplied by 2 and various differences in unweighted events, so actually the status so far is pretty good! 