### PR TITLE
Compiler tests for Jorgen and minor fixes for bmk

### DIFF
--- a/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -43,37 +43,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
-DATE: 2022-08-24_17:21:55
+DATE: 2022-08-24_17:36:48
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.7.99 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.461703e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.494624e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.497135e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.474941e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.506100e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.508821e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.704991 sec
-       179,433,642      cycles:u                  #    0.217 GHz                    
-       271,200,428      instructions:u            #    1.51  insn per cycle         
-       1.024685400 seconds time elapsed
+TOTAL       :     0.700685 sec
+       185,004,489      cycles:u                  #    0.224 GHz                    
+       274,350,059      instructions:u            #    1.48  insn per cycle         
+       1.014160543 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.7.99 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.166893e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.203840e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.205398e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.165366e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.202021e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.203478e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.080209 sec
-     2,343,705,136      cycles:u                  #    0.700 GHz                    
-     5,173,898,634      instructions:u            #    2.21  insn per cycle         
-       3.403224527 seconds time elapsed
+TOTAL       :     3.084591 sec
+     2,352,160,715      cycles:u                  #    0.703 GHz                    
+     4,952,342,313      instructions:u            #    2.11  insn per cycle         
+       3.405581647 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -87,14 +87,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.739670e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.741487e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.741487e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.737035e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.738952e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.738952e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.434199 sec
-    25,222,748,829      cycles:u                  #    2.672 GHz                    
-    78,172,274,760      instructions:u            #    3.10  insn per cycle         
-       9.441641381 seconds time elapsed
+TOTAL       :     9.448888 sec
+    25,217,023,642      cycles:u                  #    2.668 GHz                    
+    78,172,276,075      instructions:u            #    3.10  insn per cycle         
+       9.465744202 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4587) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.336748e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.343461e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.343461e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.328903e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.335555e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.335555e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.922157 sec
-    13,147,491,803      cycles:u                  #    2.668 GHz                    
-    40,004,633,400      instructions:u            #    3.04  insn per cycle         
-       4.930166913 seconds time elapsed
+TOTAL       :     4.934866 sec
+    13,159,588,448      cycles:u                  #    2.667 GHz                    
+    40,004,634,499      instructions:u            #    3.04  insn per cycle         
+       4.954118642 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:12894) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.639379e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.665327e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.665327e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.643069e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.669198e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.669198e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.477416 sec
-     5,631,621,821      cycles:u                  #    2.269 GHz                    
-    14,023,884,998      instructions:u            #    2.49  insn per cycle         
-       2.485329431 seconds time elapsed
+TOTAL       :     2.481780 sec
+     5,633,111,715      cycles:u                  #    2.270 GHz                    
+    14,023,885,673      instructions:u            #    2.49  insn per cycle         
+       2.508938914 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:10617) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.510686e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.543770e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.543770e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.507035e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.540747e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.540747e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.190674 sec
-     4,985,307,916      cycles:u                  #    2.270 GHz                    
-    12,662,620,301      instructions:u            #    2.54  insn per cycle         
-       2.198787438 seconds time elapsed
+TOTAL       :     2.200598 sec
+     4,987,242,694      cycles:u                  #    2.270 GHz                    
+    12,662,621,204      instructions:u            #    2.54  insn per cycle         
+       2.223984549 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:10350) (512y:   12) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.445643e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.471214e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.471214e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.447881e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.472310e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.472310e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.552589 sec
-     4,033,733,833      cycles:u                  #    1.578 GHz                    
-     6,440,889,778      instructions:u            #    1.60  insn per cycle         
-       2.560431885 seconds time elapsed
+TOTAL       :     2.561887 sec
+     4,032,316,886      cycles:u                  #    1.578 GHz                    
+     6,440,889,346      instructions:u            #    1.60  insn per cycle         
+       2.582745260 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1266) (512y:   60) (512z: 9903)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -43,37 +43,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
-DATE: 2022-08-24_17:36:48
+DATE: 2022-08-24_17:55:11
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.7.99 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.5.119 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.474941e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.506100e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.508821e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.715107e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.745977e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.748009e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.700685 sec
-       185,004,489      cycles:u                  #    0.224 GHz                    
-       274,350,059      instructions:u            #    1.48  insn per cycle         
-       1.014160543 seconds time elapsed
+TOTAL       :     0.566455 sec
+       175,691,871      cycles:u                  #    0.220 GHz                    
+       269,541,725      instructions:u            #    1.53  insn per cycle         
+       0.857059745 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.7.99 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.5.119 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.165366e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.202021e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.203478e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.144058e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.176681e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.178041e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.084591 sec
-     2,352,160,715      cycles:u                  #    0.703 GHz                    
-     4,952,342,313      instructions:u            #    2.11  insn per cycle         
-       3.405581647 seconds time elapsed
+TOTAL       :     3.087924 sec
+     2,366,510,133      cycles:u                  #    0.707 GHz                    
+     5,078,657,691      instructions:u            #    2.15  insn per cycle         
+       3.404354685 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -87,14 +87,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.737035e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.738952e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.738952e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.740342e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.742203e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.742203e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.448888 sec
-    25,217,023,642      cycles:u                  #    2.668 GHz                    
-    78,172,276,075      instructions:u            #    3.10  insn per cycle         
-       9.465744202 seconds time elapsed
+TOTAL       :     9.430247 sec
+    25,206,016,492      cycles:u                  #    2.672 GHz                    
+    78,172,275,072      instructions:u            #    3.10  insn per cycle         
+       9.438317423 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 4587) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -112,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.328903e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.335555e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.335555e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.325493e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.332123e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.332123e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.934866 sec
-    13,159,588,448      cycles:u                  #    2.667 GHz                    
-    40,004,634,499      instructions:u            #    3.04  insn per cycle         
-       4.954118642 seconds time elapsed
+TOTAL       :     4.938869 sec
+    13,152,503,602      cycles:u                  #    2.661 GHz                    
+    40,004,634,602      instructions:u            #    3.04  insn per cycle         
+       4.946618495 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:12894) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -137,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.643069e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.669198e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.669198e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.644396e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.670640e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.670640e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.481780 sec
-     5,633,111,715      cycles:u                  #    2.270 GHz                    
-    14,023,885,673      instructions:u            #    2.49  insn per cycle         
-       2.508938914 seconds time elapsed
+TOTAL       :     2.475603 sec
+     5,630,960,048      cycles:u                  #    2.271 GHz                    
+    14,023,885,827      instructions:u            #    2.49  insn per cycle         
+       2.482611057 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:10617) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -162,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.507035e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.540747e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.540747e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.480757e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.514049e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.514049e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.200598 sec
-     4,987,242,694      cycles:u                  #    2.270 GHz                    
-    12,662,621,204      instructions:u            #    2.54  insn per cycle         
-       2.223984549 seconds time elapsed
+TOTAL       :     2.199533 sec
+     4,987,334,365      cycles:u                  #    2.265 GHz                    
+    12,662,621,852      instructions:u            #    2.54  insn per cycle         
+       2.206740724 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:10350) (512y:   12) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -187,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.447881e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.472310e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.472310e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.445087e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.469775e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.469775e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.561887 sec
-     4,032,316,886      cycles:u                  #    1.578 GHz                    
-     6,440,889,346      instructions:u            #    1.60  insn per cycle         
-       2.582745260 seconds time elapsed
+TOTAL       :     2.552233 sec
+     4,031,871,771      cycles:u                  #    1.577 GHz                    
+     6,440,890,193      instructions:u            #    1.60  insn per cycle         
+       2.559806658 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1266) (512y:   60) (512z: 9903)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe

