### PR TITLE
Next patch for cudacpp-only MEs: add dummy color choice to fix 'failed to reduce to color index' 

### DIFF
--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
@@ -1,5 +1,5 @@
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
-index 1734289bf..50dc11b89 100644
+index 1734289bf..3c66b950f 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 @@ -76,13 +76,13 @@ C     Keep track of whether cuts already calculated for this event
@@ -36,9 +36,11 @@ index 1734289bf..50dc11b89 100644
        INCLUDE 'run.inc'
  
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
-@@ -452,7 +452,8 @@ C
+@@ -451,8 +451,10 @@ C
+ 
        USE OMP_LIB
  
++      IMPLICIT NONE
        INCLUDE 'nexternal.inc'
 -      INCLUDE '../../Source/vector.inc'
 +      include 'vector.inc'
@@ -46,7 +48,7 @@ index 1734289bf..50dc11b89 100644
        INCLUDE 'maxamps.inc'
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
        DOUBLE PRECISION HEL_RAND(NB_PAGE_MAX)
-@@ -462,22 +463,125 @@ C
+@@ -462,22 +464,125 @@ C
        DOUBLE PRECISION JAMP2_MULTI(0:MAXFLOW, NB_PAGE_MAX)
  
        INTEGER IVEC
@@ -154,7 +156,7 @@ index 1734289bf..50dc11b89 100644
 +
 +      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
 +        DO IVEC=1, NB_PAGE_LOOP
-+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
++          JAMP2_MULTI(0,IVEC) = 2 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
 +        END DO
 +      ENDIF
 +#endif

--- a/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
+++ b/epochX/cudacpp/CODEGEN/MG5aMC_patches/patch.auto_dsig1.f
@@ -1,5 +1,5 @@
 diff --git b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
-index 1734289bf..8ce665534 100644
+index 1734289bf..50dc11b89 100644
 --- b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 +++ a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
 @@ -76,13 +76,13 @@ C     Keep track of whether cuts already calculated for this event
@@ -46,7 +46,7 @@ index 1734289bf..8ce665534 100644
        INCLUDE 'maxamps.inc'
        DOUBLE PRECISION P_MULTI(0:3, NEXTERNAL, NB_PAGE_MAX)
        DOUBLE PRECISION HEL_RAND(NB_PAGE_MAX)
-@@ -462,22 +463,119 @@ C
+@@ -462,22 +463,125 @@ C
        DOUBLE PRECISION JAMP2_MULTI(0:MAXFLOW, NB_PAGE_MAX)
  
        INTEGER IVEC
@@ -149,6 +149,12 @@ index 1734289bf..8ce665534 100644
 +      IF( FBRIDGE_MODE .EQ. 1 .OR. FBRIDGE_MODE .LT. 0 ) THEN ! (CppOnly=1 or BothQuiet=-1 or BothDebug=-2)
 +        DO IVEC=1, NB_PAGE_LOOP
 +          OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
++        END DO
++      ENDIF
++
++      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
++        DO IVEC=1, NB_PAGE_LOOP
++          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
 +        END DO
 +      ENDIF
 +#endif

--- a/epochX/cudacpp/CODEGEN/patchMad.sh
+++ b/epochX/cudacpp/CODEGEN/patchMad.sh
@@ -106,6 +106,11 @@ for p1dir in ${dir}/SubProcesses/P1_*; do
     if ! patch -p6 -i ${scrdir}/MG5aMC_patches/patch.auto_dsig1.f; then status=1; fi  
   fi
   \rm -f *.orig
