### PR TITLE
Move CI to Alma9.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,6 +52,7 @@ jobs:
   GPU:
     runs-on: self-hosted
     env:
+      CUDA_HOME: /usr/local/cuda-12.0/
       FC: gfortran
       REQUIRE_CUDA: 1
     strategy:
@@ -61,9 +62,11 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    - name: path
+      run: echo "PATH=$PATH"
     - name: make info
-      run: source /opt/rh/gcc-toolset-10/enable; make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} info
+      run: make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} info
     - name: make
-      run: source /opt/rh/gcc-toolset-10/enable; make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }}
+      run: make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }}
     - name: make check
-      run: source /opt/rh/gcc-toolset-10/enable; make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} check
+      run: make FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} check


### PR DESCRIPTION
In order to move to Alma9, devtoolset-10 had to be disabled, since Alma9 is already at gcc-11.
Cuda was updated to v12.0.

Both concern the GPU part only.