### PR TITLE
Add back tools/CommonRandomNumbers.h as discussed with Zenn…

### DIFF
--- a/tools/CommonRandomNumbers.h
+++ b/tools/CommonRandomNumbers.h
@@ -1,0 +1,89 @@
+/*
+ * CommonRandomNumbers.h
+ *
+ *  Created on: 04.11.2020
+ *      Author: Stephan Hageboeck
+ */
+
+#ifndef COMMONRANDOMNUMBERS_H_
+#define COMMONRANDOMNUMBERS_H_
+
+#include <vector>
+#include <random>
+#include <thread>
+#include <future>
+
+namespace CommonRandomNumbers {
+
+/// Create `n` random numbers using simple c++ engine.
+template<typename T>
+std::vector<T> generate(std::size_t n, std::minstd_rand::result_type seed = 1337) {
+  std::vector<T> result;
+  result.reserve(n);
+
+  std::minstd_rand generator(seed);
+  std::uniform_real_distribution<T> distribution(0.0, 1.0);
+
+  for (std::size_t i=0; i<n; ++i) {
+    result.push_back(distribution(generator));
+  }
+
+  return result;
+}
+
+
+/// Create `nBlock` blocks of random numbers.
+/// Each block uses a generator that's seeded with `seed + blockIndex`, and blocks are generated in parallel.
+template<typename T>
+std::vector<std::vector<T>> generateParallel(std::size_t nPerBlock, std::size_t nBlock, std::minstd_rand::result_type seed = 1337) {
+  std::vector<std::vector<T>> results(nBlock);
+  std::vector<std::thread> threads;
+  const auto partPerThread = nBlock/std::thread::hardware_concurrency() + (nBlock % std::thread::hardware_concurrency() != 0);
+
+  auto makeBlock = [nPerBlock,nBlock,seed,&results](std::size_t partitionBegin, std::size_t partitionEnd) {
+    for (std::size_t partition = partitionBegin; partition < partitionEnd && partition < nBlock; ++partition) {
+      results[partition] = generate<T>(nPerBlock, seed + partition);
+    }
+  };
+
+  for (unsigned int threadId = 0; threadId < std::thread::hardware_concurrency(); ++threadId) {
+    threads.emplace_back(makeBlock, threadId * partPerThread, (threadId+1) * partPerThread);
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  return results;
+}
+
+
+/// Starts asynchronous generation of random numbers. This uses as many threads as cores, and generates blocks of random numbers.
+/// These become available at unspecified times, but the blocks 0, 1, 2, ... are generated first.
+/// Each block is seeded with seed + blockIndex to generate stable sequences.
+/// \param[in/out] promises Vector of promise objects storing blocks of random numbers.
+/// \param[in] nPerBlock Configures number of entries generated per block.
+/// \param[in] nBlock Configures the number of blocks generated.
+/// \param[in] nThread Optional concurrency.
+/// \param[in] seed Optional seed.
+template<typename T>
+void startGenerateAsync(std::vector<std::promise<std::vector<T>>>& promises, std::size_t nPerBlock, std::size_t nBlock,
+    unsigned int nThread = std::thread::hardware_concurrency(), std::minstd_rand::result_type seed = 1337) {
+  promises.resize(nBlock);
+  std::vector<std::thread> threads;
+
+  auto makeBlocks = [=,&promises](std::size_t threadID) {
+    for (std::size_t partition = threadID; partition < nBlock; partition += nThread) {
+      auto values = generate<T>(nPerBlock, seed + partition);
+      promises[partition].set_value(std::move(values));
+    }
+  };
+
+  for (unsigned int threadId = 0; threadId < nThread; ++threadId) {
+    std::thread(makeBlocks, threadId).detach();
+  }
+}
+
+}
+
+#endif /* COMMONRANDOMNUMBERS_H_ */


### PR DESCRIPTION
Hi @zeniheisser (cc @roiser) I am adding back tools/CommonRandomNumbers.h as discussed - this is still needed by epochX/sycl (and by epoch1/2). In other words, the sycl builds would now break.

In any case I would keep it there (for epoch1/2) also later, unless we remove epoch1/2. It's clutter, but does not really harm.

This reverts parts of MRs #663 and #664 - it is related to #613