--- a/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,32 +1,49 @@
 
+make -C googletest/build
+make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+make[3]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+make[3]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+[ 50%] Built target gtest
+make[3]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+make[3]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+[100%] Built target gtest_main
+make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
+make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
 /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
+CUDACPP_BUILDDIR='build.512y_d_inl0_hrd0'
 
 make USEBUILDDIR=1 AVX=none
+CUDACPP_BUILDDIR='build.none_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=sse4
+CUDACPP_BUILDDIR='build.sse4_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=avx2
+CUDACPP_BUILDDIR='build.avx2_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=512y
+CUDACPP_BUILDDIR='build.512y_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=512z
+CUDACPP_BUILDDIR='build.512z_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
-DATE: 2022-06-20_16:22:58
+DATE: 2022-08-24_17:17:02
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
@@ -34,14 +51,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProces
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.536350e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.563536e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.565845e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.463245e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.495832e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.498216e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.574454 sec
-       181,747,037      cycles:u                  #    0.223 GHz                    
-       262,889,641      instructions:u            #    1.45  insn per cycle         
-       0.870546731 seconds time elapsed
+TOTAL       :     0.582107 sec
+       181,245,884      cycles:u                  #    0.222 GHz                    
+       270,254,347      instructions:u            #    1.49  insn per cycle         
+       0.875421275 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
@@ -49,14 +66,14 @@ runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProces
 Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.144212e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.173134e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.174349e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.164955e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.207226e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.208954e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.092735 sec
