### PR TITLE
Add support for "any" process in generateAndCompare.sh 

### DIFF
--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -294,8 +294,10 @@ function usage()
     echo "Usage: $0 [--nobrief] <proc>"
   else
     # NB: all options with $SCRBCK=cudacpp use the 311 branch by default and always disable helicity recycling
-    echo "Usage: $0 [--nobrief] [--cpp|--gpu|--madnovec|--madonly|--mad|--madcpp*|--madgpu] [--nopatch|--upstream] [-c '<cmd>'] <proc>"
-    echo "(*Note: the --madcpp option exists but code generation fails for it)"
+    echo "Usage:   $0 [--nobrief] [--cpp|--gpu|--madnovec|--madonly|--mad|--madcpp*|--madgpu] [--nopatch|--upstream] [-c '<cmd>'] <proc>"
+    echo "         (*Note: the --madcpp option exists but code generation fails for it)"
+    echo "Example: $0 gg_tt --mad"
+    echo "Example: $0 gg_bb --mad -c 'generate g g > b b~'"
   fi
   exit 1
 }

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -106,8 +106,8 @@ function codeGenAndDiff()
       generate p p > ell+ ell- @0"
       ;;
     *)
-      echo -e "\nWARNING! Skipping unknown process '$proc'"
-      return
+      echo -e "\nERROR! Unknown process '$proc'"
+      exit 1
       ;;
   esac
   if [ "$2" != "" ]; then echo -e "INTERNAL ERROR!\nUsage: ${FUNCNAME[0]} <proc>"; exit 1; fi

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -331,43 +331,40 @@ PATCHLEVEL=
 if [ "${SCRBCK}" == "gridpack" ]; then export HELREC=1; else export HELREC=0; fi
 
 # Process command line arguments (https://unix.stackexchange.com/a/258514)
-for arg in "$@"; do
-  shift
-  if [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
+while [ "$1" != "" ]; do
+  if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     usage
-  elif [ "$arg" == "--nobrief" ]; then
+  elif [ "$1" == "--nobrief" ]; then
     BRIEF=
-  elif [ "$arg" == "--nopatch" ] && [ "${PATCHLEVEL}" == "" ]; then
+  elif [ "$1" == "--nopatch" ] && [ "${PATCHLEVEL}" == "" ]; then
     PATCHLEVEL=--nopatch
-  elif [ "$arg" == "--upstream" ] && [ "${PATCHLEVEL}" == "" ]; then
+  elif [ "$1" == "--upstream" ] && [ "${PATCHLEVEL}" == "" ]; then
     PATCHLEVEL=--upstream
-  elif [ "$arg" == "--nountaronly" ] && [ "${SCRBCK}" == "gridpack" ]; then
+  elif [ "$1" == "--nountaronly" ] && [ "${SCRBCK}" == "gridpack" ]; then
     UNTARONLY=0
-  elif [ "$arg" == "--nohelrec" ] && [ "${SCRBCK}" == "gridpack" ]; then
+  elif [ "$1" == "--nohelrec" ] && [ "${SCRBCK}" == "gridpack" ]; then
     export HELREC=0
-  elif [ "$arg" == "--cpp" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--gpu" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--madnovec" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--madonly" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--mad" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--madcpp" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
-  elif [ "$arg" == "--madgpu" ] && [ "${SCRBCK}" == "cudacpp" ]; then
-    export OUTBCK=${arg#--}
+  elif [ "$1" == "--cpp" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--gpu" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--madnovec" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--madonly" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--mad" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--madcpp" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$1" == "--madgpu" ] && [ "${SCRBCK}" == "cudacpp" ]; then
+    export OUTBCK=${1#--}
+  elif [ "$proc" == "" ]; then
+    proc = "$1"
   else
-    # Keep the possibility to collect more then one process
-    # However, require a single process to be chosen (allow full cleanup before/after code generation)
-    set -- "$@" "$arg"
+    usage
   fi
+  shift
 done
-###procs=$@
-if [ "$1" == "" ] || [ "$2" != "" ]; then usage; fi # New: only one process
-proc=$1
 
 echo "SCRDIR=${SCRDIR}"
 echo "OUTDIR=${OUTDIR}"

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -110,6 +110,7 @@ function codeGenAndDiff()
       return
       ;;
   esac
+  if [ "$2" != "" ]; then echo -e "INTERNAL ERROR!\nUsage: ${FUNCNAME[0]} <proc>"; exit 1; fi
   echo -e "\n+++ Generate code for '$proc'\n"
   ###exit 0 # FOR DEBUGGING
   # Vector size for mad/madonly meexporter (VECSIZE_MEMMAX)

--- a/epochX/cudacpp/CODEGEN/generateAndCompare.sh
+++ b/epochX/cudacpp/CODEGEN/generateAndCompare.sh
@@ -279,8 +279,8 @@ function usage()
     echo "Usage: $0 [--nobrief] <proc>"
   else
     # NB: all options with $SCRBCK=cudacpp use the 311 branch by default and always disable helicity recycling
-    echo "Usage: $0 [--nobrief] [--cpp|--gpu|--madnovec|--madonly|--mad|--madgpu] [--nopatch|--upstream] <proc>"
-    echo "(NB: a --madcpp option also exists but code generation fails for it)"
+    echo "Usage: $0 [--nobrief] [--cpp|--gpu|--madnovec|--madonly|--mad|--madcpp*|--madgpu] [--nopatch|--upstream] <proc>"
+    echo "(*Note: the --madcpp option exists but code generation fails for it)"
   fi
   exit 1
 }


### PR DESCRIPTION
Add support for "any" process in generateAndCompare.sh 

Example
```
./CODEGEN/generateAndCompare.sh gg_bb --mad -c 'generate g g > b b~'
```

Error handling
```
[avalassi@itscrd80 gcc11.2/cvmfs] /data/avalassi/GPU2023/madgraph4gpuX/epochX/cudacpp>  ./CODEGEN/generateAndCompare.sh gg_bb 
...
ERROR! Unknown process 'gg_bb' and no external process specified with '-c <cmd>'
```
and
```
[avalassi@itscrd80 gcc11.2/cvmfs] /data/avalassi/GPU2023/madgraph4gpuX/epochX/cudacpp>  ./CODEGEN/generateAndCompare.sh gg_tt --mad -c 'generate g g > t t~ g g '
...
ERROR! Invalid option '-c <cmd>' to predefined process 'gg_tt'
Predefined cmd='generate g g > t t~'
User-defined cmd='generate g g > t t~ g g g g'
```