### PR TITLE
fix bug in throughputX.sh (missing fptype in cpp tests!)

### DIFF
--- a/epochX/cudacpp/tput/throughputX.sh
+++ b/epochX/cudacpp/tput/throughputX.sh
@@ -337,10 +337,12 @@ for dir in $dirs; do
       hrdsuf=_hrd${hrdcod}
       if [ "$bckend" == "alpaka" ]; then hrdsuf=""; fi
       for helinl in $helinls; do
-        for simd in none sse4 avx2 512y 512z; do
-          if [ "${simds/${simd}}" != "${simds}" ]; then 
-            exes="$exes $dir/build.${simd}_${fptype}_inl${helinl}${hrdsuf}/check.exe"
-          fi
+        for fptype in $fptypes; do
+          for simd in none sse4 avx2 512y 512z; do
+            if [ "${simds/${simd}}" != "${simds}" ]; then 
+              exes="$exes $dir/build.${simd}_${fptype}_inl${helinl}${hrdsuf}/check.exe"
+            fi
+          done
         done
       done
     done


### PR DESCRIPTION
Fix bug in throughputX.sh (missing fptype in cpp tests!)

The bug was introduced in 13a8faca40f3cb3afbd4c6b276416ac6c8262f76