-     2,428,886,073      cycles:u                  #    0.725 GHz                    
-     5,159,681,910      instructions:u            #    2.12  insn per cycle         
-       3.406606241 seconds time elapsed
+TOTAL       :     3.099928 sec
+     2,392,103,470      cycles:u                  #    0.711 GHz                    
+     5,005,803,043      instructions:u            #    2.09  insn per cycle         
+       3.425826351 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -70,14 +87,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.784410e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.786343e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.786343e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.785992e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.787980e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.787980e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.197996 sec
-    24,565,885,991      cycles:u                  #    2.670 GHz                    
-    76,502,178,157      instructions:u            #    3.11  insn per cycle         
-       9.205309416 seconds time elapsed
+TOTAL       :     9.190315 sec
+    24,567,213,167      cycles:u                  #    2.672 GHz                    
+    76,502,178,095      instructions:u            #    3.11  insn per cycle         
+       9.197883044 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4: 1735) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
@@ -95,14 +112,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.302018e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.308670e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.308670e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.298652e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.305399e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.305399e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.973902 sec
-    13,282,863,477      cycles:u                  #    2.668 GHz                    
-    40,390,406,558      instructions:u            #    3.04  insn per cycle         
-       4.981548128 seconds time elapsed
+TOTAL       :     4.979394 sec
+    13,307,936,201      cycles:u                  #    2.670 GHz                    
+    40,390,406,702      instructions:u            #    3.04  insn per cycle         
+       4.986959571 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:12251) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
@@ -120,14 +137,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.677933e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.704793e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.704793e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.672534e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.699310e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.699310e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.463240 sec
-     5,596,270,225      cycles:u                  #    2.268 GHz                    
-    13,996,170,553      instructions:u            #    2.50  insn per cycle         
-       2.470688069 seconds time elapsed
+TOTAL       :     2.465563 sec
+     5,599,359,399      cycles:u                  #    2.268 GHz                    
+    13,996,170,921      instructions:u            #    2.50  insn per cycle         
+       2.473999848 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2:10023) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
@@ -145,14 +162,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.501566e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.534905e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.534905e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.495965e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.529774e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.529774e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.193558 sec
-     4,985,200,751      cycles:u                  #    2.267 GHz                    
-    12,679,383,158      instructions:u            #    2.54  insn per cycle         
-       2.201693460 seconds time elapsed
+TOTAL       :     2.195572 sec
+     4,988,145,859      cycles:u                  #    2.267 GHz                    
+    12,679,382,744      instructions:u            #    2.54  insn per cycle         
+       2.203514157 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 9790) (512y:   40) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
@@ -170,14 +187,14 @@ Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.426644e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.451350e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.451350e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.435066e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.459824e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.459824e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.559435 sec
-     4,041,828,670      cycles:u                  #    1.576 GHz                    
-     6,461,158,495      instructions:u            #    1.60  insn per cycle         
-       2.567146696 seconds time elapsed
+TOTAL       :     2.556468 sec
+     4,039,463,259      cycles:u                  #    1.577 GHz                    
+     6,461,158,666      instructions:u            #    1.60  insn per cycle         
+       2.564330697 seconds time elapsed
 =Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1339) (512y:   69) (512z: 9328)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe
@@ -190,3 +207,5 @@ Avg ME (F77/C++)    = 6.6266731198157342E-004
 Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 =========================================================================
+
+TEST COMPLETED