+  ncolor=$(cat matrix1.f | grep PARAMETER | grep NCOLOR= | sed 's/.*NCOLOR=//' | sed 's/)//')
+  cat auto_dsig1.f \
+    | sed "s|JAMP2_MULTI(0,IVEC) = 2 ! workaround|JAMP2_MULTI(0,IVEC) = ${ncolor} ! workaround|" \
+    > auto_dsig1.f.new
+  \mv auto_dsig1.f.new auto_dsig1.f
   cd - > /dev/null
 done
 

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -56,7 +56,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006867885589599609 [0m
+[1;32mDEBUG: model prefixing  takes 0.006848335266113281 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -167,7 +167,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f740a18b280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f4014e3c280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -199,19 +199,19 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group ll_ll 
 Generated helas calls for 1 subprocesses (2 diagrams) in 0.005 s
-Wrote files for 8 helas calls in 0.114 s
+Wrote files for 8 helas calls in 0.113 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.238 s
+ALOHA: aloha creates 3 routines in  0.240 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.304 s
+ALOHA: aloha creates 7 routines in  0.306 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV2
@@ -237,6 +237,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.396s
-user	0m2.096s
-sys	0m0.291s
+real	0m2.386s
+user	0m2.076s
+sys	0m0.300s

--- a/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
+++ b/epochX/cudacpp/ee_mumu.mad/CODEGEN_mad_ee_mumu_log.txt
@@ -56,7 +56,7 @@ generate e+ e- > mu+ mu-
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068814754486083984 [0m
+[1;32mDEBUG: model prefixing  takes 0.006867885589599609 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -154,7 +154,7 @@ output madevent CODEGEN_mad_ee_mumu --hel_recycling=False --vector_size=16384 --
 Load PLUGIN.CUDACPP_SA_OUTPUT
 [1mAddition matrix-element will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
-[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3071][0m [0m
+[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3008][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.__init__ (initialise the exporter) [1;30m[output.py at line 141][0m [0m
 INFO: initialize a new directory: CODEGEN_mad_ee_mumu 
 INFO: remove old information in CODEGEN_mad_ee_mumu 
@@ -167,7 +167,7 @@ INFO: Organizing processes into subprocess groups
 INFO: Generating Helas calls for process: e+ e- > mu+ mu- WEIGHTED<=4 @1 
 INFO: Processing color information for process: e+ e- > mu+ mu- @1 
 INFO: Creating files in directory P1_ll_ll 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fb9ef3a0d30> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f740a18b280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -204,14 +204,14 @@ ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
-ALOHA: aloha creates 3 routines in  0.240 s
+ALOHA: aloha creates 3 routines in  0.238 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates FFV2 routines[0m
 ALOHA: aloha creates FFV4 routines[0m
 ALOHA: aloha creates FFV2_4 routines[0m
-ALOHA: aloha creates 7 routines in  0.308 s
+ALOHA: aloha creates 7 routines in  0.304 s
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV2
@@ -237,6 +237,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.415s
-user	0m2.097s
-sys	0m0.304s
+real	0m2.396s
+user	0m2.096s
+sys	0m0.291s

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -582,7 +582,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+          JAMP2_MULTI(0,IVEC) = 1 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -465,6 +465,7 @@ C
 
       USE OMP_LIB
 
+      IMPLICIT NONE
       INCLUDE 'nexternal.inc'
       include 'vector.inc'
       include 'coupl.inc'
@@ -581,7 +582,6 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          write(*,*) 'DEBUG JAMP2_MULTI', IVEC, NCOLOR
           JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -581,6 +581,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
+          write(*,*) 'DEBUG JAMP2_MULTI', IVEC, NCOLOR
           JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF

--- a/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
+++ b/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll/auto_dsig1.f
@@ -578,6 +578,12 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
+        DO IVEC=1, NB_PAGE_LOOP
+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006848335266113281 [0m
+[1;32mDEBUG: model prefixing  takes 0.006930828094482422 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -155,7 +155,7 @@ output madevent CODEGEN_mad_gg_tt --hel_recycling=False --vector_size=16384 --me
 Load PLUGIN.CUDACPP_SA_OUTPUT
 [1mAddition matrix-element will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
-[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3071][0m [0m
+[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3008][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.__init__ (initialise the exporter) [1;30m[output.py at line 141][0m [0m
 INFO: initialize a new directory: CODEGEN_mad_gg_tt 
 INFO: remove old information in CODEGEN_mad_gg_tt 
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fdb7d0293a0> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd28d3cb280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -209,12 +209,12 @@ Wrote files for 10 helas calls in 0.129 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.174 s
+ALOHA: aloha creates 2 routines in  0.172 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.161 s
+ALOHA: aloha creates 4 routines in  0.159 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -236,6 +236,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.225s
-user	0m1.906s
-sys	0m0.291s
+real	0m2.205s
+user	0m1.921s
+sys	0m0.272s

--- a/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
+++ b/epochX/cudacpp/gg_tt.mad/CODEGEN_mad_gg_tt_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006930828094482422 [0m
+[1;32mDEBUG: model prefixing  takes 0.006841897964477539 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
 INFO: Process has 3 diagrams 
-1 processes with 3 diagrams generated in 0.010 s
+1 processes with 3 diagrams generated in 0.011 s
 Total: 1 processes with 3 diagrams
 output madevent CODEGEN_mad_gg_tt --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ @1
 INFO: Creating files in directory P1_gg_ttx 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fd28d3cb280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fa00b51c280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -205,16 +205,16 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: g g > t t~ WEIGHTED<=2 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttx 
 Generated helas calls for 1 subprocesses (3 diagrams) in 0.008 s
-Wrote files for 10 helas calls in 0.129 s
+Wrote files for 10 helas calls in 0.130 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 2 routines in  0.172 s
+ALOHA: aloha creates 2 routines in  0.171 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 set of routines with options: P0[0m
 ALOHA: aloha creates FFV1 routines[0m
-ALOHA: aloha creates 4 routines in  0.159 s
+ALOHA: aloha creates 4 routines in  0.158 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -236,6 +236,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.205s
-user	0m1.921s
-sys	0m0.272s
+real	0m2.202s
+user	0m1.909s
+sys	0m0.280s

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -451,6 +451,7 @@ C
 
       USE OMP_LIB
 
+      IMPLICIT NONE
       INCLUDE 'nexternal.inc'
       include 'vector.inc'
       include 'coupl.inc'

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -568,7 +568,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+          JAMP2_MULTI(0,IVEC) = 2 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
+++ b/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx/auto_dsig1.f
@@ -564,6 +564,12 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
+        DO IVEC=1, NB_PAGE_LOOP
+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006859779357910156 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068988800048828125 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,13 +149,13 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=3: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g WEIGHTED<=3 @1  
 INFO: Process has 16 diagrams 
-1 processes with 16 diagrams generated in 0.028 s
+1 processes with 16 diagrams generated in 0.029 s
 Total: 1 processes with 16 diagrams
 output madevent CODEGEN_mad_gg_ttg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
 [1mAddition matrix-element will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
-[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3071][0m [0m
+[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3008][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.__init__ (initialise the exporter) [1;30m[output.py at line 141][0m [0m
 INFO: initialize a new directory: CODEGEN_mad_gg_ttg 
 INFO: remove old information in CODEGEN_mad_gg_ttg 
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7eff07d033a0> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f70bca1d280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -206,15 +206,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g WEIGHTED<=3 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxg 
-Generated helas calls for 1 subprocesses (16 diagrams) in 0.050 s
-Wrote files for 36 helas calls in 0.200 s
+Generated helas calls for 1 subprocesses (16 diagrams) in 0.051 s
+Wrote files for 36 helas calls in 0.202 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.394 s
+ALOHA: aloha creates 5 routines in  0.387 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -222,7 +222,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.375 s
+ALOHA: aloha creates 10 routines in  0.371 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -249,6 +249,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.861s
-user	0m2.526s
-sys	0m0.325s
+real	0m2.891s
+user	0m2.556s
+sys	0m0.285s

--- a/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
+++ b/epochX/cudacpp/gg_ttg.mad/CODEGEN_mad_gg_ttg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068988800048828125 [0m
+[1;32mDEBUG: model prefixing  takes 0.00681757926940918 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=3: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g WEIGHTED<=3 @1  
 INFO: Process has 16 diagrams 
-1 processes with 16 diagrams generated in 0.029 s
+1 processes with 16 diagrams generated in 0.028 s
 Total: 1 processes with 16 diagrams
 output madevent CODEGEN_mad_gg_ttg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g @1
 INFO: Creating files in directory P1_gg_ttxg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f70bca1d280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f8987a35280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -207,14 +207,14 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 INFO: Generating Feynman diagrams for Process: g g > t t~ g WEIGHTED<=3 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxg 
 Generated helas calls for 1 subprocesses (16 diagrams) in 0.051 s
-Wrote files for 36 helas calls in 0.202 s
+Wrote files for 36 helas calls in 0.204 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 5 routines in  0.387 s
+ALOHA: aloha creates 5 routines in  0.390 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -222,7 +222,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV3 set of routines with options: P0[0m
 ALOHA: aloha creates VVVV4 set of routines with options: P0[0m
-ALOHA: aloha creates 10 routines in  0.371 s
+ALOHA: aloha creates 10 routines in  0.372 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -249,6 +249,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m2.891s
-user	0m2.556s
-sys	0m0.285s
+real	0m2.855s
+user	0m2.555s
+sys	0m0.290s

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -451,6 +451,7 @@ C
 
       USE OMP_LIB
 
+      IMPLICIT NONE
       INCLUDE 'nexternal.inc'
       include 'vector.inc'
       include 'coupl.inc'
@@ -567,7 +568,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+          JAMP2_MULTI(0,IVEC) = 6 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg/auto_dsig1.f
@@ -564,6 +564,12 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
+        DO IVEC=1, NB_PAGE_LOOP
+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/addmothers.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/addmothers.f
@@ -91,8 +91,6 @@ c
       real ran1
       external pt,ran1,get_color,elim_indices,set_colmp,fix_tchannel_color
 
-      write(*,*) 'DEBUG add_mothers'
-
       if (first_time) then
          include 'props.inc'
          first_time=.false.
@@ -833,8 +831,6 @@ c
       integer is_colors(2,nincoming)
       integer i,j,i3,i3bar
 
-c     write(*,*) 'DEBUG elim_indices', n3, n3bar
-
 c     Successively eliminate color indices in pairs until only the wanted
 c     indices remain
       do i=1,ncolmp
@@ -899,7 +895,6 @@ c        We have a previous epsilon which gives the wrong pop-up index
      $           ires,icol,is_colors)
          else
 c           Don't know how to deal with this
-            write(*,*) 'DEBUG1001', i3, n3, i3bar, n3bar
             call write_error(1001,n3,n3bar)
          endif
       endif

--- a/epochX/cudacpp/gg_ttg.mad/SubProcesses/addmothers.f
+++ b/epochX/cudacpp/gg_ttg.mad/SubProcesses/addmothers.f
@@ -91,6 +91,8 @@ c
       real ran1
       external pt,ran1,get_color,elim_indices,set_colmp,fix_tchannel_color
 
+      write(*,*) 'DEBUG add_mothers'
+
       if (first_time) then
          include 'props.inc'
          first_time=.false.
@@ -831,6 +833,8 @@ c
       integer is_colors(2,nincoming)
       integer i,j,i3,i3bar
 
+c     write(*,*) 'DEBUG elim_indices', n3, n3bar
+
 c     Successively eliminate color indices in pairs until only the wanted
 c     indices remain
       do i=1,ncolmp
@@ -895,6 +899,7 @@ c        We have a previous epsilon which gives the wrong pop-up index
      $           ires,icol,is_colors)
          else
 c           Don't know how to deal with this
+            write(*,*) 'DEBUG1001', i3, n3, i3bar, n3bar
             call write_error(1001,n3,n3bar)
          endif
       endif

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006844043731689453 [0m
+[1;32mDEBUG: model prefixing  takes 0.006837606430053711 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,13 +149,13 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.213 s
+1 processes with 123 diagrams generated in 0.208 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
 [1mAddition matrix-element will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
-[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3071][0m [0m
+[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3008][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.__init__ (initialise the exporter) [1;30m[output.py at line 141][0m [0m
 INFO: initialize a new directory: CODEGEN_mad_gg_ttgg 
 INFO: remove old information in CODEGEN_mad_gg_ttgg 
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f58fc1b85b0> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fcb3fbb3700> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -208,15 +208,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.579 s
-Wrote files for 222 helas calls in 0.951 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.576 s
+Wrote files for 222 helas calls in 0.942 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.409 s
+ALOHA: aloha creates 5 routines in  0.381 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -224,7 +224,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.380 s
+ALOHA: aloha creates 10 routines in  0.373 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -254,6 +254,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m4.561s
-user	0m4.226s
-sys	0m0.298s
+real	0m4.517s
+user	0m4.183s
+sys	0m0.323s

--- a/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
+++ b/epochX/cudacpp/gg_ttgg.mad/CODEGEN_mad_gg_ttgg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006837606430053711 [0m
+[1;32mDEBUG: model prefixing  takes 0.006869077682495117 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=4: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g WEIGHTED<=4 @1  
 INFO: Process has 123 diagrams 
-1 processes with 123 diagrams generated in 0.208 s
+1 processes with 123 diagrams generated in 0.209 s
 Total: 1 processes with 123 diagrams
 output madevent CODEGEN_mad_gg_ttgg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -170,7 +170,7 @@ INFO: Processing color information for process: g g > t t~ g g @1
 INFO: Creating files in directory P1_gg_ttxgg 
 [1mINFO: Some T-channel width have been set to zero [new since 2.8.0]
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fcb3fbb3700> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f75b5635700> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -208,15 +208,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g WEIGHTED<=4 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxgg 
-Generated helas calls for 1 subprocesses (123 diagrams) in 0.576 s
-Wrote files for 222 helas calls in 0.942 s
+Generated helas calls for 1 subprocesses (123 diagrams) in 0.577 s
+Wrote files for 222 helas calls in 0.943 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.381 s
+ALOHA: aloha creates 5 routines in  0.391 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -224,7 +224,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.373 s
+ALOHA: aloha creates 10 routines in  0.381 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -254,6 +254,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	0m4.517s
-user	0m4.183s
-sys	0m0.323s
+real	0m4.546s
+user	0m4.221s
+sys	0m0.298s

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -564,6 +564,12 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
+        DO IVEC=1, NB_PAGE_LOOP
+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/auto_dsig1.f
@@ -451,6 +451,7 @@ C
 
       USE OMP_LIB
 
+      IMPLICIT NONE
       INCLUDE 'nexternal.inc'
       include 'vector.inc'
       include 'coupl.inc'
@@ -567,7 +568,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+          JAMP2_MULTI(0,IVEC) = 24 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.006914854049682617 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068743228912353516 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,13 +149,13 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.475 s
+1 processes with 1240 diagrams generated in 2.451 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
 [1mAddition matrix-element will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
 [1mOutput will be done with PLUGIN: CUDACPP_SA_OUTPUT[0m
-[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3071][0m [0m
+[1;32mDEBUG:  cformat = [0m standalone_cudacpp [1;30m[export_cpp.py at line 3008][0m [0m
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.__init__ (initialise the exporter) [1;30m[output.py at line 141][0m [0m
 INFO: initialize a new directory: CODEGEN_mad_gg_ttggg 
 INFO: remove old information in CODEGEN_mad_gg_ttggg 
@@ -172,7 +172,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7fac0f670610> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f296218f280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -212,15 +212,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.012 s
-Wrote files for 2281 helas calls in 54.692 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 9.014 s
+Wrote files for 2281 helas calls in 54.870 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.426 s
+ALOHA: aloha creates 5 routines in  0.398 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -228,7 +228,7 @@ ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 10 routines in  0.377 s
+ALOHA: aloha creates 10 routines in  0.375 s
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> VVV1
 <class 'aloha.create_aloha.AbstractRoutine'> FFV1
@@ -258,6 +258,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m11.452s
-user	1m10.012s
-sys	0m1.379s
+real	1m11.627s
+user	1m10.089s
+sys	0m1.499s

--- a/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
+++ b/epochX/cudacpp/gg_ttggg.mad/CODEGEN_mad_gg_ttggg_log.txt
@@ -56,7 +56,7 @@ generate g g > t t~ g g g
 No model currently active, so we import the Standard Model
 INFO: load particles 
 INFO: load vertices 
-[1;32mDEBUG: model prefixing  takes 0.0068743228912353516 [0m
+[1;32mDEBUG: model prefixing  takes 0.0068666934967041016 [0m
 INFO: Restrict model sm with file models/sm/restrict_default.dat . 
 [1;32mDEBUG: Simplifying conditional expressions [0m
 [1;32mDEBUG: remove interactions: u s w+ at order: QED=1 [0m
@@ -149,7 +149,7 @@ INFO: Please specify coupling orders to bypass this step.
 INFO: Trying coupling order WEIGHTED<=5: WEIGTHED IS QCD+2*QED 
 INFO: Trying process: g g > t t~ g g g WEIGHTED<=5 @1  
 INFO: Process has 1240 diagrams 
-1 processes with 1240 diagrams generated in 2.451 s
+1 processes with 1240 diagrams generated in 2.468 s
 Total: 1 processes with 1240 diagrams
 output madevent CODEGEN_mad_gg_ttggg --hel_recycling=False --vector_size=16384 --me_exporter=standalone_cudacpp
 Load PLUGIN.CUDACPP_SA_OUTPUT
@@ -172,7 +172,7 @@ INFO: Creating files in directory P1_gg_ttxggg
  if you want to keep this width please set "zerowidth_tchannel" to False [0m
 INFO: Computing Color-Flow optimization [15120 term] 
 INFO: Color-Flow passed to 1592 term in 41s. Introduce 2768 contraction 
-[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f296218f280> [1;30m[export_v4.py at line 6106][0m [0m
+[1;32mDEBUG:  process_exporter_cpp = [0m <PLUGIN.CUDACPP_SA_OUTPUT.model_handling.PLUGIN_OneProcessExporter object at 0x7f1abbf00280> [1;30m[export_v4.py at line 6106][0m [0m
 INFO: Creating files in directory . 
 [1;32mDEBUG:  Entering PLUGIN_OneProcessExporter.generate_process_files [1;30m[model_handling.py at line 1198][0m [0m
 [1;32mDEBUG:  self.include_multi_channel is already defined: this is madevent+second_exporter mode [1;30m[model_handling.py at line 1200][0m [0m
@@ -212,15 +212,15 @@ INFO: Created files CPPProcess.h and CPPProcess.cc in directory ./.
 [1;32mDEBUG:  Done [1;30m[export_cpp.py at line 713][0m [0m
 INFO: Generating Feynman diagrams for Process: g g > t t~ g g g WEIGHTED<=5 @1 
 INFO: Finding symmetric diagrams for subprocess group gg_ttxggg 
-Generated helas calls for 1 subprocesses (1240 diagrams) in 9.014 s
-Wrote files for 2281 helas calls in 54.870 s
+Generated helas calls for 1 subprocesses (1240 diagrams) in 8.982 s
+Wrote files for 2281 helas calls in 54.861 s
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
 ALOHA: aloha creates FFV1 routines[0m
 ALOHA: aloha creates VVVV1 routines[0m
 ALOHA: aloha creates VVVV3 routines[0m
 ALOHA: aloha creates VVVV4 routines[0m
-ALOHA: aloha creates 5 routines in  0.398 s
+ALOHA: aloha creates 5 routines in  0.389 s
 [1;32mDEBUG:  Entering PLUGIN_ProcessExporter.convert_model (create the model) [1;30m[output.py at line 179][0m [0m
 ALOHA: aloha starts to compute helicity amplitudes
 ALOHA: aloha creates VVV1 routines[0m
@@ -258,6 +258,6 @@ Type "launch" to generate events from this process, or see
 Run "open index.html" to see more information about this process.
 quit
 
-real	1m11.627s
-user	1m10.089s
-sys	0m1.499s
+real	1m11.500s
+user	1m10.007s
+sys	0m1.476s

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -564,6 +564,12 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
           OUT(IVEC) = OUT2(IVEC) ! use the cudacpp ME instead of the fortran ME!
         END DO
       ENDIF
+
+      IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
+        DO IVEC=1, NB_PAGE_LOOP
+          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+        END DO
+      ENDIF
 #endif
 
       IF ( FIRST_CHID ) THEN

--- a/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
+++ b/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg/auto_dsig1.f
@@ -451,6 +451,7 @@ C
 
       USE OMP_LIB
 
+      IMPLICIT NONE
       INCLUDE 'nexternal.inc'
       include 'vector.inc'
       include 'coupl.inc'
@@ -567,7 +568,7 @@ c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_
 
       IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all, JAMP2_MULTI is not filled)
         DO IVEC=1, NB_PAGE_LOOP
-          JAMP2_MULTI(0,IVEC) = NCOLOR ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
+          JAMP2_MULTI(0,IVEC) = 120 ! workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14
         END DO
       ENDIF
 #endif

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:52:42
+DATE: 2022-06-15_15:04:21
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -23,7 +23,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Cross section = 0.09017
  [COUNTERS] PROGRAM TOTAL          :    0.0303s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1454s
+ [COUNTERS] PROGRAM TOTAL          :    0.1452s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0132s for     2080 events => throughput is 1.58E+05 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.61E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1462s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1321s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.05E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1467s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1329s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.08E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.685793e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.681346e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.208751e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.163254e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.7213s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7045s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0133s for     2080 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7027s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6857s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0135s for     2080 events => throughput is 1.54E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.94E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.930618e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.934393e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.769053e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.386302e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6350s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6219s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2048 events => throughput is 1.57E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6369s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6237s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.56E+05 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.40E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.933863e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.944827e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.349195e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.282036e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:11:28
+DATE: 2022-06-15_16:16:51
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0301s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0303s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0175s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1454s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1324s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1464s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1330s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.55E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp 2>&1'
+Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp 2>&1 ) > /tmp/avalassi/output_eemumu_cpp'
 ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp' failed
 #3  0x410c23 in ???
 #4  0x43cfd8 in ???
@@ -66,6 +66,6 @@ ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/ou
 #7  0x45b96a in ???
 #8  0x43ab5f in ???
 #9  0x43b10a in ???
-#10  0x7f0836079554 in ???
+#10  0x7f3907136554 in ???
 #11  0x4024b8 in ???
 #12  0xffffffffffffffff in ???

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,9 +1,9 @@
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
+Working directory (build): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_17:30:34
+DATE: 2022-06-15_17:47:09
 
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
+Working directory (run): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
 *** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
@@ -15,15 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0304s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0305s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0175s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -35,16 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1442s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1312s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1448s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1317s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -58,26 +56,25 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002] fbridge_mode=1
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1348s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1339s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0009s for     2080 events => throughput is 2.35E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1394s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1384s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.10E+06 events/s
 
 *** EXECUTE CHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.428516e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.406119e+06                 )  sec^-1
 
 *** EXECUTE CHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.041352e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.008085e+06                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -91,26 +88,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.041352e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002] fbridge_mode=1
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6528s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6494s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.13E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6342s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6307s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 6.01E+05 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.957280e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.924197e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.442402e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.101002e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -124,25 +120,24 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.442402e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 2048
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.2175 [0.21754196695805308]
+ [XSECTION] Cross section = 0.2175 [0.21754196695805308] fbridge_mode=1
  [UNWEIGHT] Wrote 966 events (found 967 events)
- [COUNTERS] PROGRAM TOTAL          :    0.6226s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6225s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.53E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.6185s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6184s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.45E+07 events/s
 
 *** EXECUTE GCHECK -p 64 32 1 --bridge ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.953267e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.959040e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 64 32 1 ***
 Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.424863e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.350250e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_15:04:21
+DATE: 2022-06-15_16:04:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0303s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0309s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0181s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1452s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1322s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.61E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1471s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1341s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 2048 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,106 +58,14 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
- [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.3e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.1467s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1329s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.63E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0010s for     2080 events => throughput is 2.08E+06 events/s
+ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp' failed
+ Renormalization scale set on event-by-event basis
+ Factorization   scale set on event-by-event basis
 
-*** EXECUTE CHECK -p 64 32 1 --bridge ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.681346e+06                 )  sec^-1
 
-*** EXECUTE CHECK -p 64 32 1 ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.163254e+06                 )  sec^-1
-
-*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
-2048 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 32
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
- [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2080
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.7e-17 +- 4.9e-18
- [COUNTERS] PROGRAM TOTAL          :    0.7027s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6857s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0135s for     2080 events => throughput is 1.54E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0035s for     2080 events => throughput is 5.94E+05 events/s
-
-*** EXECUTE GCHECK -p 64 32 1 --bridge ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.934393e+07                 )  sec^-1
-
-*** EXECUTE GCHECK -p 64 32 1 ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.386302e+07                 )  sec^-1
-
-*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
---------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-2048 ! Number of events in a single CUDA iteration (nb_page_loop)
-2048 1 1 ! Number of events and max and min iterations
-0.000001 ! Accuracy (ignored because max iterations = min iterations)
-0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
-1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
-0 ! Helicity Sum/event 0=exact
-1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
---------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
- [XSECTION] fbridge_mode = -1
- [XSECTION] nb_page_loop = 2048
- [XSECTION] MultiChannel = TRUE
- [XSECTION] Configuration = 1
- [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.2175 [0.21754196695805308]
- [UNWEIGHT] Wrote 966 events (found 967 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 1.00000000 = 1 - 8.9e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00000000 = 1 + 6.7e-16
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   2048
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = -2.9e-17 +- 5e-18
- [COUNTERS] PROGRAM TOTAL          :    0.6369s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6237s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2048 events => throughput is 1.56E+05 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.40E+07 events/s
-
-*** EXECUTE GCHECK -p 64 32 1 --bridge ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.944827e+07                 )  sec^-1
-
-*** EXECUTE GCHECK -p 64 32 1 ***
-Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
-Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.282036e+07                 )  sec^-1
-
-TEST COMPLETED
+ getting user params
+Enter number of events and max and min iterations: 
+ Number of events and iterations         2048           1           1
+Enter desired fractional accuracy: 
+ Desired fractional accuracy:    9.9999999999999995E-007
+Enter 0 for fixed, 2 for adjustable grid: 

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:48
+DATE: 2022-06-15_17:30:34
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0309s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0181s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0304s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0174s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.61E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1471s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1341s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1442s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1312s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.61E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -58,14 +58,91 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
-ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp' failed
- Renormalization scale set on event-by-event basis
- Factorization   scale set on event-by-event basis
+ [XSECTION] fbridge_mode = 1
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
+ [UNWEIGHT] Wrote 1009 events (found 1010 events)
+ [COUNTERS] PROGRAM TOTAL          :    0.1348s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1339s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0009s for     2080 events => throughput is 2.35E+06 events/s
 
+*** EXECUTE CHECK -p 64 32 1 --bridge ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 5.428516e+06                 )  sec^-1
 
- getting user params
-Enter number of events and max and min iterations: 
- Number of events and iterations         2048           1           1
-Enter desired fractional accuracy: 
- Desired fractional accuracy:    9.9999999999999995E-007
-Enter 0 for fixed, 2 for adjustable grid: 
+*** EXECUTE CHECK -p 64 32 1 ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 6.041352e+06                 )  sec^-1
+
+*** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
+2048 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+ [XSECTION] fbridge_mode = 1
+ [XSECTION] nb_page_loop = 32
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.09017 [9.0170633677521442E-002]
+ [UNWEIGHT] Wrote 1009 events (found 1010 events)
+ [COUNTERS] PROGRAM TOTAL          :    0.6528s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6494s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0034s for     2080 events => throughput is 6.13E+05 events/s
+
+*** EXECUTE GCHECK -p 64 32 1 --bridge ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.957280e+07                 )  sec^-1
+
+*** EXECUTE GCHECK -p 64 32 1 ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.442402e+07                 )  sec^-1
+
+*** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
+--------------------
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
+2048 ! Number of events in a single CUDA iteration (nb_page_loop)
+2048 1 1 ! Number of events and max and min iterations
+0.000001 ! Accuracy (ignored because max iterations = min iterations)
+0 ! Grid Adjustment 0=none, 2=adjust (NB if = 0, ftn26 will still be used if present)
+1 ! Suppress Amplitude 1=yes (i.e. use MadEvent single-diagram enhancement)
+0 ! Helicity Sum/event 0=exact
+1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
+--------------------
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_eemumu_cuda > /tmp/avalassi/output_eemumu_cuda'
+ [XSECTION] fbridge_mode = 1
+ [XSECTION] nb_page_loop = 2048
+ [XSECTION] MultiChannel = TRUE
+ [XSECTION] Configuration = 1
+ [XSECTION] ChannelId = 1
+ [XSECTION] Cross section = 0.2175 [0.21754196695805308]
+ [UNWEIGHT] Wrote 966 events (found 967 events)
+ [COUNTERS] PROGRAM TOTAL          :    0.6226s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6225s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0001s for     2048 events => throughput is 1.53E+07 events/s
+
+*** EXECUTE GCHECK -p 64 32 1 --bridge ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 1.953267e+07                 )  sec^-1
+
+*** EXECUTE GCHECK -p 64 32 1 ***
+Process                     = SIGMA_SM_EPEM_MUPMUM_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
+EvtsPerSec[MECalcOnly] (3a) = ( 7.424863e+07                 )  sec^-1
+
+TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:16:51
+DATE: 2022-06-15_16:04:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -14,15 +14,15 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/avalassi/output_eemumu_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0303s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0175s
+ [COUNTERS] PROGRAM TOTAL          :    0.0309s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0181s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
@@ -34,7 +34,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/aval
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/avalassi/output_eemumu_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/aval
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1464s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1330s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0134s for     2080 events => throughput is 1.55E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1471s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1341s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,15 +57,15 @@ Executing '(  ./madevent < /tmp/avalassi/input_eemumu_fortran 2>&1 ) > /tmp/aval
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp 2>&1 ) > /tmp/avalassi/output_eemumu_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
 ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp' failed
-#3  0x410c23 in ???
-#4  0x43cfd8 in ???
-#5  0x43da40 in ???
-#6  0x43e397 in ???
-#7  0x45b96a in ???
-#8  0x43ab5f in ???
-#9  0x43b10a in ???
-#10  0x7f3907136554 in ???
-#11  0x4024b8 in ???
-#12  0xffffffffffffffff in ???
+ Renormalization scale set on event-by-event basis
+ Factorization   scale set on event-by-event basis
+
+
+ getting user params
+Enter number of events and max and min iterations: 
+ Number of events and iterations         2048           1           1
+Enter desired fractional accuracy: 
+ Desired fractional accuracy:    9.9999999999999995E-007
+Enter 0 for fixed, 2 for adjustable grid: 

--- a/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_eemumu_mad/log_eemumu_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:48
+DATE: 2022-06-15_16:11:28
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_ll_ll
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/ee_mumu.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017
- [COUNTERS] PROGRAM TOTAL          :    0.0309s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.0181s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0129s for     2080 events => throughput is 1.62E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.0301s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.0173s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0128s for     2080 events => throughput is 1.62E+05 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/output_eemumu_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.09017 [9.0170633677521428E-002]
  [UNWEIGHT] Wrote 1009 events (found 1010 events)
- [COUNTERS] PROGRAM TOTAL          :    0.1471s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1341s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.0130s for     2080 events => throughput is 1.60E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.1454s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1324s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.0131s for     2080 events => throughput is 1.59E+05 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,15 +57,15 @@ Executing ' ./madevent < /tmp/avalassi/input_eemumu_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp 2>&1'
 ERROR! ' ./cmadevent_cudacpp < /tmp/avalassi/input_eemumu_cpp > /tmp/avalassi/output_eemumu_cpp' failed
- Renormalization scale set on event-by-event basis
- Factorization   scale set on event-by-event basis
-
-
- getting user params
-Enter number of events and max and min iterations: 
- Number of events and iterations         2048           1           1
-Enter desired fractional accuracy: 
- Desired fractional accuracy:    9.9999999999999995E-007
-Enter 0 for fixed, 2 for adjustable grid: 
+#3  0x410c23 in ???
+#4  0x43cfd8 in ???
+#5  0x43da40 in ???
+#6  0x43e397 in ???
+#7  0x45b96a in ???
+#8  0x43ab5f in ???
+#9  0x43b10a in ???
+#10  0x7f0836079554 in ???
+#11  0x4024b8 in ???
+#12  0xffffffffffffffff in ???

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:11:28
+DATE: 2022-06-15_16:16:52
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1109s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7464s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3645s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1130s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7490s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3640s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4076s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3639s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4103s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0425s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3678s for    16416 events => throughput is 4.46E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp 2>&1'
+Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4153s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.3737s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.94E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1737s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1317s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.91E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.165592e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.177552e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.257825e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.241417e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.257825e+05                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.6307s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5480s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0828s for    16416 events => throughput is 1.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6510s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5676s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0833s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.916024e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.940327e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.105510e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.004622e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.105510e+07                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda 2>&1 ) > /tmp/avalassi/output_ggtt_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5388s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5380s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5490s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5482s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.23E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.929277e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.904079e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.751295e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.801031e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_15:04:27
+DATE: 2022-06-15_16:04:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1058s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7435s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3623s for    16416 events => throughput is 4.53E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1210s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7574s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3636s for    16416 events => throughput is 4.52E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4089s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4059s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0407s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3652s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5127s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1063s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1400s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0981s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.192362e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.139865e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.265352e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.266108e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.265352e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0071s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5538s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3704s for    16416 events => throughput is 4.43E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0829s for    16416 events => throughput is 1.98E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5996s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5162s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0833s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.931373e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.907021e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.133785e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.771254e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 16384 ! Number of events in a single CUDA iteration (nb_page_loop)
 16384 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.133785e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999992 = 1 - 8e-08
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8985s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5305s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3673s for    16384 events => throughput is 4.46E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.18E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5543s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5536s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.940422e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.832701e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.074445e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.868057e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:48
+DATE: 2022-06-15_17:30:40
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1210s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7574s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3636s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1091s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7451s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3639s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4059s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0407s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3652s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4108s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0465s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3643s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1400s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0981s
+ [COUNTERS] PROGRAM TOTAL          :    1.1563s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1144s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.139865e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.189229e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.266108e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.253994e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5996s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5162s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0833s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6363s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5533s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0830s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.907021e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.943026e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.771254e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.728404e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5543s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5536s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5350s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5342s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.20E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.832701e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.924513e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.868057e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.757330e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:48
+DATE: 2022-06-15_16:11:28
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1210s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7574s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3636s for    16416 events => throughput is 4.52E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1109s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7464s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3645s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4059s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0407s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3652s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4076s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3639s for    16416 events => throughput is 4.51E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1400s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0981s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4153s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.3737s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0416s for    16416 events => throughput is 3.94E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.139865e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.165592e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.266108e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.257825e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.266108e+05                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5996s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5162s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0833s for    16416 events => throughput is 1.97E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6307s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5480s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0828s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.907021e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.916024e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.771254e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.105510e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.771254e+07                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5543s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5536s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5388s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5380s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.832701e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.929277e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.868057e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.751295e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,9 +1,9 @@
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
+Working directory (build): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_17:30:40
+DATE: 2022-06-15_17:47:14
 
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
+Working directory (run): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
 *** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
@@ -15,15 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1091s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7451s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3639s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1138s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7471s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3667s for    16416 events => throughput is 4.48E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -35,16 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4108s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0465s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3643s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4223s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0500s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3723s for    16416 events => throughput is 4.41E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -58,26 +56,25 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91 [45.914455838006880]
+ [XSECTION] Cross section = 45.91 [45.914455838006880] fbridge_mode=1
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1563s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1144s
+ [COUNTERS] PROGRAM TOTAL          :    1.1362s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0944s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.189229e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.165012e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.253994e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.269368e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -91,26 +88,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.253994e+05                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 45.91 [45.914455838006880]
+ [XSECTION] Cross section = 45.91 [45.914455838006880] fbridge_mode=1
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.6363s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5533s
+ [COUNTERS] PROGRAM TOTAL          :    1.6385s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5555s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0830s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.943026e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.891323e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.728404e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.979060e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -124,25 +120,24 @@ EvtsPerSec[MECalcOnly] (3a) = ( 8.728404e+07                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 47.67 [47.668452211994605]
+ [XSECTION] Cross section = 47.67 [47.668452211994605] fbridge_mode=1
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5350s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5342s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.20E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5348s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5340s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.19E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.924513e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.915012e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.757330e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.685879e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:16:52
+DATE: 2022-06-15_16:04:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalassi/output_ggtt_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1130s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7490s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3640s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1210s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7574s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3636s for    16416 events => throughput is 4.52E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalas
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalassi/output_ggtt_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output_ggtt_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalas
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4103s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0425s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3678s for    16416 events => throughput is 4.46E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4059s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0407s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3652s for    16416 events => throughput is 4.50E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggtt_fortran 2>&1 ) > /tmp/avalas
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/avalassi/output_ggtt_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/a
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1737s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1317s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.91E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1400s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0981s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.177552e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.139865e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.241417e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.266108e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.241417e+05                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/avalassi/output_ggtt_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/output_ggtt_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp 2>&1 ) > /tmp/a
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914455838006880]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.6510s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5676s
+ [COUNTERS] PROGRAM TOTAL          :    1.5996s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5162s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0833s for    16416 events => throughput is 1.97E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.940327e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.907021e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.004622e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.771254e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.004622e+07                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda 2>&1 ) > /tmp/avalassi/output_ggtt_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/output_ggtt_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 16384
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda 2>&1 ) > /tmp/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 47.67 [47.668452211994605]
  [UNWEIGHT] Wrote 804 events (found 2280 events)
- [COUNTERS] PROGRAM TOTAL          :    1.5490s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5482s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.23E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5543s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5536s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.15E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.904079e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.832701e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.801031e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 8.868057e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggtt_mad/log_ggtt_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:52:48
+DATE: 2022-06-15_15:04:27
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_tt.mad/SubProcesses/P1_gg_ttx
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91
- [COUNTERS] PROGRAM TOTAL          :    1.1100s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7458s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3642s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1058s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7435s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3623s for    16416 events => throughput is 4.53E+04 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggtt_fortran > /tmp/avalassi/output
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 45.91 [45.914216281363188]
  [UNWEIGHT] Wrote 788 events (found 2238 events)
- [COUNTERS] PROGRAM TOTAL          :    1.4062s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.0422s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3641s for    16416 events => throughput is 4.51E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4089s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.0436s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3653s for    16416 events => throughput is 4.49E+04 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.5161s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.1098s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3644s for    16416 events => throughput is 4.51E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0419s for    16416 events => throughput is 3.92E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.5127s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.1063s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3646s for    16416 events => throughput is 4.50E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0418s for    16416 events => throughput is 3.92E+05 events/s
 
 *** EXECUTE CHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.166394e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.192362e+05                 )  sec^-1
 
 *** EXECUTE CHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.218249e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.265352e+05                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cpp > /tmp/avalassi/o
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002015 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16416
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    2.0160s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5648s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3686s for    16416 events => throughput is 4.45E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0826s for    16416 events => throughput is 1.99E+05 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0071s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5538s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3704s for    16416 events => throughput is 4.43E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0829s for    16416 events => throughput is 1.98E+05 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.119312e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.931373e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.780467e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.133785e+07                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggtt_cuda > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00002017 = 1 + 2e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =  16384
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.2e-06 +- 5.3e-08
- [COUNTERS] PROGRAM TOTAL          :    1.8929s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5253s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.3669s for    16384 events => throughput is 4.47E+04 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0007s for    16384 events => throughput is 2.21E+07 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.8985s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5305s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.3673s for    16384 events => throughput is 4.46E+04 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0008s for    16384 events => throughput is 2.18E+07 events/s
 
 *** EXECUTE GCHECK -p 512 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.127965e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.940422e+07                 )  sec^-1
 
 *** EXECUTE GCHECK -p 512 32 1 ***
 Process                     = SIGMA_SM_GG_TTX_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 8.730683e+07                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.074445e+07                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_15:04:39
+DATE: 2022-06-15_16:04:59
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8913s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3050s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8876s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3040s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5836s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9577s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3719s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5858s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9651s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3770s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5882s for     4128 events => throughput is 7.02E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0252s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3942s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5842s for     4128 events => throughput is 7.07E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4358s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3889s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.879332e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.908162e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.868503e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.920342e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.868503e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998501 = 1 - 1.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4656s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7964s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5832s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9586s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8727s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0858s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.343534e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.354913e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.020280e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.009451e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 4096 ! Number of events in a single CUDA iteration (nb_page_loop)
 4096 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.020280e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
  [UNWEIGHT] Wrote 16 events (found 397 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99998926 = 1 - 1.1e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4561s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8697s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5851s for     4096 events => throughput is 7.00E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8657s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8644s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.390973e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.367089e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.018883e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.028973e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:17:03
+DATE: 2022-06-15_16:04:59
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avalassi/output_ggttg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8907s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5843s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8876s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3040s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5836s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avalassi/output_ggttg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avala
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9583s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3713s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5870s for     4128 events => throughput is 7.03E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9651s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3770s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5882s for     4128 events => throughput is 7.02E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avala
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/avalassi/output_ggttg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.4364s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3893s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0471s for     4128 events => throughput is 8.77E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4358s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3889s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.908918e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.908162e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.923990e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.920342e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.923990e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/avalassi/output_ggttg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9567s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8709s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9586s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8727s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0858s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.383740e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.354913e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.021165e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.009451e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.021165e+06                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda 2>&1 ) > /tmp/avalassi/output_ggttg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
@@ -138,11 +138,11 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda 2>&1 ) > /tmp
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.356068e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.367089e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.018617e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.028973e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:00
+DATE: 2022-06-15_15:04:39
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8925s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8913s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3050s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9572s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3709s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9577s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3719s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5858s for     4128 events => throughput is 7.05E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.0292s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3943s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5881s for     4128 events => throughput is 7.02E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0252s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3942s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5842s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0468s for     4128 events => throughput is 8.81E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.603134e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.879332e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.827705e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.868503e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00557897 = 1 + 0.0056
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4128
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.6e-05 +- 2.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.5562s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8876s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5827s for     4128 events => throughput is 7.08E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4656s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7964s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5832s for     4128 events => throughput is 7.08E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0860s for     4128 events => throughput is 4.80E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.404555e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.343534e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.006376e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.020280e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00486187 = 1 + 0.0049
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =   4096
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.7e-05 +- 2.5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.4447s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8672s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5762s for     4096 events => throughput is 7.11E+03 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.21E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.4561s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8697s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5851s for     4096 events => throughput is 7.00E+03 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.389550e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.390973e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.008826e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.018883e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,9 +1,9 @@
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
+Working directory (build): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_17:30:51
+DATE: 2022-06-15_17:47:25
 
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
+Working directory (run): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
 *** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
@@ -15,15 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8896s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3053s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5842s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8918s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3058s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -35,16 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9595s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3736s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9573s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3710s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5863s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -58,26 +56,25 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002] fbridge_mode=1
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.4369s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3899s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0470s for     4128 events => throughput is 8.78E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4358s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3888s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0470s for     4128 events => throughput is 8.79E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.907556e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.870743e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.913810e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.922355e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -91,26 +88,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.913810e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
+ [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002] fbridge_mode=1
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9544s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8686s
+ [COUNTERS] PROGRAM TOTAL          :    0.9611s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8753s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0858s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.386596e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.375391e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.018369e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.034409e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -124,25 +120,24 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.018369e+06                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
+ [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002] fbridge_mode=1
  [UNWEIGHT] Wrote 16 events (found 397 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8659s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8646s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.16E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8711s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8698s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.18E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.374443e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.375628e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.940890e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.023388e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:11:40
+DATE: 2022-06-15_16:17:03
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8896s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3042s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5854s for     4128 events => throughput is 7.05E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8907s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3064s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5843s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttg_fortran 2>&1 ) > /tmp/avalassi/output_ggttg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9643s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3717s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5926s for     4128 events => throughput is 6.97E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9583s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3713s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5870s for     4128 events => throughput is 7.03E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp 2>&1'
+Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.4351s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3881s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0470s for     4128 events => throughput is 8.78E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4364s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3893s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0471s for     4128 events => throughput is 8.77E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.902995e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.908918e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.916443e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.923990e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.916443e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp 2>&1 ) > /tmp/avalassi/output_ggttg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7228s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.6371s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0857s for     4128 events => throughput is 4.82E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9567s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8709s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0859s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.346162e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.383740e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.038368e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.021165e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.038368e+06                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda 2>&1 ) > /tmp/avalassi/output_ggttg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
  [UNWEIGHT] Wrote 16 events (found 397 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8664s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8651s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8657s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8644s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.381907e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.356068e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 5.944684e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.018617e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:59
+DATE: 2022-06-15_16:11:40
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.ma
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8876s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3040s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5836s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8896s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3042s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5854s for     4128 events => throughput is 7.05E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/output_ggttg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9651s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3770s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5882s for     4128 events => throughput is 7.02E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9643s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3717s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5926s for     4128 events => throughput is 6.97E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.4358s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3889s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4351s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3881s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0470s for     4128 events => throughput is 8.78E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.908162e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.902995e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.920342e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.916443e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 9.920342e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/output_ggttg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9586s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8727s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0858s for     4128 events => throughput is 4.81E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7228s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.6371s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0857s for     4128 events => throughput is 4.82E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.354913e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.346162e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.009451e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.038368e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 6.009451e+06                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi/output_ggttg_cuda 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 4096
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
  [UNWEIGHT] Wrote 16 events (found 397 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8657s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8644s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8664s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8651s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.19E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.367089e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.381907e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.028973e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.944684e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttg_mad/log_ggttg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:04:59
+DATE: 2022-06-15_17:30:51
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttg.mad/SubProcesses/P1_gg_ttxg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045
- [COUNTERS] PROGRAM TOTAL          :    0.8876s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3040s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5836s for     4128 events => throughput is 7.07E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8896s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3053s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5842s for     4128 events => throughput is 7.07E+03 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttg_fortran > /tmp/avalassi/outpu
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0445416635721884E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9651s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3770s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.5882s for     4128 events => throughput is 7.02E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9595s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3736s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.5860s for     4128 events => throughput is 7.04E+03 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.4358s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.3889s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0469s for     4128 events => throughput is 8.80E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.4369s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.3899s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0470s for     4128 events => throughput is 8.78E+04 events/s
 
 *** EXECUTE CHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.908162e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.907556e+04                 )  sec^-1
 
 *** EXECUTE CHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 9.920342e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 9.913810e+04                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cpp > /tmp/avalassi/
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08045 [8.0446406133394599E-002]
  [UNWEIGHT] Wrote 56 events (found 449 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9586s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8727s
+ [COUNTERS] PROGRAM TOTAL          :    0.9544s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8686s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0858s for     4128 events => throughput is 4.81E+04 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.354913e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.386596e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.009451e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.018369e+06                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttg_cuda > /tmp/avalassi
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 0.08402 [8.4018030529591323E-002]
  [UNWEIGHT] Wrote 16 events (found 397 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8657s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8644s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.20E+06 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8659s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8646s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0013s for     4096 events => throughput is 3.16E+06 events/s
 
 *** EXECUTE GCHECK -p 128 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 3.367089e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.374443e+06                 )  sec^-1
 
 *** EXECUTE GCHECK -p 128 32 1 ***
 Process                     = SIGMA_SM_GG_TTXG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 6.028973e+06                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 5.940890e+06                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:05:07
+DATE: 2022-06-15_17:30:59
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1008s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1683s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9325s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1023s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1677s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9346s for      544 events => throughput is 5.82E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1121s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1787s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9334s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1163s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1818s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9345s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.2648s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1899s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.2662s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1914s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.534051e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.549940e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.542972e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.538251e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9218s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7217s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2001s for      544 events => throughput is 2.72E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9225s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7227s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.1998s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757006e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.755538e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979541e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.988017e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7665s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7487s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7767s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7590s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757791e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756962e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.981329e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.979968e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:17:11
+DATE: 2022-06-15_16:05:07
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/avalassi/output_ggttgg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1004s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1661s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9343s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1008s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1683s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9325s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/aval
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/avalassi/output_ggttgg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/aval
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1126s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1785s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9341s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1121s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1787s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9334s for      544 events => throughput is 5.83E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/aval
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp/avalassi/output_ggttgg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.2633s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1885s
+ [COUNTERS] PROGRAM TOTAL          :    0.2648s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1899s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.536885e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.534051e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.475199e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.542972e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.475199e+03                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp/avalassi/output_ggttgg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9199s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7195s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2003s for      544 events => throughput is 2.72E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9218s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7217s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2001s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.759645e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757006e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.982901e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.979541e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.982901e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda 2>&1 ) > /tmp/avalassi/output_ggttgg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda 2>&1 ) > /tm
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7622s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7445s
+ [COUNTERS] PROGRAM TOTAL          :    0.7665s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7487s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756332e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757791e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978817e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981329e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_15:04:49
+DATE: 2022-06-15_16:05:07
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -22,8 +22,8 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
  [COUNTERS] PROGRAM TOTAL          :    1.1008s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1672s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9336s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1683s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9325s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1181s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1835s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9346s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1121s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1787s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9334s for      544 events => throughput is 5.83E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.1853s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1981s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.2648s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1899s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.526781e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.534051e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.535138e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.542972e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.535138e+03                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999493 = 1 - 5.1e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.9270s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.8016s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9116s for      544 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2138s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9218s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7217s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2001s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.758349e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757006e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980444e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.979541e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 512 ! Number of events in a single CUDA iteration (nb_page_loop)
 512 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.980444e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999649 = 1 - 3.5e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6203s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7454s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8571s for      512 events => throughput is 5.97E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7665s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7487s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757562e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757791e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.987068e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.981329e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:11:48
+DATE: 2022-06-15_16:17:11
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1023s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1666s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9356s for      544 events => throughput is 5.81E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1004s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1661s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9343s for      544 events => throughput is 5.82E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttgg_fortran 2>&1 ) > /tmp/avalassi/output_ggttgg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp 2>&1'
+Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -66,18 +66,18 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
  [COUNTERS] PROGRAM TOTAL          :    0.2633s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1884s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1885s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.535162e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.536885e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.537271e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.475199e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.537271e+03                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp 2>&1 ) > /tmp/avalassi/output_ggttgg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9203s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7206s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.1998s for      544 events => throughput is 2.72E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9199s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7195s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2003s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.749101e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.759645e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.982057e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.982901e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.982057e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda 2>&1 ) > /tmp/avalassi/output_ggttgg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7620s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7442s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7622s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7445s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.751326e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.756332e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.982953e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978817e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:05:07
+DATE: 2022-06-15_16:11:48
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1008s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1683s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9325s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1023s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1666s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9356s for      544 events => throughput is 5.81E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1121s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1787s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9334s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1126s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1785s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9341s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.2648s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1899s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.2633s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1884s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.534051e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.535162e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.542972e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.537271e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.542972e+03                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9218s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7217s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2001s for      544 events => throughput is 2.72E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.9203s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7206s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.1998s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757006e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.749101e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979541e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.982057e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.979541e+04                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7665s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7487s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0177s for      512 events => throughput is 2.89E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.7620s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7442s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.757791e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.751326e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.981329e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.982953e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,9 +1,9 @@
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
+Working directory (build): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_17:30:59
+DATE: 2022-06-15_17:47:33
 
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
+Working directory (run): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
 *** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
@@ -15,15 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.m
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.1023s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1677s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9346s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.0995s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1663s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9333s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -35,15 +34,14 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/output_ggttgg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1163s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1818s
+ [COUNTERS] PROGRAM TOTAL          :    1.1157s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1812s
  [COUNTERS] Fortran MEs      ( 1 ) :    0.9345s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
@@ -58,26 +56,25 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004] fbridge_mode=1
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.2662s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1914s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.27E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.2640s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1892s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0748s for      544 events => throughput is 7.27E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.549940e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.533560e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.538251e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.541999e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -91,26 +88,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 7.538251e+03                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi/output_ggttgg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004]
+ [XSECTION] Cross section = 0.0001289 [1.2885954287258873E-004] fbridge_mode=1
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    0.9225s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7227s
+ [COUNTERS] PROGRAM TOTAL          :    0.9196s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7198s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.1998s for      544 events => throughput is 2.72E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.755538e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757837e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.988017e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.983713e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -124,25 +120,24 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.988017e+04                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalassi/output_ggttgg_cuda'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 512
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
- [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004]
+ [XSECTION] Cross section = 0.0002221 [2.2210365310367753E-004] fbridge_mode=1
  [UNWEIGHT] Wrote 7 events (found 79 events)
- [COUNTERS] PROGRAM TOTAL          :    0.7767s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7590s
+ [COUNTERS] PROGRAM TOTAL          :    0.7665s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7487s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756962e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761582e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.979968e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.983273e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:10
+DATE: 2022-06-15_15:04:49
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289
- [COUNTERS] PROGRAM TOTAL          :    1.0994s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1659s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9335s for      544 events => throughput is 5.83E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1008s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1672s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9336s for      544 events => throughput is 5.83E+02 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttgg_fortran > /tmp/avalassi/outp
  [XSECTION] ChannelId = 2
  [XSECTION] Cross section = 0.0001289 [1.2885825323149218E-004]
  [UNWEIGHT] Wrote 4 events (found 74 events)
- [COUNTERS] PROGRAM TOTAL          :    1.1194s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1797s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9397s for      544 events => throughput is 5.79E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1181s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1835s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9346s for      544 events => throughput is 5.82E+02 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.2001s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.1898s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9354s for      544 events => throughput is 5.82E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.1853s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.1981s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9123s for      544 events => throughput is 5.96E+02 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0749s for      544 events => throughput is 7.26E+03 events/s
 
 *** EXECUTE CHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.519028e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.526781e+03                 )  sec^-1
 
 *** EXECUTE CHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 7.533124e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.535138e+03                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cpp > /tmp/avalassi
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00127182 = 1 + 0.0013
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    544
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 4.9e-05 +- 5e-06
- [COUNTERS] PROGRAM TOTAL          :    1.8701s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7187s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.9371s for      544 events => throughput is 5.81E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2143s for      544 events => throughput is 2.54E+03 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.9270s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.8016s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.9116s for      544 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.2138s for      544 events => throughput is 2.54E+03 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756425e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.758349e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.978130e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.980444e+04                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttgg_cuda > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00211545 = 1 + 0.0021
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =    512
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 5.1e-05 +- 6.3e-06
- [COUNTERS] PROGRAM TOTAL          :    1.6406s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.7438s
- [COUNTERS] Fortran MEs      ( 1 ) :    0.8790s for      512 events => throughput is 5.82E+02 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.87E+04 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.6203s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.7454s
+ [COUNTERS] Fortran MEs      ( 1 ) :    0.8571s for      512 events => throughput is 5.97E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.0178s for      512 events => throughput is 2.88E+04 events/s
 
 *** EXECUTE GCHECK -p 16 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.756175e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.757562e+04                 )  sec^-1
 
 *** EXECUTE GCHECK -p 16 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.980393e+04                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.987068e+04                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_10:53:21
+DATE: 2022-06-15_15:05:00
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9445s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2448s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6997s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9640s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2463s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7176s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9511s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2467s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7044s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9811s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2500s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7311s for       96 events => throughput is 2.57E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -69,20 +69,20 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.5336s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4476s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6945s for       96 events => throughput is 2.60E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3915s for       96 events => throughput is 2.45E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4906s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4484s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6466s for       96 events => throughput is 2.63E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3956s for       96 events => throughput is 2.43E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.839455e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.830657e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.834996e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.829052e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -107,20 +107,20 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    5.7932s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.2535s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6680s for       96 events => throughput is 2.62E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    6.0318s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5073s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.6527s for       96 events => throughput is 2.63E+01 events/s
  [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8718s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.765302e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764739e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975554e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.976290e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -145,19 +145,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
  [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
  [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4515s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6433s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4417s for       64 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    4.4449s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
+ [COUNTERS] Fortran MEs      ( 1 ) :    2.4382s for       64 events => throughput is 2.62E+01 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3664s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.762918e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.763308e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975020e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977592e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:17:19
+DATE: 2022-06-15_16:05:16
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/avalassi/output_ggttggg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9534s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2438s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7096s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9583s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2474s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7109s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/ava
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/avalassi/output_ggttggg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/ava
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9579s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2482s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7097s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9666s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7185s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/ava
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tmp/avalassi/output_ggttggg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tm
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8470s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4500s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3970s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8462s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4495s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.831558e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.827846e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.829715e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838396e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.829715e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tmp/avalassi/output_ggttggg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tm
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    2.3895s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5169s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8726s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.4061s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5334s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8727s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.762255e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761435e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975728e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975400e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.975728e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda 2>&1 ) > /tmp/avalassi/output_ggttggg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda 2>&1 ) > /t
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [COUNTERS] PROGRAM TOTAL          :    1.9962s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6297s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3665s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.0072s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761414e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764683e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977366e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977320e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:05:16
+DATE: 2022-06-15_16:11:56
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9583s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2474s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7109s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9574s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2443s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7131s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
+Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran 2>&1'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9666s
+ [COUNTERS] PROGRAM TOTAL          :    3.9599s
  [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7185s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7119s for       96 events => throughput is 2.59E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8462s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4495s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8433s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4480s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3953s for       96 events => throughput is 2.43E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.827846e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838402e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.838396e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.823398e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.838396e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    2.4061s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5334s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8727s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.3917s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5192s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8725s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761435e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.763777e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975400e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975652e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.975400e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
+Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda 2>&1'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [COUNTERS] PROGRAM TOTAL          :    2.0072s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.9988s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6326s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3661s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764683e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.762749e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977320e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977362e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:05:16
+DATE: 2022-06-15_17:31:07
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9583s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2474s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7109s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9508s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2459s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7049s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9666s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7185s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9739s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2504s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7235s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8462s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4495s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8428s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4503s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3925s for       96 events => throughput is 2.45E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.827846e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.832763e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.838396e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.835337e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    2.4061s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5334s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8727s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.3923s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5198s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8725s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761435e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.760626e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975400e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977390e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [COUNTERS] PROGRAM TOTAL          :    2.0072s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.9970s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6303s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764683e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761910e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977320e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977655e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_15:05:00
+DATE: 2022-06-15_16:05:16
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -21,9 +21,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9640s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2463s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7176s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9583s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2474s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7109s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -42,13 +42,13 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9811s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2500s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7311s for       96 events => throughput is 2.57E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9666s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7185s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -58,35 +58,30 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4906s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4484s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6466s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3956s for       96 events => throughput is 2.43E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8462s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4495s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3967s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.830657e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.827846e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.829052e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838396e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -96,35 +91,30 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.829052e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00015988 = 1 + 0.00016
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     96
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.8e-05 +- 3.4e-06
- [COUNTERS] PROGRAM TOTAL          :    6.0318s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5073s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.6527s for       96 events => throughput is 2.63E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8718s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.4061s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5334s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8727s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.764739e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761435e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.976290e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975400e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
--1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
++1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
 64 ! Number of events in a single CUDA iteration (nb_page_loop)
 64 1 1 ! Number of events and max and min iterations
 0.000001 ! Accuracy (ignored because max iterations = min iterations)
@@ -134,30 +124,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.976290e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
- [XSECTION] fbridge_mode = -1
+ [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [MERATIOS] ME ratio CudaCpp/Fortran: MIN = 0.99999778 = 1 - 2.2e-06
- [MERATIOS] ME ratio CudaCpp/Fortran: MAX = 1.00008518 = 1 + 8.5e-05
- [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES =     64
- [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = 1.6e-05 +- 3.5e-06
- [COUNTERS] PROGRAM TOTAL          :    4.4449s
+ [COUNTERS] PROGRAM TOTAL          :    2.0072s
  [COUNTERS] Fortran Overhead ( 0 ) :    1.6403s
- [COUNTERS] Fortran MEs      ( 1 ) :    2.4382s for       64 events => throughput is 2.62E+01 events/s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3664s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3669s for       64 events => throughput is 1.74E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.763308e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.764683e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977592e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977320e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,9 +1,9 @@
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
+Working directory (build): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_17:31:07
+DATE: 2022-06-15_17:47:42
 
-Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
+Working directory (run): /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
 *** (1) EXECUTE MADEVENT (create results.dat) ***
 --------------------
@@ -15,15 +15,14 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9508s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2459s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7049s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9598s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2452s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7146s for       96 events => throughput is 2.58E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -35,16 +34,15 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran'
- [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9739s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2504s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7235s for       96 events => throughput is 2.58E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9656s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2510s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7146s for       96 events => throughput is 2.58E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -58,26 +56,25 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007] fbridge_mode=1
  [UNWEIGHT] Wrote 4 events (found 15 events)
  [COUNTERS] PROGRAM TOTAL          :    0.8428s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4503s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3925s for       96 events => throughput is 2.45E+02 events/s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4493s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3934s for       96 events => throughput is 2.44E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.832763e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.838858e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.835337e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.828686e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -91,26 +88,25 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.835337e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
+ [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007] fbridge_mode=1
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    2.3923s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5198s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8725s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.3896s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5167s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8730s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.760626e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765865e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977390e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.978107e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -124,25 +120,24 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.977390e+02                 )  sec^-1
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
 Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda'
- [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
- [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
+ [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006] fbridge_mode=1
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [COUNTERS] PROGRAM TOTAL          :    1.9970s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6303s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3666s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.9933s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6273s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3660s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.761910e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.765005e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977655e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977670e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tmad/logs_ggttggg_mad/log_ggttggg_mad_d_inl0_hrd0.txt
@@ -1,7 +1,7 @@
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 make: Nothing to be done for `all'.
 
-DATE: 2022-06-15_16:11:56
+DATE: 2022-06-15_16:17:19
 
 Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.mad/SubProcesses/P1_gg_ttxggg
 
@@ -14,16 +14,16 @@ Working directory: /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttggg.
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
  [XSECTION] Configuration = 1
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07
- [COUNTERS] PROGRAM TOTAL          :    3.9574s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2443s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7131s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9534s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2438s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7096s for       96 events => throughput is 2.59E+01 events/s
 
 *** (1) EXECUTE MADEVENT (create events.lhe) ***
 --------------------
@@ -34,7 +34,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/output_ggttggg_fortran 2>&1'
+Executing '(  ./madevent < /tmp/avalassi/input_ggttggg_fortran 2>&1 ) > /tmp/avalassi/output_ggttggg_fortran'
  [XSECTION] fbridge_mode = 
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -42,9 +42,9 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471868628442136E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    3.9599s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.2480s
- [COUNTERS] Fortran MEs      ( 1 ) :    3.7119s for       96 events => throughput is 2.59E+01 events/s
+ [COUNTERS] PROGRAM TOTAL          :    3.9579s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.2482s
+ [COUNTERS] Fortran MEs      ( 1 ) :    3.7097s for       96 events => throughput is 2.59E+01 events/s
 
 *** (2) EXECUTE CMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -57,7 +57,7 @@ Executing ' ./madevent < /tmp/avalassi/input_ggttggg_fortran > /tmp/avalassi/out
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp 2>&1'
+Executing '(  ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -65,19 +65,19 @@ Executing ' ./cmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045729E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    0.8433s
- [COUNTERS] Fortran Overhead ( 0 ) :    0.4480s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3953s for       96 events => throughput is 2.43E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    0.8470s
+ [COUNTERS] Fortran Overhead ( 0 ) :    0.4500s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3970s for       96 events => throughput is 2.42E+02 events/s
 
 *** EXECUTE CHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+BRDHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.838402e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.831558e+02                 )  sec^-1
 
 *** EXECUTE CHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 2.823398e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 2.829715e+02                 )  sec^-1
 
 *** (3a) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -90,7 +90,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 2.823398e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalassi/output_ggttggg_cpp 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp 2>&1 ) > /tmp/avalassi/output_ggttggg_cpp'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 32
  [XSECTION] MultiChannel = TRUE
@@ -98,19 +98,19 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cpp > /tmp/avalass
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 3.447e-07 [3.4471908676045713E-007]
  [UNWEIGHT] Wrote 4 events (found 15 events)
- [COUNTERS] PROGRAM TOTAL          :    2.3917s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.5192s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8725s for       96 events => throughput is 1.10E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    2.3895s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.5169s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.8726s for       96 events => throughput is 1.10E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.763777e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.762255e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.975652e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.975728e+02                 )  sec^-1
 
 *** (3b) EXECUTE GMADEVENT_CUDACPP (create events.lhe) ***
 --------------------
@@ -123,7 +123,7 @@ EvtsPerSec[MECalcOnly] (3a) = ( 1.975652e+02                 )  sec^-1
 0 ! Helicity Sum/event 0=exact
 1 ! Channel number (1-N) for single-diagram enhancement multi-channel (NB used even if suppress amplitude is 0!)
 --------------------
-Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalassi/output_ggttggg_cuda 2>&1'
+Executing '(  ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda 2>&1 ) > /tmp/avalassi/output_ggttggg_cuda'
  [XSECTION] fbridge_mode = 1
  [XSECTION] nb_page_loop = 64
  [XSECTION] MultiChannel = TRUE
@@ -131,18 +131,18 @@ Executing ' ./gmadevent_cudacpp < /tmp/avalassi/input_ggttggg_cuda > /tmp/avalas
  [XSECTION] ChannelId = 1
  [XSECTION] Cross section = 2.008e-06 [2.0075279247605889E-006]
  [UNWEIGHT] Wrote 2 events (found 11 events)
- [COUNTERS] PROGRAM TOTAL          :    1.9988s
- [COUNTERS] Fortran Overhead ( 0 ) :    1.6326s
- [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3661s for       64 events => throughput is 1.75E+02 events/s
+ [COUNTERS] PROGRAM TOTAL          :    1.9962s
+ [COUNTERS] Fortran Overhead ( 0 ) :    1.6297s
+ [COUNTERS] CudaCpp MEs      ( 2 ) :    0.3665s for       64 events => throughput is 1.75E+02 events/s
 
 *** EXECUTE GCHECK -p 2 32 1 --bridge ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURHST+RMBHST+BRDDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.762749e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.761414e+02                 )  sec^-1
 
 *** EXECUTE GCHECK -p 2 32 1 ***
 Process                     = SIGMA_SM_GG_TTXGGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
-EvtsPerSec[MECalcOnly] (3a) = ( 1.977362e+02                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.977366e+02                 )  sec^-1
 
 TEST COMPLETED

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -217,9 +217,9 @@ function runmadevent()
   set +e # do not fail on error
   if [ "${debug}" == "1" ]; then
     echo "--------------------"; cat ${tmpin}; echo "--------------------"
-    echo "Executing '$timecmd $cmd < ${tmpin} > ${tmp} 2>&1'"
+    echo "Executing '( $timecmd $cmd < ${tmpin} 2>&1 ) > ${tmp}'"
   fi
-  $timecmd $cmd < ${tmpin} > ${tmp} 2>&1 
+  ( $timecmd $cmd < ${tmpin} 2>&1 ) > ${tmp}
   if [ "$?" != "0" ]; then echo "ERROR! '$timecmd $cmd < ${tmpin} > ${tmp}' failed"; tail -10 $tmp; exit 1; fi
   fbm=$(cat ${tmp} | grep --binary-files=text 'FBRIDGE_MODE =' | awk '{print $NF}')
   nbp=$(cat ${tmp} | grep --binary-files=text 'NB_PAGE_LOOP =' | awk '{print $NF}')

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -148,14 +148,14 @@ function getinputfile()
   elif [ "$1" == "-cuda" ]; then
     mv ${tmp} ${tmp}_cuda
     tmp=${tmp}_cuda
-    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     nloop=32768
     while [ $nloop -gt $nevt ]; do (( nloop = nloop / 2 )); done
     echo "${nloop} ! Number of events in a single CUDA iteration (nb_page_loop)" >> ${tmp}
   elif [ "$1" == "-cpp" ]; then
     mv ${tmp} ${tmp}_cpp
     tmp=${tmp}_cpp
-    echo "-1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
+    echo "+1 ! Fortran bridge mode (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)" >> ${tmp}
     echo "32 ! Number of events in a single C++ or CUDA iteration (nb_page_loop)" >> ${tmp}
   else
     echo "Usage: getinputfile <backend [-fortran][-cuda]-cpp]>"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -217,9 +217,9 @@ function runmadevent()
   set +e # do not fail on error
   if [ "${debug}" == "1" ]; then
     echo "--------------------"; cat ${tmpin}; echo "--------------------"
-    echo "Executing '( $timecmd $cmd < ${tmpin} 2>&1 ) > ${tmp}'"
+    echo "Executing '$timecmd $cmd < ${tmpin} > ${tmp}'"
   fi
-  ( $timecmd $cmd < ${tmpin} 2>&1 ) > ${tmp}
+  $timecmd $cmd < ${tmpin} > ${tmp}
   if [ "$?" != "0" ]; then echo "ERROR! '$timecmd $cmd < ${tmpin} > ${tmp}' failed"; tail -10 $tmp; exit 1; fi
   fbm=$(cat ${tmp} | grep --binary-files=text 'FBRIDGE_MODE =' | awk '{print $NF}')
   nbp=$(cat ${tmp} | grep --binary-files=text 'NB_PAGE_LOOP =' | awk '{print $NF}')

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -217,9 +217,9 @@ function runmadevent()
   set +e # do not fail on error
   if [ "${debug}" == "1" ]; then
     echo "--------------------"; cat ${tmpin}; echo "--------------------"
-    echo "Executing '$timecmd $cmd < ${tmpin} > ${tmp}'"
+    echo "Executing '$timecmd $cmd < ${tmpin} > ${tmp} 2>&1'"
   fi
-  $timecmd $cmd < ${tmpin} > ${tmp}
+  $timecmd $cmd < ${tmpin} > ${tmp} 2>&1 
   if [ "$?" != "0" ]; then echo "ERROR! '$timecmd $cmd < ${tmpin} > ${tmp}' failed"; tail -10 $tmp; exit 1; fi
   fbm=$(cat ${tmp} | grep --binary-files=text 'FBRIDGE_MODE =' | awk '{print $NF}')
   nbp=$(cat ${tmp} | grep --binary-files=text 'NB_PAGE_LOOP =' | awk '{print $NF}')

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -226,14 +226,15 @@ function runmadevent()
   mch=$(cat ${tmp} | grep --binary-files=text 'MULTI_CHANNEL =' | awk '{print $NF}')
   conf=$(cat ${tmp} | grep --binary-files=text 'Running Configuration Number:' | awk '{print $NF}')
   chid=$(cat ${tmp} | grep --binary-files=text 'CHANNEL_ID =' | awk '{print $NF}')
-  if [ "${fbm}" != "" ]; then echo " [XSECTION] fbridge_mode = ${fbm}"; fi
   echo " [XSECTION] nb_page_loop = ${nbp}"
   echo " [XSECTION] MultiChannel = ${mch}"
   echo " [XSECTION] Configuration = ${conf}"
   echo " [XSECTION] ChannelId = ${chid}"
   xsec=$(cat ${tmp} | grep --binary-files=text 'Cross sec =' | awk '{print 0+$NF}')
   xsec2=$(cat ${tmp} | grep --binary-files=text 'Actual xsec' | awk '{print $NF}')
-  if [ "${xsec2}" != "" ]; then
+  if [ "${fbm}" != "" ]; then
+    echo " [XSECTION] Cross section = ${xsec} [${xsec2}] fbridge_mode=${fbm}"
+  elif [ "${xsec2}" != "" ]; then
     echo " [XSECTION] Cross section = ${xsec} [${xsec2}]"
   elif [ "${xsec}" != "" ]; then
     echo " [XSECTION] Cross section = ${xsec}"

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -266,7 +266,7 @@ for suff in $suffs; do
 
   dir=$(showdir)
   if [ ! -d $dir ]; then echo "WARNING! Skip missing directory $dir"; continue; fi
-  echo "Working directory: $dir"
+  echo "Working directory (build): $dir"
   cd $dir
 
   if [ "${maketype}" == "-makeclean" ]; then make cleanall; echo; fi
@@ -288,7 +288,7 @@ for suff in $suffs; do
 
   dir=$(showdir)
   if [ ! -d $dir ]; then echo "WARNING! Skip missing directory $dir"; continue; fi
-  echo "Working directory: $dir"
+  echo "Working directory (run): $dir"
   cd $dir
 
   # Disable OpenMP multithreading in Fortran

--- a/epochX/cudacpp/tmad/madX.sh
+++ b/epochX/cudacpp/tmad/madX.sh
@@ -226,7 +226,7 @@ function runmadevent()
   mch=$(cat ${tmp} | grep --binary-files=text 'MULTI_CHANNEL =' | awk '{print $NF}')
   conf=$(cat ${tmp} | grep --binary-files=text 'Running Configuration Number:' | awk '{print $NF}')
   chid=$(cat ${tmp} | grep --binary-files=text 'CHANNEL_ID =' | awk '{print $NF}')
-  echo " [XSECTION] fbridge_mode = ${fbm}"
+  if [ "${fbm}" != "" ]; then echo " [XSECTION] fbridge_mode = ${fbm}"; fi
   echo " [XSECTION] nb_page_loop = ${nbp}"
   echo " [XSECTION] MultiChannel = ${mch}"
   echo " [XSECTION] Configuration = ${conf}"


### PR DESCRIPTION
This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/14

It is the first step of #402: it implements a dummy color choice (as opposed to a random color choice)

Essentially I have just added JAMP2_MULTI(0,IVEC) = NCOLOR. I have not even initialised JAMP2_MULTI(1:MAXFLOW,IVEC), it seems that addmothers.f manages this by itself somehow