--- a/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -43,37 +43,37 @@ make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
-DATE: 2022-08-24_17:17:02
+DATE: 2022-08-24_17:21:55
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.463245e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.495832e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.498216e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.461703e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.494624e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.497135e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.582107 sec
-       181,245,884      cycles:u                  #    0.222 GHz                    
-       270,254,347      instructions:u            #    1.49  insn per cycle         
-       0.875421275 seconds time elapsed
+TOTAL       :     0.704991 sec
+       179,433,642      cycles:u                  #    0.217 GHz                    
+       271,200,428      instructions:u            #    1.51  insn per cycle         
+       1.024685400 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.164955e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.207226e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.208954e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.166893e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.203840e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.205398e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.099928 sec
-     2,392,103,470      cycles:u                  #    0.711 GHz                    
-     5,005,803,043      instructions:u            #    2.09  insn per cycle         
-       3.425826351 seconds time elapsed
+TOTAL       :     3.080209 sec
+     2,343,705,136      cycles:u                  #    0.700 GHz                    
+     5,173,898,634      instructions:u            #    2.21  insn per cycle         
+       3.403224527 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -83,19 +83,19 @@ Relative difference = 2.837296512218831e-07
 OK (relative difference <= 2E-4)
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.785992e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.787980e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.787980e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.739670e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.741487e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.741487e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.190315 sec
-    24,567,213,167      cycles:u                  #    2.672 GHz                    
-    76,502,178,095      instructions:u            #    3.11  insn per cycle         
-       9.197883044 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4: 1735) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     9.434199 sec
+    25,222,748,829      cycles:u                  #    2.672 GHz                    
+    78,172,274,760      instructions:u            #    3.10  insn per cycle         
+       9.441641381 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4: 4587) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -108,19 +108,19 @@ Relative difference = 2.8372990711072594e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.298652e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.305399e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.305399e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.336748e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.343461e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.343461e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.979394 sec
-    13,307,936,201      cycles:u                  #    2.670 GHz                    
-    40,390,406,702      instructions:u            #    3.04  insn per cycle         
-       4.986959571 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:12251) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     4.922157 sec
+    13,147,491,803      cycles:u                  #    2.668 GHz                    
+    40,004,633,400      instructions:u            #    3.04  insn per cycle         
+       4.930166913 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:12894) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -133,19 +133,19 @@ Relative difference = 2.837299076015613e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.672534e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.699310e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.699310e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.639379e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.665327e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.665327e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.465563 sec
-     5,599,359,399      cycles:u                  #    2.268 GHz                    
-    13,996,170,921      instructions:u            #    2.50  insn per cycle         
-       2.473999848 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10023) (512y:    0) (512z:    0)
+TOTAL       :     2.477416 sec
+     5,631,621,821      cycles:u                  #    2.269 GHz                    
+    14,023,884,998      instructions:u            #    2.49  insn per cycle         
+       2.485329431 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10617) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -158,19 +158,19 @@ Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.495965e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.529774e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.529774e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.510686e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.543770e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.543770e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.195572 sec
-     4,988,145,859      cycles:u                  #    2.267 GHz                    
-    12,679,382,744      instructions:u            #    2.54  insn per cycle         
-       2.203514157 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 9790) (512y:   40) (512z:    0)
+TOTAL       :     2.190674 sec
+     4,985,307,916      cycles:u                  #    2.270 GHz                    
+    12,662,620,301      instructions:u            #    2.54  insn per cycle         
+       2.198787438 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10350) (512y:   12) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -183,19 +183,19 @@ Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.435066e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.459824e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.459824e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.445643e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.471214e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.471214e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.556468 sec
-     4,039,463,259      cycles:u                  #    1.577 GHz                    
-     6,461,158,666      instructions:u            #    1.60  insn per cycle         
-       2.564330697 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1339) (512y:   69) (512z: 9328)
+TOTAL       :     2.552589 sec
+     4,033,733,833      cycles:u                  #    1.578 GHz                    
+     6,440,889,778      instructions:u            #    1.60  insn per cycle         
+       2.560431885 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1266) (512y:   60) (512z: 9903)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.

--- a/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
+++ b/epochX/cudacpp/tput/logs_ggttgg_mad/log_ggttgg_mad_d_inl0_hrd0.txt
@@ -1,79 +1,62 @@
 
-make -C googletest/build
-make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-make[2]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-make[3]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-make[3]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-[ 50%] Built target gtest
-make[3]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-make[3]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-[100%] Built target gtest_main
-make[2]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
-make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/test/googletest/build'
 /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg
-CUDACPP_BUILDDIR='build.512y_d_inl0_hrd0'
 
 make USEBUILDDIR=1 AVX=none
-CUDACPP_BUILDDIR='build.none_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=sse4
-CUDACPP_BUILDDIR='build.sse4_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=avx2
-CUDACPP_BUILDDIR='build.avx2_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=512y
-CUDACPP_BUILDDIR='build.512y_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
 make USEBUILDDIR=1 AVX=512z
-CUDACPP_BUILDDIR='build.512z_d_inl0_hrd0'
 make[1]: Entering directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 make[1]: Nothing to be done for `all'.
 make[1]: Leaving directory `/data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg'
 
-DATE: 2022-08-24_17:55:11
+DATE: 2022-06-20_16:22:58
 
 On itscrd70.cern.ch [CPU: Intel(R) Xeon(R) Silver 4216 CPU] [GPU: 1x Tesla V100S-PCIE-32GB]:
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.5.119 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 3.715107e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.745977e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.748009e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.536350e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.563536e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.565845e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     0.566455 sec
-       175,691,871      cycles:u                  #    0.220 GHz                    
-       269,541,725      instructions:u            #    1.53  insn per cycle         
-       0.857059745 seconds time elapsed
+TOTAL       :     0.574454 sec
+       181,747,037      cycles:u                  #    0.223 GHz                    
+       262,889,641      instructions:u            #    1.45  insn per cycle         
+       0.870546731 seconds time elapsed
 ==PROF== Profiling "sigmaKin": launch__registers_per_thread 255
 ==PROF== Profiling "sigmaKin": sm__sass_average_branch_targets_threads_uniform.pct 100%
 .........................................................................
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe -p 2048 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.5.119 (gcc 11.2.0)] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CUDA [nvcc 11.6.124 (gcc 10.2.0)] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CUD:DBL+THX:CURDEV+RMBDEV+MESDEV/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
-EvtsPerSec[Rmb+ME]     (23) = ( 4.144058e+05                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 4.176681e+05                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 4.178041e+05                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 4.144212e+05                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 4.173134e+05                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 4.174349e+05                 )  sec^-1
 MeanMatrixElemValue         = ( 6.665112e+00 +- 5.002651e+00 )  GeV^-4
-TOTAL       :     3.087924 sec
-     2,366,510,133      cycles:u                  #    0.707 GHz                    
-     5,078,657,691      instructions:u            #    2.15  insn per cycle         
-       3.404354685 seconds time elapsed
+TOTAL       :     3.092735 sec
+     2,428,886,073      cycles:u                  #    0.725 GHz                    
+     5,159,681,910      instructions:u            #    2.12  insn per cycle         
+       3.406606241 seconds time elapsed
 -------------------------------------------------------------------------
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/gcheck.exe --common -p 2 64 2
 cmpExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/fgcheck.exe 2 64 2
@@ -83,19 +66,19 @@ Relative difference = 2.837296512218831e-07
 OK (relative difference <= 2E-4)
 =========================================================================
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/none+NAVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = SCALAR ('none': ~vector[1], no SIMD)
-EvtsPerSec[Rmb+ME]     (23) = ( 1.740342e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 1.742203e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 1.742203e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 1.784410e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 1.786343e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 1.786343e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     9.430247 sec
-    25,206,016,492      cycles:u                  #    2.672 GHz                    
-    78,172,275,072      instructions:u            #    3.10  insn per cycle         
-       9.438317423 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4: 4587) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     9.197996 sec
+    24,565,885,991      cycles:u                  #    2.670 GHz                    
+    76,502,178,157      instructions:u            #    3.11  insn per cycle         
+       9.205309416 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4: 1735) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.none_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -108,19 +91,19 @@ Relative difference = 2.8372990711072594e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/sse4+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[2] ('sse4': SSE4.2, 128bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 3.325493e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 3.332123e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 3.332123e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 3.302018e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 3.308670e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 3.308670e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     4.938869 sec
-    13,152,503,602      cycles:u                  #    2.661 GHz                    
-    40,004,634,602      instructions:u            #    3.04  insn per cycle         
-       4.946618495 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:12894) (avx2:    0) (512y:    0) (512z:    0)
+TOTAL       :     4.973902 sec
+    13,282,863,477      cycles:u                  #    2.668 GHz                    
+    40,390,406,558      instructions:u            #    3.04  insn per cycle         
+       4.981548128 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:12251) (avx2:    0) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.sse4_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -133,19 +116,19 @@ Relative difference = 2.837299076015613e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/avx2+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('avx2': AVX2, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.644396e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.670640e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.670640e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.677933e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.704793e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.704793e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.475603 sec
-     5,630,960,048      cycles:u                  #    2.271 GHz                    
-    14,023,885,827      instructions:u            #    2.49  insn per cycle         
-       2.482611057 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10617) (512y:    0) (512z:    0)
+TOTAL       :     2.463240 sec
+     5,596,270,225      cycles:u                  #    2.268 GHz                    
+    13,996,170,553      instructions:u            #    2.50  insn per cycle         
+       2.470688069 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10023) (512y:    0) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.avx2_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -158,19 +141,19 @@ Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512y+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[4] ('512y': AVX512, 256bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 7.480757e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 7.514049e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 7.514049e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 7.501566e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 7.534905e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 7.534905e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.199533 sec
-     4,987,334,365      cycles:u                  #    2.265 GHz                    
-    12,662,621,852      instructions:u            #    2.54  insn per cycle         
-       2.206740724 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2:10350) (512y:   12) (512z:    0)
+TOTAL       :     2.193558 sec
+     4,985,200,751      cycles:u                  #    2.267 GHz                    
+    12,679,383,158      instructions:u            #    2.54  insn per cycle         
+       2.201693460 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 9790) (512y:   40) (512z:    0)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512y_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -183,19 +166,19 @@ Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/check.exe -p 64 256 1 OMP=
-Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 11.2.0] [inlineHel=0] [hardcodePARAM=0]
+Process                     = SIGMA_SM_GG_TTXGG_CPP [gcc 10.2.0] [inlineHel=0] [hardcodePARAM=0]
 Workflow summary            = CPP:DBL+CXS:CURHST+RMBHST+MESHST/512z+CXVBRK
 FP precision                = DOUBLE (NaN/abnormal=0, zero=0)
 Internal loops fptype_sv    = VECTOR[8] ('512z': AVX512, 512bit) [cxtype_ref=YES]
-EvtsPerSec[Rmb+ME]     (23) = ( 6.445087e+03                 )  sec^-1
-EvtsPerSec[MatrixElems] (3) = ( 6.469775e+03                 )  sec^-1
-EvtsPerSec[MECalcOnly] (3a) = ( 6.469775e+03                 )  sec^-1
+EvtsPerSec[Rmb+ME]     (23) = ( 6.426644e+03                 )  sec^-1
+EvtsPerSec[MatrixElems] (3) = ( 6.451350e+03                 )  sec^-1
+EvtsPerSec[MECalcOnly] (3a) = ( 6.451350e+03                 )  sec^-1
 MeanMatrixElemValue         = ( 4.063123e+00 +- 2.368970e+00 )  GeV^-4
-TOTAL       :     2.552233 sec
-     4,031,871,771      cycles:u                  #    1.577 GHz                    
-     6,440,890,193      instructions:u            #    1.60  insn per cycle         
-       2.559806658 seconds time elapsed
-=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1266) (512y:   60) (512z: 9903)
+TOTAL       :     2.559435 sec
+     4,041,828,670      cycles:u                  #    1.576 GHz                    
+     6,461,158,495      instructions:u            #    1.60  insn per cycle         
+       2.567146696 seconds time elapsed
+=Symbols in CPPProcess.o= (~sse4:    0) (avx2: 1339) (512y:   69) (512z: 9328)
 -------------------------------------------------------------------------
 runExe /data/avalassi/GPU2020/madgraph4gpuX/epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg/build.512z_d_inl0_hrd0/runTest.exe
 [  PASSED  ] 6 tests.
@@ -207,5 +190,3 @@ Avg ME (F77/C++)    = 6.6266731198157342E-004
 Relative difference = 2.837296631655439e-07
 OK (relative difference <= 2E-4)
 =========================================================================
-
-TEST COMPLETED

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,6 @@
 CXXFLAGS += -Igoogletest/googletest/include/ -std=c++11
 
-all: gtest
-
-.PHONY: gtest
+all: googletest/build/lib/libgtest.a
 
 googletest:
 	git clone https://github.com/google/googletest.git -b release-1.11.0 googletest
@@ -11,7 +9,7 @@ googletest/build: googletest
 	mkdir -p $@
 	cd googletest/build && cmake -DBUILD_GMOCK=OFF ../
 
-gtest: googletest/build
+googletest/build/lib/libgtest.a: googletest/build
 	$(MAKE) -C googletest/build
 
 clean:


### PR DESCRIPTION
Compiler tests for Jorgen and minor fixes for bmk

This includes
- the first tests for cuda117 (with gcc11.2)
- a test of cuda115 and gcc112 for juwels

For the bmk I further simplified the googletest makefiles