### PR TITLE
WIP: separate cpu/gpu namespaces and fix runtest segmentation fault

### DIFF
--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/Bridge.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/Bridge.h
@@ -152,32 +152,32 @@ namespace mg5amcCpu
 #ifdef __CUDACC__
     int m_gputhreads; // number of gpu threads (default set from number of events, can be modified)
     int m_gpublocks;  // number of gpu blocks (default set from number of events, can be modified)
-    mg5amcGpu::DeviceBuffer<FORTRANFPTYPE, sizePerEventMomenta> m_devMomentaF;
-    mg5amcGpu::DeviceBufferMomenta m_devMomentaC;
-    mg5amcGpu::DeviceBufferGs m_devGs;
-    mg5amcGpu::DeviceBufferRndNumHelicity m_devRndHel;
-    mg5amcGpu::DeviceBufferRndNumColor m_devRndCol;
-    mg5amcGpu::DeviceBufferMatrixElements m_devMEs;
-    mg5amcGpu::DeviceBufferSelectedHelicity m_devSelHel;
-    mg5amcGpu::DeviceBufferSelectedColor m_devSelCol;
-    mg5amcGpu::PinnedHostBufferGs m_hstGs;
-    mg5amcGpu::PinnedHostBufferRndNumHelicity m_hstRndHel;
-    mg5amcGpu::PinnedHostBufferRndNumColor m_hstRndCol;
-    mg5amcGpu::PinnedHostBufferMatrixElements m_hstMEs;
-    mg5amcGpu::PinnedHostBufferSelectedHelicity m_hstSelHel;
-    mg5amcGpu::PinnedHostBufferSelectedColor m_hstSelCol;
-    std::unique_ptr<mg5amcGpu::MatrixElementKernelDevice> m_pmek;
+    DeviceBuffer<FORTRANFPTYPE, sizePerEventMomenta> m_devMomentaF;
+    DeviceBufferMomenta m_devMomentaC;
+    DeviceBufferGs m_devGs;
+    DeviceBufferRndNumHelicity m_devRndHel;
+    DeviceBufferRndNumColor m_devRndCol;
+    DeviceBufferMatrixElements m_devMEs;
+    DeviceBufferSelectedHelicity m_devSelHel;
+    DeviceBufferSelectedColor m_devSelCol;
+    PinnedHostBufferGs m_hstGs;
+    PinnedHostBufferRndNumHelicity m_hstRndHel;
+    PinnedHostBufferRndNumColor m_hstRndCol;
+    PinnedHostBufferMatrixElements m_hstMEs;
+    PinnedHostBufferSelectedHelicity m_hstSelHel;
+    PinnedHostBufferSelectedColor m_hstSelCol;
+    std::unique_ptr<MatrixElementKernelDevice> m_pmek;
     //static constexpr int s_gputhreadsmin = 16; // minimum number of gpu threads (TEST VALUE FOR MADEVENT)
     static constexpr int s_gputhreadsmin = 32; // minimum number of gpu threads (DEFAULT)
 #else
-    mg5amcCpu::HostBufferMomenta m_hstMomentaC;
-    mg5amcCpu::HostBufferGs m_hstGs;
-    mg5amcCpu::HostBufferRndNumHelicity m_hstRndHel;
-    mg5amcCpu::HostBufferRndNumColor m_hstRndCol;
-    mg5amcCpu::HostBufferMatrixElements m_hstMEs;
-    mg5amcCpu::HostBufferSelectedHelicity m_hstSelHel;
-    mg5amcCpu::HostBufferSelectedColor m_hstSelCol;
-    std::unique_ptr<mg5amcCpu::MatrixElementKernelHost> m_pmek;
+    HostBufferMomenta m_hstMomentaC;
+    HostBufferGs m_hstGs;
+    HostBufferRndNumHelicity m_hstRndHel;
+    HostBufferRndNumColor m_hstRndCol;
+    HostBufferMatrixElements m_hstMEs;
+    HostBufferSelectedHelicity m_hstSelHel;
+    HostBufferSelectedColor m_hstSelCol;
+    std::unique_ptr<MatrixElementKernelHost> m_pmek;
 #endif
   };
 
@@ -244,12 +244,12 @@ namespace mg5amcCpu
     }
     std::cout << "WARNING! Instantiate device Bridge (nevt=" << m_nevt << ", gpublocks=" << m_gpublocks << ", gputhreads=" << m_gputhreads
               << ", gpublocks*gputhreads=" << m_gpublocks * m_gputhreads << ")" << std::endl;
-    mg5amcGpu::CPPProcess process( /*verbose=*/false );
-    m_pmek.reset( new mg5amcGpu::MatrixElementKernelDevice( m_devMomentaC, m_devGs, m_devRndHel, m_devRndCol, m_devMEs, m_devSelHel, m_devSelCol, m_gpublocks, m_gputhreads ) );
+    CPPProcess process( /*verbose=*/false );
+    m_pmek.reset( new MatrixElementKernelDevice( m_devMomentaC, m_devGs, m_devRndHel, m_devRndCol, m_devMEs, m_devSelHel, m_devSelCol, m_gpublocks, m_gputhreads ) );
 #else
     std::cout << "WARNING! Instantiate host Bridge (nevt=" << m_nevt << ")" << std::endl;
-    mg5amcCpu::CPPProcess process( /*verbose=*/false );
-    m_pmek.reset( new mg5amcCpu::MatrixElementKernelHost( m_hstMomentaC, m_hstGs, m_hstRndHel, m_hstRndCol, m_hstMEs, m_hstSelHel, m_hstSelCol, m_nevt ) );
+    CPPProcess process( /*verbose=*/false );
+    m_pmek.reset( new MatrixElementKernelHost( m_hstMomentaC, m_hstGs, m_hstRndHel, m_hstRndCol, m_hstMEs, m_hstSelHel, m_hstSelCol, m_nevt ) );
 #endif // __CUDACC__
     process.initProc( "../../Cards/param_card.dat" );
   }

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/BridgeKernels.cc
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/BridgeKernels.cc
@@ -9,9 +9,6 @@
 
 #include <sstream>
 
-constexpr int np4 = CPPProcess::np4;   // dimensions of 4-momenta (E,px,py,pz)
-constexpr int npar = CPPProcess::npar; // #particles in total (external = initial + final): e.g. 4 for e+ e- -> mu+ mu-
-
 //============================================================================
 
 #ifdef __CUDACC__
@@ -20,6 +17,10 @@ namespace mg5amcGpu
 namespace mg5amcCpu
 #endif
 {
+
+  constexpr int np4 = CPPProcess::np4;   // dimensions of 4-momenta (E,px,py,pz)
+  constexpr int npar = CPPProcess::npar; // #particles in total (external = initial + final): e.g. 4 for e+ e- -> mu+ mu-
+
   //--------------------------------------------------------------------------
 
   BridgeKernelBase::BridgeKernelBase( const BufferMomenta& momenta,         // input: momenta

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessAmplitudes.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessAmplitudes.h
@@ -14,142 +14,152 @@
 
 #define MGONGPU_TRIVIAL_AMPLITUDES 1
 
-//----------------------------------------------------------------------------
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
+{
+
+  //----------------------------------------------------------------------------
 
 #ifndef MGONGPU_TRIVIAL_AMPLITUDES
 
-// A class describing the internal layout of memory buffers for amplitudes
-// This implementation uses an AOSOA[npagA][nx2][neppA] where nevt=npagA*neppA
-// [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
-class MemoryAccessAmplitudesBase //_AOSOAv1
-{
-public:
-
-  // Number of Events Per Page in the amplitude AOSOA memory buffer layout
-  static constexpr int neppA = 1; // AOS (just a test...)
-
-private:
-
-  friend class MemoryAccessHelper<MemoryAccessAmplitudesBase>;
-  friend class KernelAccessHelper<MemoryAccessAmplitudesBase, true>;
-  friend class KernelAccessHelper<MemoryAccessAmplitudesBase, false>;
-
-  // The number of floating point components of a complex number
-  static constexpr int nx2 = mgOnGpu::nx2;
-
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
+  // A class describing the internal layout of memory buffers for amplitudes
+  // This implementation uses an AOSOA[npagA][nx2][neppA] where nevt=npagA*neppA
+  // [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
+  class MemoryAccessAmplitudesBase //_AOSOAv1
   {
-    const int ipagA = ievt / neppA; // #event "A-page"
-    const int ieppA = ievt % neppA; // #event in the current event A-page
-    constexpr int ix2 = 0;
-    return &( buffer[ipagA * nx2 * neppA + ix2 * neppA + ieppA] ); // AOSOA[ipagA][ix2][ieppA]
-  }
+  public:
 
-  //--------------------------------------------------------------------------
+    // Number of Events Per Page in the amplitude AOSOA memory buffer layout
+    static constexpr int neppA = 1; // AOS (just a test...)
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to "const int ix2" and rename "Field" as "Ix2"]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer,
-                const int ix2 )
+  private:
+
+    friend class MemoryAccessHelper<MemoryAccessAmplitudesBase>;
+    friend class KernelAccessHelper<MemoryAccessAmplitudesBase, true>;
+    friend class KernelAccessHelper<MemoryAccessAmplitudesBase, false>;
+
+    // The number of floating point components of a complex number
+    static constexpr int nx2 = mgOnGpu::nx2;
+
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      const int ipagA = ievt / neppA; // #event "A-page"
+      const int ieppA = ievt % neppA; // #event in the current event A-page
+      constexpr int ix2 = 0;
+      return &( buffer[ipagA * nx2 * neppA + ix2 * neppA + ieppA] ); // AOSOA[ipagA][ix2][ieppA]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to "const int ix2" and rename "Field" as "Ix2"]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer,
+                  const int ix2 )
+    {
+      constexpr int ipagA = 0;
+      constexpr int ieppA = 0;
+      return buffer[ipagA * nx2 * neppA + ix2 * neppA + ieppA]; // AOSOA[ipagA][ix2][ieppA]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessAmplitudes : public MemoryAccessAmplitudesBase
   {
-    constexpr int ipagA = 0;
-    constexpr int ieppA = 0;
-    return buffer[ipagA * nx2 * neppA + ix2 * neppA + ieppA]; // AOSOA[ipagA][ix2][ieppA]
-  }
-};
+  public:
 
-//----------------------------------------------------------------------------
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessAmplitudesBase>::ieventAccessRecord;
 
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessAmplitudes : public MemoryAccessAmplitudesBase
-{
-public:
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessAmplitudesBase>::ieventAccessRecordConst;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessAmplitudesBase>::ieventAccessRecord;
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ix2 ) <===]
+    static constexpr auto decodeRecordIx2 = MemoryAccessHelper<MemoryAccessAmplitudesBase>::decodeRecord;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessAmplitudesBase>::ieventAccessRecordConst;
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ix2 ) <===]
+    static constexpr auto decodeRecordIx2Const =
+      MemoryAccessHelper<MemoryAccessAmplitudesBase>::template decodeRecordConst<int>;
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ix2 ) <===]
-  static constexpr auto decodeRecordIx2 = MemoryAccessHelper<MemoryAccessAmplitudesBase>::decodeRecord;
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccessIx2( fptype* buffer, const ievt, const int ix2 ) <===]
+    static constexpr auto ieventAccessIx2 =
+      MemoryAccessHelper<MemoryAccessAmplitudesBase>::template ieventAccessField<int>;
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ix2 ) <===]
-  static constexpr auto decodeRecordIx2Const =
-    MemoryAccessHelper<MemoryAccessAmplitudesBase>::template decodeRecordConst<int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccessIx2( fptype* buffer, const ievt, const int ix2 ) <===]
-  static constexpr auto ieventAccessIx2 =
-    MemoryAccessHelper<MemoryAccessAmplitudesBase>::template ieventAccessField<int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessIx2Const( const fptype* buffer, const ievt, const int ix2 ) <===]
-  static constexpr auto ieventAccessIx2Const =
-    MemoryAccessHelper<MemoryAccessAmplitudesBase>::template ieventAccessFieldConst<int>;
-};
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessIx2Const( const fptype* buffer, const ievt, const int ix2 ) <===]
+    static constexpr auto ieventAccessIx2Const =
+      MemoryAccessHelper<MemoryAccessAmplitudesBase>::template ieventAccessFieldConst<int>;
+  };
 
 #endif // #ifndef MGONGPU_TRIVIAL_AMPLITUDES
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessAmplitudes
-{
-public:
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessAmplitudes
+  {
+  public:
 
 #ifndef MGONGPU_TRIVIAL_AMPLITUDES
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
-  static constexpr auto kernelAccessIx2 =
-    KernelAccessHelper<MemoryAccessAmplitudesBase, onDevice>::template kernelAccessField<int>;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
+    static constexpr auto kernelAccessIx2 =
+      KernelAccessHelper<MemoryAccessAmplitudesBase, onDevice>::template kernelAccessField<int>;
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
-  static constexpr auto kernelAccessIx2Const =
-    KernelAccessHelper<MemoryAccessAmplitudesBase, onDevice>::template kernelAccessFieldConst<int>;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
+    static constexpr auto kernelAccessIx2Const =
+      KernelAccessHelper<MemoryAccessAmplitudesBase, onDevice>::template kernelAccessFieldConst<int>;
 
 #else
 
-  static __host__ __device__ inline cxtype_sv*
-  kernelAccess( fptype* buffer )
-  {
-    return reinterpret_cast<cxtype_sv*>( buffer );
-  }
+    static __host__ __device__ inline cxtype_sv*
+    kernelAccess( fptype* buffer )
+    {
+      return reinterpret_cast<cxtype_sv*>( buffer );
+    }
 
-  static __host__ __device__ inline const cxtype_sv*
-  kernelAccessConst( const fptype* buffer )
-  {
-    return reinterpret_cast<const cxtype_sv*>( buffer );
-  }
+    static __host__ __device__ inline const cxtype_sv*
+    kernelAccessConst( const fptype* buffer )
+    {
+      return reinterpret_cast<const cxtype_sv*>( buffer );
+    }
 
 #endif // #ifndef MGONGPU_TRIVIAL_AMPLITUDES
-};
+  };
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-typedef KernelAccessAmplitudes<false> HostAccessAmplitudes;
-typedef KernelAccessAmplitudes<true> DeviceAccessAmplitudes;
+  typedef KernelAccessAmplitudes<false> HostAccessAmplitudes;
+  typedef KernelAccessAmplitudes<true> DeviceAccessAmplitudes;
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessAmplitudes_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessCouplings.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessCouplings.h
@@ -14,248 +14,258 @@
 #include "MemoryAccessMomenta.h" // for MemoryAccessMomentaBase::neppM
 #include "MemoryBuffers.h"       // for HostBufferCouplings::isaligned
 
-//----------------------------------------------------------------------------
-
-// A class describing the internal layout of memory buffers for couplings
-// This implementation uses an AOSOA[npagC][ndcoup][nx2][neppC] "super-buffer" where nevt=npagC*neppC
-// From the "super-buffer" for ndcoup different couplings, use idcoupAccessBuffer to access the buffer for one specific coupling
-// [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
-class MemoryAccessCouplingsBase //_AOSOAv1
-{
-public:
-
-  // Number of Events Per Page in the coupling AOSOA memory buffer layout
-  static constexpr int neppC = MemoryAccessMomentaBase::neppM; // use the same AOSOA striding as for momenta
-
-  // SANITY CHECK: check that neppC is a power of two
-  static_assert( ispoweroftwo( neppC ), "neppC is not a power of 2" );
-
-  //--------------------------------------------------------------------------
-  // ** NB! A single super-buffer AOSOA[npagC][ndcoup][nx2][neppC] includes data for ndcoup different couplings  **
-  // ** NB! The ieventAccessRecord and kernelAccess functions refer to the buffer for one individual coupling    **
-  // ** NB! Use idcoupAccessBuffer to add a fixed offset and locate the buffer for one given individual coupling **
-  //--------------------------------------------------------------------------
-
-  // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
-  // [Signature (non-const) ===> fptype* idcoupAccessBuffer( fptype* buffer, const int idcoup ) <===]
-  // NB: keep this in public even if exposed through KernelAccessCouplings: nvcc says it is inaccesible otherwise?
-  static __host__ __device__ inline fptype*
-  idcoupAccessBuffer( fptype* buffer, // input "super-buffer"
-                      const int idcoup )
-  {
-    constexpr int ipagC = 0;
-    constexpr int ieppC = 0;
-    constexpr int ix2 = 0;
-    // NB! this effectively adds an offset "idcoup * nx2 * neppC"
-    return &( buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC] ); // AOSOA[ipagC][idcoup][ix2][ieppC]
-  }
-
-  // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
-  // [Signature (const) ===> const fptype* idcoupAccessBufferConst( const fptype* buffer, const int idcoup ) <===]
-  // NB: keep this in public even if exposed through KernelAccessCouplings: nvcc says it is inaccesible otherwise?
-  static __host__ __device__ inline const fptype*
-  idcoupAccessBufferConst( const fptype* buffer, // input "super-buffer"
-                           const int idcoup )
-  {
-    return idcoupAccessBuffer( const_cast<fptype*>( buffer ), idcoup );
-  }
-
-private:
-
-  friend class MemoryAccessHelper<MemoryAccessCouplingsBase>;
-  friend class KernelAccessHelper<MemoryAccessCouplingsBase, true>;
-  friend class KernelAccessHelper<MemoryAccessCouplingsBase, false>;
-
-  // The number of couplings that dependent on the running alphas QCD in this specific process
-  static constexpr size_t ndcoup = Parameters_sm_dependentCouplings::ndcoup;
-
-  // The number of floating point components of a complex number
-  static constexpr int nx2 = mgOnGpu::nx2;
-
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
-  {
-    const int ipagC = ievt / neppC; // #event "C-page"
-    const int ieppC = ievt % neppC; // #event in the current event C-page
-    constexpr int idcoup = 0;
-    constexpr int ix2 = 0;
-    return &( buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC] ); // AOSOA[ipagC][idcoup][ix2][ieppC]
-  }
-
-  //--------------------------------------------------------------------------
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to "const int ix2" and rename "Field" as "Ix2"]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer,
-                const int ix2 )
-  {
-    constexpr int ipagC = 0;
-    constexpr int ieppC = 0;
-    // NB! the offset "idcoup * nx2 * neppC" has been added in idcoupAccessBuffer
-    constexpr int idcoup = 0;
-    return buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC]; // AOSOA[ipagC][idcoup][ix2][ieppC]
-  }
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessCouplings : public MemoryAccessCouplingsBase
-{
-public:
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessCouplingsBase>::ieventAccessRecord;
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessCouplingsBase>::ieventAccessRecordConst;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ix2 ) <===]
-  static constexpr auto decodeRecordIx2 = MemoryAccessHelper<MemoryAccessCouplingsBase>::decodeRecord;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ix2 ) <===]
-  static constexpr auto decodeRecordIx2Const =
-    MemoryAccessHelper<MemoryAccessCouplingsBase>::template decodeRecordConst<int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccessIx2( fptype* buffer, const ievt, const int ix2 ) <===]
-  static constexpr auto ieventAccessIx2 =
-    MemoryAccessHelper<MemoryAccessCouplingsBase>::template ieventAccessField<int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessIx2Const( const fptype* buffer, const ievt, const int ix2 ) <===]
-  static constexpr auto ieventAccessIx2Const =
-    MemoryAccessHelper<MemoryAccessCouplingsBase>::template ieventAccessFieldConst<int>;
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessCouplings
-{
-public:
-
-  // Expose selected functions from MemoryAccessCouplingsBase
-  static constexpr auto idcoupAccessBuffer = MemoryAccessCouplingsBase::idcoupAccessBuffer;
-  static constexpr auto idcoupAccessBufferConst = MemoryAccessCouplingsBase::idcoupAccessBufferConst;
-
-  // Expose selected functions from MemoryAccessCouplings
-  static constexpr auto ieventAccessRecordConst = MemoryAccessCouplings::ieventAccessRecordConst;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const, SCALAR) ===> fptype& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
-  static constexpr auto kernelAccessIx2_s =
-    KernelAccessHelper<MemoryAccessCouplingsBase, onDevice>::template kernelAccessField<int>;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR) ===> const fptype& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
-  static constexpr auto kernelAccessIx2Const_s =
-    KernelAccessHelper<MemoryAccessCouplingsBase, onDevice>::template kernelAccessFieldConst<int>;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
-  static __host__ __device__ inline fptype_sv&
-  kernelAccessIx2( fptype* buffer,
-                   const int ix2 )
-  {
-    fptype& out = kernelAccessIx2_s( buffer, ix2 );
-#ifndef MGONGPU_CPPSIMD
-    return out;
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
 #else
-    // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays
-    constexpr int neppC = MemoryAccessCouplingsBase::neppC;
-    static_assert( neppC >= neppV );                              // ASSUME CONTIGUOUS ARRAYS
-    static_assert( neppC % neppV == 0 );                          // ASSUME CONTIGUOUS ARRAYS
-    static_assert( mg5amcCpu::HostBufferCouplings::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+namespace mg5amcCpu
 #endif
-  }
+{
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
-  static __host__ __device__ inline const fptype_sv&
-  kernelAccessIx2Const( const fptype* buffer,
-                        const int ix2 )
-  {
-    return kernelAccessIx2( const_cast<fptype*>( buffer ), ix2 );
-  }
+  //----------------------------------------------------------------------------
 
-  /*
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
-  static __host__ __device__ inline const fptype_sv&
-  kernelAccessIx2Const( const fptype* buffer,
-                        const int ix2 )
+  // A class describing the internal layout of memory buffers for couplings
+  // This implementation uses an AOSOA[npagC][ndcoup][nx2][neppC] "super-buffer" where nevt=npagC*neppC
+  // From the "super-buffer" for ndcoup different couplings, use idcoupAccessBuffer to access the buffer for one specific coupling
+  // [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
+  class MemoryAccessCouplingsBase //_AOSOAv1
   {
-    const fptype& out = kernelAccessIx2Const_s( buffer, ix2 );
+  public:
+
+    // Number of Events Per Page in the coupling AOSOA memory buffer layout
+    static constexpr int neppC = MemoryAccessMomentaBase::neppM; // use the same AOSOA striding as for momenta
+
+    // SANITY CHECK: check that neppC is a power of two
+    static_assert( ispoweroftwo( neppC ), "neppC is not a power of 2" );
+
+    //--------------------------------------------------------------------------
+    // ** NB! A single super-buffer AOSOA[npagC][ndcoup][nx2][neppC] includes data for ndcoup different couplings  **
+    // ** NB! The ieventAccessRecord and kernelAccess functions refer to the buffer for one individual coupling    **
+    // ** NB! Use idcoupAccessBuffer to add a fixed offset and locate the buffer for one given individual coupling **
+    //--------------------------------------------------------------------------
+
+    // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
+    // [Signature (non-const) ===> fptype* idcoupAccessBuffer( fptype* buffer, const int idcoup ) <===]
+    // NB: keep this in public even if exposed through KernelAccessCouplings: nvcc says it is inaccesible otherwise?
+    static __host__ __device__ inline fptype*
+    idcoupAccessBuffer( fptype* buffer, // input "super-buffer"
+                        const int idcoup )
+    {
+      constexpr int ipagC = 0;
+      constexpr int ieppC = 0;
+      constexpr int ix2 = 0;
+      // NB! this effectively adds an offset "idcoup * nx2 * neppC"
+      return &( buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC] ); // AOSOA[ipagC][idcoup][ix2][ieppC]
+    }
+
+    // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
+    // [Signature (const) ===> const fptype* idcoupAccessBufferConst( const fptype* buffer, const int idcoup ) <===]
+    // NB: keep this in public even if exposed through KernelAccessCouplings: nvcc says it is inaccesible otherwise?
+    static __host__ __device__ inline const fptype*
+    idcoupAccessBufferConst( const fptype* buffer, // input "super-buffer"
+                             const int idcoup )
+    {
+      return idcoupAccessBuffer( const_cast<fptype*>( buffer ), idcoup );
+    }
+
+  private:
+
+    friend class MemoryAccessHelper<MemoryAccessCouplingsBase>;
+    friend class KernelAccessHelper<MemoryAccessCouplingsBase, true>;
+    friend class KernelAccessHelper<MemoryAccessCouplingsBase, false>;
+
+    // The number of couplings that dependent on the running alphas QCD in this specific process
+    static constexpr size_t ndcoup = Parameters_sm_dependentCouplings::ndcoup;
+
+    // The number of floating point components of a complex number
+    static constexpr int nx2 = mgOnGpu::nx2;
+
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      const int ipagC = ievt / neppC; // #event "C-page"
+      const int ieppC = ievt % neppC; // #event in the current event C-page
+      constexpr int idcoup = 0;
+      constexpr int ix2 = 0;
+      return &( buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC] ); // AOSOA[ipagC][idcoup][ix2][ieppC]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to "const int ix2" and rename "Field" as "Ix2"]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer,
+                  const int ix2 )
+    {
+      constexpr int ipagC = 0;
+      constexpr int ieppC = 0;
+      // NB! the offset "idcoup * nx2 * neppC" has been added in idcoupAccessBuffer
+      constexpr int idcoup = 0;
+      return buffer[ipagC * ndcoup * nx2 * neppC + idcoup * nx2 * neppC + ix2 * neppC + ieppC]; // AOSOA[ipagC][idcoup][ix2][ieppC]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessCouplings : public MemoryAccessCouplingsBase
+  {
+  public:
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessCouplingsBase>::ieventAccessRecord;
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessCouplingsBase>::ieventAccessRecordConst;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ix2 ) <===]
+    static constexpr auto decodeRecordIx2 = MemoryAccessHelper<MemoryAccessCouplingsBase>::decodeRecord;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ix2 ) <===]
+    static constexpr auto decodeRecordIx2Const =
+      MemoryAccessHelper<MemoryAccessCouplingsBase>::template decodeRecordConst<int>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccessIx2( fptype* buffer, const ievt, const int ix2 ) <===]
+    static constexpr auto ieventAccessIx2 =
+      MemoryAccessHelper<MemoryAccessCouplingsBase>::template ieventAccessField<int>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessIx2Const( const fptype* buffer, const ievt, const int ix2 ) <===]
+    static constexpr auto ieventAccessIx2Const =
+      MemoryAccessHelper<MemoryAccessCouplingsBase>::template ieventAccessFieldConst<int>;
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessCouplings
+  {
+  public:
+
+    // Expose selected functions from MemoryAccessCouplingsBase
+    static constexpr auto idcoupAccessBuffer = MemoryAccessCouplingsBase::idcoupAccessBuffer;
+    static constexpr auto idcoupAccessBufferConst = MemoryAccessCouplingsBase::idcoupAccessBufferConst;
+
+    // Expose selected functions from MemoryAccessCouplings
+    static constexpr auto ieventAccessRecordConst = MemoryAccessCouplings::ieventAccessRecordConst;
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const, SCALAR) ===> fptype& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
+    static constexpr auto kernelAccessIx2_s =
+      KernelAccessHelper<MemoryAccessCouplingsBase, onDevice>::template kernelAccessField<int>;
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR) ===> const fptype& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
+    static constexpr auto kernelAccessIx2Const_s =
+      KernelAccessHelper<MemoryAccessCouplingsBase, onDevice>::template kernelAccessFieldConst<int>;
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccessIx2( fptype* buffer, const int ix2 ) <===]
+    static __host__ __device__ inline fptype_sv&
+    kernelAccessIx2( fptype* buffer,
+                     const int ix2 )
+    {
+      fptype& out = kernelAccessIx2_s( buffer, ix2 );
 #ifndef MGONGPU_CPPSIMD
-    return out;
+      return out;
 #else
-    // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays
-    constexpr int neppC = MemoryAccessCouplingsBase::neppC;
-    static_assert( neppC >= neppV ); // ASSUME CONTIGUOUS ARRAYS
-    static_assert( neppC % neppV == 0 ); // ASSUME CONTIGUOUS ARRAYS
-    static_assert( mg5amcCpu::HostBufferCouplings::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)    
-    //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+      // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays
+      constexpr int neppC = MemoryAccessCouplingsBase::neppC;
+      static_assert( neppC >= neppV );                              // ASSUME CONTIGUOUS ARRAYS
+      static_assert( neppC % neppV == 0 );                          // ASSUME CONTIGUOUS ARRAYS
+      static_assert( mg5amcCpu::HostBufferCouplings::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
 #endif
-  }
-  */
+    }
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non const, SCALAR OR VECTOR) ===> cxtype_sv_ref kernelAccess( fptype* buffer ) <===]
-  static __host__ __device__ inline cxtype_sv_ref
-  kernelAccess( fptype* buffer )
-  {
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
+    static __host__ __device__ inline const fptype_sv&
+    kernelAccessIx2Const( const fptype* buffer,
+                          const int ix2 )
+    {
+      return kernelAccessIx2( const_cast<fptype*>( buffer ), ix2 );
+    }
+
     /*
-    fptype_sv& real = kernelAccessIx2( buffer, 0 );
-    fptype_sv& imag = kernelAccessIx2( buffer, 1 );
-    printf( "C_ACCESS::kernelAccess: pbuffer=%p pr=%p pi=%p\n", buffer, &real, &imag );
-    return cxtype_sv_ref( real, imag );
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccessIx2Const( const fptype* buffer, const int ix2 ) <===]
+    static __host__ __device__ inline const fptype_sv&
+    kernelAccessIx2Const( const fptype* buffer,
+                          const int ix2 )
+    {
+      const fptype& out = kernelAccessIx2Const_s( buffer, ix2 );
+#ifndef MGONGPU_CPPSIMD
+      return out;
+#else
+      // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays
+      constexpr int neppC = MemoryAccessCouplingsBase::neppC;
+      static_assert( neppC >= neppV ); // ASSUME CONTIGUOUS ARRAYS
+      static_assert( neppC % neppV == 0 ); // ASSUME CONTIGUOUS ARRAYS
+      static_assert( mg5amcCpu::HostBufferCouplings::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+#endif
+    }
     */
-    return cxtype_sv_ref( kernelAccessIx2( buffer, 0 ),
-                          kernelAccessIx2( buffer, 1 ) );
-  }
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR OR VECTOR) ===> cxtype_sv kernelAccessConst( const fptype* buffer ) <===]
-  static __host__ __device__ inline cxtype_sv
-  kernelAccessConst( const fptype* buffer )
-  {
-    /*
-    const fptype_sv& real = kernelAccessIx2Const( buffer, 0 );
-    const fptype_sv& imag = kernelAccessIx2Const( buffer, 1 );
-    printf( "C_ACCESS::kernelAccessConst: pbuffer=%p pr=%p pi=%p\n", buffer, &real, &imag );
-    return cxtype_sv( real, imag );
-    */
-    return cxtype_sv( kernelAccessIx2Const( buffer, 0 ),
-                      kernelAccessIx2Const( buffer, 1 ) );
-  }
-};
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non const, SCALAR OR VECTOR) ===> cxtype_sv_ref kernelAccess( fptype* buffer ) <===]
+    static __host__ __device__ inline cxtype_sv_ref
+    kernelAccess( fptype* buffer )
+    {
+      /*
+      fptype_sv& real = kernelAccessIx2( buffer, 0 );
+      fptype_sv& imag = kernelAccessIx2( buffer, 1 );
+      printf( "C_ACCESS::kernelAccess: pbuffer=%p pr=%p pi=%p\n", buffer, &real, &imag );
+      return cxtype_sv_ref( real, imag );
+      */
+      return cxtype_sv_ref( kernelAccessIx2( buffer, 0 ),
+                            kernelAccessIx2( buffer, 1 ) );
+    }
 
-//----------------------------------------------------------------------------
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR OR VECTOR) ===> cxtype_sv kernelAccessConst( const fptype* buffer ) <===]
+    static __host__ __device__ inline cxtype_sv
+    kernelAccessConst( const fptype* buffer )
+    {
+      /*
+      const fptype_sv& real = kernelAccessIx2Const( buffer, 0 );
+      const fptype_sv& imag = kernelAccessIx2Const( buffer, 1 );
+      printf( "C_ACCESS::kernelAccessConst: pbuffer=%p pr=%p pi=%p\n", buffer, &real, &imag );
+      return cxtype_sv( real, imag );
+      */
+      return cxtype_sv( kernelAccessIx2Const( buffer, 0 ),
+                        kernelAccessIx2Const( buffer, 1 ) );
+    }
+  };
 
-typedef KernelAccessCouplings<false> HostAccessCouplings;
-typedef KernelAccessCouplings<true> DeviceAccessCouplings;
+  //----------------------------------------------------------------------------
 
-//----------------------------------------------------------------------------
+  typedef KernelAccessCouplings<false> HostAccessCouplings;
+  typedef KernelAccessCouplings<true> DeviceAccessCouplings;
+
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessCouplings_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessCouplingsFixed.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessCouplingsFixed.h
@@ -13,63 +13,73 @@
 
 //#include "MemoryAccessHelpers.h"
 
-//----------------------------------------------------------------------------
-
-// A class describing the internal layout of memory buffers for fixed couplings
-// This implementation uses a STRUCT[ndcoup][nx2] "super-buffer" layout: in practice, the cIPC global array
-// From the "super-buffer" for ndcoup different couplings, use idcoupAccessBuffer to access the buffer for one specific coupling
-// [If many implementations are used, a suffix _Sv1 should be appended to the class name]
-class MemoryAccessCouplingsFixedBase //_Sv1
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
-public:
 
-  // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
-  // [Signature (const) ===> const fptype* iicoupAccessBufferConst( const fptype* buffer, const int iicoup ) <===]
-  static __host__ __device__ inline const fptype*
-  iicoupAccessBufferConst( const fptype* buffer, // input "super-buffer": in practice, the cIPC global array
-                           const int iicoup )
+  //----------------------------------------------------------------------------
+
+  // A class describing the internal layout of memory buffers for fixed couplings
+  // This implementation uses a STRUCT[ndcoup][nx2] "super-buffer" layout: in practice, the cIPC global array
+  // From the "super-buffer" for ndcoup different couplings, use idcoupAccessBuffer to access the buffer for one specific coupling
+  // [If many implementations are used, a suffix _Sv1 should be appended to the class name]
+  class MemoryAccessCouplingsFixedBase //_Sv1
   {
-    constexpr int ix2 = 0;
-    // NB! this effectively adds an offset "iicoup * nx2"
-    return &( buffer[iicoup * nx2 + ix2] ); // STRUCT[idcoup][ix2]
-  }
+  public:
 
-private:
+    // Locate the buffer for a single coupling (output) in a memory super-buffer (input) from the given coupling index (input)
+    // [Signature (const) ===> const fptype* iicoupAccessBufferConst( const fptype* buffer, const int iicoup ) <===]
+    static __host__ __device__ inline const fptype*
+    iicoupAccessBufferConst( const fptype* buffer, // input "super-buffer": in practice, the cIPC global array
+                             const int iicoup )
+    {
+      constexpr int ix2 = 0;
+      // NB! this effectively adds an offset "iicoup * nx2"
+      return &( buffer[iicoup * nx2 + ix2] ); // STRUCT[idcoup][ix2]
+    }
 
-  // The number of floating point components of a complex number
-  static constexpr int nx2 = mgOnGpu::nx2;
-};
+  private:
 
-//----------------------------------------------------------------------------
+    // The number of floating point components of a complex number
+    static constexpr int nx2 = mgOnGpu::nx2;
+  };
 
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessCouplingsFixed
-{
-public:
+  //----------------------------------------------------------------------------
 
-  // Expose selected functions from MemoryAccessCouplingsFixedBase
-  static constexpr auto iicoupAccessBufferConst = MemoryAccessCouplingsFixedBase::iicoupAccessBufferConst;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR OR VECTOR) ===> cxtype_sv kernelAccessConst( const fptype* buffer ) <===]
-  static __host__ __device__ inline const cxtype_sv
-  kernelAccessConst( const fptype* buffer )
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessCouplingsFixed
   {
-    // TRIVIAL ACCESS to fixed-couplings buffers!
-    //return cxmake( fptype_sv{ buffer[0] }, fptype_sv{ buffer[1] } ); // NO! BUG #339!
-    const fptype_sv r_sv = fptype_sv{ 0 } + buffer[0];
-    const fptype_sv i_sv = fptype_sv{ 0 } + buffer[1];
-    return cxmake( r_sv, i_sv ); // ugly but effective
-  }
-};
+  public:
 
-//----------------------------------------------------------------------------
+    // Expose selected functions from MemoryAccessCouplingsFixedBase
+    static constexpr auto iicoupAccessBufferConst = MemoryAccessCouplingsFixedBase::iicoupAccessBufferConst;
 
-typedef KernelAccessCouplingsFixed<false> HostAccessCouplingsFixed;
-typedef KernelAccessCouplingsFixed<true> DeviceAccessCouplingsFixed;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR OR VECTOR) ===> cxtype_sv kernelAccessConst( const fptype* buffer ) <===]
+    static __host__ __device__ inline const cxtype_sv
+    kernelAccessConst( const fptype* buffer )
+    {
+      // TRIVIAL ACCESS to fixed-couplings buffers!
+      //return cxmake( fptype_sv{ buffer[0] }, fptype_sv{ buffer[1] } ); // NO! BUG #339!
+      const fptype_sv r_sv = fptype_sv{ 0 } + buffer[0];
+      const fptype_sv i_sv = fptype_sv{ 0 } + buffer[1];
+      return cxmake( r_sv, i_sv ); // ugly but effective
+    }
+  };
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
+
+  typedef KernelAccessCouplingsFixed<false> HostAccessCouplingsFixed;
+  typedef KernelAccessCouplingsFixed<true> DeviceAccessCouplingsFixed;
+
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessCouplingsFixed_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessGs.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessGs.h
@@ -12,142 +12,152 @@
 #include "MemoryAccessVectors.h"
 #include "MemoryBuffers.h" // for HostBufferMatrixElements::isaligned
 
-//----------------------------------------------------------------------------
-
-// A class describing the internal layout of memory buffers for Gs
-// This implementation uses a plain ARRAY[nevt]
-// [If many implementations are used, a suffix _ARRAYv1 should be appended to the class name]
-class MemoryAccessGsBase //_ARRAYv1
-{
-private:
-
-  friend class MemoryAccessHelper<MemoryAccessGsBase>;
-  friend class KernelAccessHelper<MemoryAccessGsBase, true>;
-  friend class KernelAccessHelper<MemoryAccessGsBase, false>;
-
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
-  {
-    return &( buffer[ievt] ); // ARRAY[nevt]
-  }
-
-  //--------------------------------------------------------------------------
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to empty and rename "Field" as empty]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer )
-  {
-    constexpr int ievt = 0;
-    return buffer[ievt]; // ARRAY[nevt]
-  }
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessGs : public MemoryAccessGsBase
-{
-public:
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessGsBase>::ieventAccessRecord;
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessGsBase>::ieventAccessRecordConst;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer ) <===]
-  static constexpr auto decodeRecord = MemoryAccessHelper<MemoryAccessGsBase>::decodeRecord;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer ) <===]
-  static constexpr auto decodeRecordConst =
-    MemoryAccessHelper<MemoryAccessGsBase>::template decodeRecordConst<>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccess( fptype* buffer, const ievt ) <===]
-  static constexpr auto ieventAccess =
-    MemoryAccessHelper<MemoryAccessGsBase>::template ieventAccessField<>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessConst( const fptype* buffer, const ievt ) <===]
-  static constexpr auto ieventAccessConst =
-    MemoryAccessHelper<MemoryAccessGsBase>::template ieventAccessFieldConst<>;
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessGs
-{
-public:
-
-  // Expose selected functions from MemoryAccessGs
-  static constexpr auto ieventAccessRecord = MemoryAccessGs::ieventAccessRecord;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const, SCALAR) ===> fptype& kernelAccess( fptype* buffer ) <===]
-  static constexpr auto kernelAccess_s =
-    KernelAccessHelper<MemoryAccessGsBase, onDevice>::template kernelAccessField<>; // requires cuda 11.4
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
-  // [Signature (non-const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccess( fptype* buffer ) <===]
-  static __host__ __device__ inline fptype_sv&
-  kernelAccess( fptype* buffer )
-  {
-    fptype& out = kernelAccess_s( buffer );
-#ifndef MGONGPU_CPPSIMD
-    return out;
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
 #else
-    // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
-    static_assert( mg5amcCpu::HostBufferGs::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+namespace mg5amcCpu
 #endif
-  }
+{
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR) ===> const fptype& kernelAccessConst( const fptype* buffer ) <===]
-  static constexpr auto kernelAccessConst_s =
-    KernelAccessHelper<MemoryAccessGsBase, onDevice>::template kernelAccessFieldConst<>; // requires cuda 11.4
+  //----------------------------------------------------------------------------
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
-  // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccess( const fptype* buffer ) <===]
-  static __host__ __device__ inline const fptype_sv&
-  kernelAccessConst( const fptype* buffer )
+  // A class describing the internal layout of memory buffers for Gs
+  // This implementation uses a plain ARRAY[nevt]
+  // [If many implementations are used, a suffix _ARRAYv1 should be appended to the class name]
+  class MemoryAccessGsBase //_ARRAYv1
   {
-    const fptype& out = kernelAccessConst_s( buffer );
+  private:
+
+    friend class MemoryAccessHelper<MemoryAccessGsBase>;
+    friend class KernelAccessHelper<MemoryAccessGsBase, true>;
+    friend class KernelAccessHelper<MemoryAccessGsBase, false>;
+
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      return &( buffer[ievt] ); // ARRAY[nevt]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to empty and rename "Field" as empty]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer )
+    {
+      constexpr int ievt = 0;
+      return buffer[ievt]; // ARRAY[nevt]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessGs : public MemoryAccessGsBase
+  {
+  public:
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessGsBase>::ieventAccessRecord;
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessGsBase>::ieventAccessRecordConst;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer ) <===]
+    static constexpr auto decodeRecord = MemoryAccessHelper<MemoryAccessGsBase>::decodeRecord;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer ) <===]
+    static constexpr auto decodeRecordConst =
+      MemoryAccessHelper<MemoryAccessGsBase>::template decodeRecordConst<>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccess( fptype* buffer, const ievt ) <===]
+    static constexpr auto ieventAccess =
+      MemoryAccessHelper<MemoryAccessGsBase>::template ieventAccessField<>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessConst( const fptype* buffer, const ievt ) <===]
+    static constexpr auto ieventAccessConst =
+      MemoryAccessHelper<MemoryAccessGsBase>::template ieventAccessFieldConst<>;
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessGs
+  {
+  public:
+
+    // Expose selected functions from MemoryAccessGs
+    static constexpr auto ieventAccessRecord = MemoryAccessGs::ieventAccessRecord;
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const, SCALAR) ===> fptype& kernelAccess( fptype* buffer ) <===]
+    static constexpr auto kernelAccess_s =
+      KernelAccessHelper<MemoryAccessGsBase, onDevice>::template kernelAccessField<>; // requires cuda 11.4
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
+    // [Signature (non-const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccess( fptype* buffer ) <===]
+    static __host__ __device__ inline fptype_sv&
+    kernelAccess( fptype* buffer )
+    {
+      fptype& out = kernelAccess_s( buffer );
 #ifndef MGONGPU_CPPSIMD
-    return out;
+      return out;
 #else
-    // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
-    static_assert( mg5amcCpu::HostBufferGs::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+      // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
+      static_assert( mg5amcCpu::HostBufferGs::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
 #endif
-  }
-};
+    }
 
-//----------------------------------------------------------------------------
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR) ===> const fptype& kernelAccessConst( const fptype* buffer ) <===]
+    static constexpr auto kernelAccessConst_s =
+      KernelAccessHelper<MemoryAccessGsBase, onDevice>::template kernelAccessFieldConst<>; // requires cuda 11.4
 
-typedef KernelAccessGs<false> HostAccessGs;
-typedef KernelAccessGs<true> DeviceAccessGs;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
+    // [Signature (const, SCALAR OR VECTOR) ===> const fptype_sv& kernelAccess( const fptype* buffer ) <===]
+    static __host__ __device__ inline const fptype_sv&
+    kernelAccessConst( const fptype* buffer )
+    {
+      const fptype& out = kernelAccessConst_s( buffer );
+#ifndef MGONGPU_CPPSIMD
+      return out;
+#else
+      // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
+      static_assert( mg5amcCpu::HostBufferGs::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+#endif
+    }
+  };
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
+
+  typedef KernelAccessGs<false> HostAccessGs;
+  typedef KernelAccessGs<true> DeviceAccessGs;
+
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessGs_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessMatrixElements.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessMatrixElements.h
@@ -12,126 +12,136 @@
 #include "MemoryAccessVectors.h"
 #include "MemoryBuffers.h" // for HostBufferMatrixElements::isaligned
 
-//----------------------------------------------------------------------------
-
-// A class describing the internal layout of memory buffers for matrix elements
-// This implementation uses a plain ARRAY[nevt]
-// [If many implementations are used, a suffix _ARRAYv1 should be appended to the class name]
-class MemoryAccessMatrixElementsBase //_ARRAYv1
-{
-private:
-
-  friend class MemoryAccessHelper<MemoryAccessMatrixElementsBase>;
-  friend class KernelAccessHelper<MemoryAccessMatrixElementsBase, true>;
-  friend class KernelAccessHelper<MemoryAccessMatrixElementsBase, false>;
-
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
-  {
-    return &( buffer[ievt] ); // ARRAY[nevt]
-  }
-
-  //--------------------------------------------------------------------------
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to empty and rename "Field" as empty]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer )
-  {
-    constexpr int ievt = 0;
-    return buffer[ievt]; // ARRAY[nevt]
-  }
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessMatrixElements : public MemoryAccessMatrixElementsBase
-{
-public:
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::ieventAccessRecord;
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::ieventAccessRecordConst;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer ) <===]
-  static constexpr auto decodeRecord = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::decodeRecord;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer ) <===]
-  static constexpr auto decodeRecordConst =
-    MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template decodeRecordConst<>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccess( fptype* buffer, const ievt ) <===]
-  static constexpr auto ieventAccess =
-    MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template ieventAccessField<>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessConst( const fptype* buffer, const ievt ) <===]
-  static constexpr auto ieventAccessConst =
-    MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template ieventAccessFieldConst<>;
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessMatrixElements
-{
-public:
-
-  // Expose selected functions from MemoryAccessMatrixElements
-  static constexpr auto ieventAccessRecord = MemoryAccessMatrixElements::ieventAccessRecord;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const, SCALAR) ===> fptype& kernelAccess_s( fptype* buffer ) <===]
-  static constexpr auto kernelAccess_s =
-    KernelAccessHelper<MemoryAccessMatrixElementsBase, onDevice>::template kernelAccessField<>; // requires cuda 11.4
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
-  // [Signature (non const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccess( const fptype* buffer ) <===]
-  static __host__ __device__ inline fptype_sv&
-  kernelAccess( fptype* buffer )
-  {
-    fptype& out = kernelAccess_s( buffer );
-#ifndef MGONGPU_CPPSIMD
-    return out;
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
 #else
-    // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
-    static_assert( mg5amcCpu::HostBufferMatrixElements::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
-    return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+namespace mg5amcCpu
 #endif
-  }
+{
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& kernelAccessConst( const fptype* buffer ) <===]
-  static constexpr auto kernelAccessConst =
-    KernelAccessHelper<MemoryAccessMatrixElementsBase, onDevice>::template kernelAccessFieldConst<>; // requires cuda 11.4
-};
+  //----------------------------------------------------------------------------
 
-//----------------------------------------------------------------------------
+  // A class describing the internal layout of memory buffers for matrix elements
+  // This implementation uses a plain ARRAY[nevt]
+  // [If many implementations are used, a suffix _ARRAYv1 should be appended to the class name]
+  class MemoryAccessMatrixElementsBase //_ARRAYv1
+  {
+  private:
 
-typedef KernelAccessMatrixElements<false> HostAccessMatrixElements;
-typedef KernelAccessMatrixElements<true> DeviceAccessMatrixElements;
+    friend class MemoryAccessHelper<MemoryAccessMatrixElementsBase>;
+    friend class KernelAccessHelper<MemoryAccessMatrixElementsBase, true>;
+    friend class KernelAccessHelper<MemoryAccessMatrixElementsBase, false>;
 
-//----------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      return &( buffer[ievt] ); // ARRAY[nevt]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to empty and rename "Field" as empty]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer )
+    {
+      constexpr int ievt = 0;
+      return buffer[ievt]; // ARRAY[nevt]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessMatrixElements : public MemoryAccessMatrixElementsBase
+  {
+  public:
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::ieventAccessRecord;
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::ieventAccessRecordConst;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer ) <===]
+    static constexpr auto decodeRecord = MemoryAccessHelper<MemoryAccessMatrixElementsBase>::decodeRecord;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer ) <===]
+    static constexpr auto decodeRecordConst =
+      MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template decodeRecordConst<>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccess( fptype* buffer, const ievt ) <===]
+    static constexpr auto ieventAccess =
+      MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template ieventAccessField<>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessConst( const fptype* buffer, const ievt ) <===]
+    static constexpr auto ieventAccessConst =
+      MemoryAccessHelper<MemoryAccessMatrixElementsBase>::template ieventAccessFieldConst<>;
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessMatrixElements
+  {
+  public:
+
+    // Expose selected functions from MemoryAccessMatrixElements
+    static constexpr auto ieventAccessRecord = MemoryAccessMatrixElements::ieventAccessRecord;
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const, SCALAR) ===> fptype& kernelAccess_s( fptype* buffer ) <===]
+    static constexpr auto kernelAccess_s =
+      KernelAccessHelper<MemoryAccessMatrixElementsBase, onDevice>::template kernelAccessField<>; // requires cuda 11.4
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal)
+    // [Signature (non const, SCALAR OR VECTOR) ===> fptype_sv& kernelAccess( const fptype* buffer ) <===]
+    static __host__ __device__ inline fptype_sv&
+    kernelAccess( fptype* buffer )
+    {
+      fptype& out = kernelAccess_s( buffer );
+#ifndef MGONGPU_CPPSIMD
+      return out;
+#else
+      // NB: derived from MemoryAccessMomenta, restricting the implementation to contiguous aligned arrays (#435)
+      static_assert( mg5amcCpu::HostBufferMatrixElements::isaligned() ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      //assert( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 ); // ASSUME ALIGNED ARRAYS (reinterpret_cast will segfault otherwise!)
+      return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+#endif
+    }
+
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& kernelAccessConst( const fptype* buffer ) <===]
+    static constexpr auto kernelAccessConst =
+      KernelAccessHelper<MemoryAccessMatrixElementsBase, onDevice>::template kernelAccessFieldConst<>; // requires cuda 11.4
+  };
+
+  //----------------------------------------------------------------------------
+
+  typedef KernelAccessMatrixElements<false> HostAccessMatrixElements;
+  typedef KernelAccessMatrixElements<true> DeviceAccessMatrixElements;
+
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessMatrixElements_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessMomenta.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessMomenta.h
@@ -12,261 +12,265 @@
 #include "MemoryAccessHelpers.h"
 #include "MemoryAccessVectors.h"
 
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
 #ifdef __CUDACC__
-using mg5amcGpu::CPPProcess;
+namespace mg5amcGpu
 #else
-using mg5amcCpu::CPPProcess;
+namespace mg5amcCpu
 #endif
-
-//----------------------------------------------------------------------------
-
-// A class describing the internal layout of memory buffers for momenta
-// This implementation uses an AOSOA[npagM][npar][np4][neppM] where nevt=npagM*neppM
-// [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
-class MemoryAccessMomentaBase //_AOSOAv1
 {
-public:
 
-  // Number of Events Per Page in the momenta AOSOA memory buffer layout
-  // (these are all best kept as a compile-time constants: see issue #23)
+  //----------------------------------------------------------------------------
+
+  // A class describing the internal layout of memory buffers for momenta
+  // This implementation uses an AOSOA[npagM][npar][np4][neppM] where nevt=npagM*neppM
+  // [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
+  class MemoryAccessMomentaBase //_AOSOAv1
+  {
+  public:
+
+    // Number of Events Per Page in the momenta AOSOA memory buffer layout
+    // (these are all best kept as a compile-time constants: see issue #23)
 #ifdef __CUDACC__ /* clang-format off */
-  // -----------------------------------------------------------------------------------------------
-  // --- GPUs: neppM is best set to a power of 2 times the number of fptype's in a 32-byte cacheline
-  // --- This is relevant to ensure coalesced access to momenta in global memory
-  // --- Note that neppR is hardcoded and may differ from neppM and neppV on some platforms
-  // -----------------------------------------------------------------------------------------------
-  //static constexpr int neppM = 64/sizeof(fptype); // 2x 32-byte GPU cache lines (512 bits): 8 (DOUBLE) or 16 (FLOAT)
-  static constexpr int neppM = 32/sizeof(fptype); // (DEFAULT) 32-byte GPU cache line (256 bits): 4 (DOUBLE) or 8 (FLOAT)
-  //static constexpr int neppM = 1; // *** NB: this is equivalent to AOS *** (slower: 1.03E9 instead of 1.11E9 in eemumu)
+    // -----------------------------------------------------------------------------------------------
+    // --- GPUs: neppM is best set to a power of 2 times the number of fptype's in a 32-byte cacheline
+    // --- This is relevant to ensure coalesced access to momenta in global memory
+    // --- Note that neppR is hardcoded and may differ from neppM and neppV on some platforms
+    // -----------------------------------------------------------------------------------------------
+    //static constexpr int neppM = 64/sizeof(fptype); // 2x 32-byte GPU cache lines (512 bits): 8 (DOUBLE) or 16 (FLOAT)
+    static constexpr int neppM = 32/sizeof(fptype); // (DEFAULT) 32-byte GPU cache line (256 bits): 4 (DOUBLE) or 8 (FLOAT)
+    //static constexpr int neppM = 1; // *** NB: this is equivalent to AOS *** (slower: 1.03E9 instead of 1.11E9 in eemumu)
 #else
-  // -----------------------------------------------------------------------------------------------
-  // --- CPUs: neppM is best set equal to the number of fptype's (neppV) in a vector register
-  // --- This is relevant to ensure faster access to momenta from C++ memory cache lines
-  // --- However, neppM is now decoupled from neppV (issue #176) and can be separately hardcoded
-  // --- In practice, neppR, neppM and neppV could now (in principle) all be different
-  // -----------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------
+    // --- CPUs: neppM is best set equal to the number of fptype's (neppV) in a vector register
+    // --- This is relevant to ensure faster access to momenta from C++ memory cache lines
+    // --- However, neppM is now decoupled from neppV (issue #176) and can be separately hardcoded
+    // --- In practice, neppR, neppM and neppV could now (in principle) all be different
+    // -----------------------------------------------------------------------------------------------
 #ifdef MGONGPU_CPPSIMD
-  static constexpr int neppM = MGONGPU_CPPSIMD; // (DEFAULT) neppM=neppV for optimal performance
-  //static constexpr int neppM = 64/sizeof(fptype); // maximum CPU vector width (512 bits): 8 (DOUBLE) or 16 (FLOAT)
-  //static constexpr int neppM = 32/sizeof(fptype); // lower CPU vector width (256 bits): 4 (DOUBLE) or 8 (FLOAT)
-  //static constexpr int neppM = 1; // *** NB: this is equivalent to AOS *** (slower: 4.66E6 instead of 5.09E9 in eemumu)
-  //static constexpr int neppM = MGONGPU_CPPSIMD*2; // FOR TESTS
+    static constexpr int neppM = MGONGPU_CPPSIMD; // (DEFAULT) neppM=neppV for optimal performance
+    //static constexpr int neppM = 64/sizeof(fptype); // maximum CPU vector width (512 bits): 8 (DOUBLE) or 16 (FLOAT)
+    //static constexpr int neppM = 32/sizeof(fptype); // lower CPU vector width (256 bits): 4 (DOUBLE) or 8 (FLOAT)
+    //static constexpr int neppM = 1; // *** NB: this is equivalent to AOS *** (slower: 4.66E6 instead of 5.09E9 in eemumu)
+    //static constexpr int neppM = MGONGPU_CPPSIMD*2; // FOR TESTS
 #else
-  static constexpr int neppM = 1; // (DEFAULT) neppM=neppV for optimal performance (NB: this is equivalent to AOS)
+    static constexpr int neppM = 1; // (DEFAULT) neppM=neppV for optimal performance (NB: this is equivalent to AOS)
 #endif
 #endif /* clang-format on */
 
-  // SANITY CHECK: check that neppM is a power of two
-  static_assert( ispoweroftwo( neppM ), "neppM is not a power of 2" );
+    // SANITY CHECK: check that neppM is a power of two
+    static_assert( ispoweroftwo( neppM ), "neppM is not a power of 2" );
 
-private:
+  private:
 
-  friend class MemoryAccessHelper<MemoryAccessMomentaBase>;
-  friend class KernelAccessHelper<MemoryAccessMomentaBase, true>;
-  friend class KernelAccessHelper<MemoryAccessMomentaBase, false>;
+    friend class MemoryAccessHelper<MemoryAccessMomentaBase>;
+    friend class KernelAccessHelper<MemoryAccessMomentaBase, true>;
+    friend class KernelAccessHelper<MemoryAccessMomentaBase, false>;
 
-  // The number of components of a 4-momentum
-  static constexpr int np4 = CPPProcess::np4;
+    // The number of components of a 4-momentum
+    static constexpr int np4 = CPPProcess::np4;
 
-  // The number of particles in this physics process
-  static constexpr int npar = CPPProcess::npar;
+    // The number of particles in this physics process
+    static constexpr int npar = CPPProcess::npar;
 
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      const int ipagM = ievt / neppM; // #event "M-page"
+      const int ieppM = ievt % neppM; // #event in the current event M-page
+      constexpr int ip4 = 0;
+      constexpr int ipar = 0;
+      return &( buffer[ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM] ); // AOSOA[ipagM][ipar][ip4][ieppM]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to "const int ip4, const int ipar" and rename "Field" as "Ip4Ipar"]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer,
+                  const int ip4,
+                  const int ipar )
+    {
+      constexpr int ipagM = 0;
+      constexpr int ieppM = 0;
+      return buffer[ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM]; // AOSOA[ipagM][ipar][ip4][ieppM]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessMomenta : public MemoryAccessMomentaBase
   {
-    const int ipagM = ievt / neppM; // #event "M-page"
-    const int ieppM = ievt % neppM; // #event in the current event M-page
-    constexpr int ip4 = 0;
-    constexpr int ipar = 0;
-    return &( buffer[ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM] ); // AOSOA[ipagM][ipar][ip4][ieppM]
-  }
+  public:
 
-  //--------------------------------------------------------------------------
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessMomentaBase>::ieventAccessRecord;
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to "const int ip4, const int ipar" and rename "Field" as "Ip4Ipar"]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer,
-                const int ip4,
-                const int ipar )
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessMomentaBase>::ieventAccessRecordConst;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ipar, const int ipar ) <===]
+    static constexpr auto decodeRecordIp4Ipar = MemoryAccessHelper<MemoryAccessMomentaBase>::decodeRecord;
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ipar, const int ipar ) <===]
+    static constexpr auto decodeRecordIp4IparConst =
+      MemoryAccessHelper<MemoryAccessMomentaBase>::template decodeRecordConst<int, int>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccessIp4Ipar( fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
+    static constexpr auto ieventAccessIp4Ipar =
+      MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessField<int, int>;
+
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessIp4IparConst( const fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
+    // DEFAULT VERSION
+    static constexpr auto ieventAccessIp4IparConst =
+      MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessFieldConst<int, int>;
+
+    /*
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessIp4IparConst( const fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
+    // DEBUG VERSION WITH PRINTOUTS
+    static __host__ __device__ inline const fptype&
+    ieventAccessIp4IparConst( const fptype* buffer,
+                                            const int ievt,
+                                            const int ip4,
+                                            const int ipar )
+    {
+      const fptype& out = MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessFieldConst<int, int>( buffer, ievt, ip4, ipar );
+      printf( "ipar=%2d ip4=%2d ievt=%8d out=%8.3f\n", ipar, ip4, ievt, out );
+      return out;
+    }
+    */
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessMomenta
   {
-    constexpr int ipagM = 0;
-    constexpr int ieppM = 0;
-    return buffer[ipagM * npar * np4 * neppM + ipar * np4 * neppM + ip4 * neppM + ieppM]; // AOSOA[ipagM][ipar][ip4][ieppM]
-  }
-};
+  public:
 
-//----------------------------------------------------------------------------
+    // Expose selected functions from MemoryAccessMomenta
+    static constexpr auto ieventAccessRecordConst = MemoryAccessMomenta::ieventAccessRecordConst;
 
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessMomenta : public MemoryAccessMomentaBase
-{
-public:
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const, SCALAR) ===> fptype& kernelAccessIp4Ipar( fptype* buffer, const int ipar, const int ipar ) <===]
+    static constexpr auto kernelAccessIp4Ipar =
+      KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessField<int, int>;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessMomentaBase>::ieventAccessRecord;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR) ===> const fptype& kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
+    // DEFAULT VERSION
+    static constexpr auto kernelAccessIp4IparConst_s =
+      KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessFieldConst<int, int>;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessMomentaBase>::ieventAccessRecordConst;
+    /*
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR) ===> const fptype& kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
+    // DEBUG VERSION WITH PRINTOUTS
+    static __host__ __device__ inline const fptype&
+    kernelAccessIp4IparConst_s( const fptype* buffer,
+                                const int ip4,
+                                const int ipar )
+    {
+      const fptype& out = KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessFieldConst<int, int>( buffer, ip4, ipar );
+      printf( "ipar=%2d ip4=%2d ievt='kernel' out=%8.3f\n", ipar, ip4, out );
+      return out;
+    }
+    */
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int ipar, const int ipar ) <===]
-  static constexpr auto decodeRecordIp4Ipar = MemoryAccessHelper<MemoryAccessMomentaBase>::decodeRecord;
-
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int ipar, const int ipar ) <===]
-  static constexpr auto decodeRecordIp4IparConst =
-    MemoryAccessHelper<MemoryAccessMomentaBase>::template decodeRecordConst<int, int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccessIp4Ipar( fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
-  static constexpr auto ieventAccessIp4Ipar =
-    MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessField<int, int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessIp4IparConst( const fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
-  // DEFAULT VERSION
-  static constexpr auto ieventAccessIp4IparConst =
-    MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessFieldConst<int, int>;
-
-  /*
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessIp4IparConst( const fptype* buffer, const ievt, const int ipar, const int ipar ) <===]
-  // DEBUG VERSION WITH PRINTOUTS
-  static __host__ __device__ inline const fptype& 
-  ieventAccessIp4IparConst( const fptype* buffer,
-                                          const int ievt,
-                                          const int ip4,
-                                          const int ipar )
-  {
-    const fptype& out = MemoryAccessHelper<MemoryAccessMomentaBase>::template ieventAccessFieldConst<int, int>( buffer, ievt, ip4, ipar );
-    printf( "ipar=%2d ip4=%2d ievt=%8d out=%8.3f\n", ipar, ip4, ievt, out );
-    return out;
-  }
-  */
-};
-
-//----------------------------------------------------------------------------
-
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessMomenta
-{
-public:
-
-  // Expose selected functions from MemoryAccessMomenta
-  static constexpr auto ieventAccessRecordConst = MemoryAccessMomenta::ieventAccessRecordConst;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const, SCALAR) ===> fptype& kernelAccessIp4Ipar( fptype* buffer, const int ipar, const int ipar ) <===]
-  static constexpr auto kernelAccessIp4Ipar =
-    KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessField<int, int>;
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR) ===> const fptype& kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
-  // DEFAULT VERSION
-  static constexpr auto kernelAccessIp4IparConst_s =
-    KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessFieldConst<int, int>;
-
-  /*
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR) ===> const fptype& kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
-  // DEBUG VERSION WITH PRINTOUTS
-  static __host__ __device__ inline const fptype&
-  kernelAccessIp4IparConst_s( const fptype* buffer,
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const, SCALAR OR VECTOR) ===> fptype_sv kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
+    // FIXME? Eventually return by const reference and support aligned arrays only?
+    // FIXME? Currently return by value to support also unaligned and arbitrary arrays
+    static __host__ __device__ inline fptype_sv
+    kernelAccessIp4IparConst( const fptype* buffer,
                               const int ip4,
                               const int ipar )
-  {
-    const fptype& out = KernelAccessHelper<MemoryAccessMomentaBase, onDevice>::template kernelAccessFieldConst<int, int>( buffer, ip4, ipar );
-    printf( "ipar=%2d ip4=%2d ievt='kernel' out=%8.3f\n", ipar, ip4, out );
-    return out;
-  }
-  */
-
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const, SCALAR OR VECTOR) ===> fptype_sv kernelAccessIp4IparConst( const fptype* buffer, const int ipar, const int ipar ) <===]
-  // FIXME? Eventually return by const reference and support aligned arrays only?
-  // FIXME? Currently return by value to support also unaligned and arbitrary arrays
-  static __host__ __device__ inline fptype_sv
-  kernelAccessIp4IparConst( const fptype* buffer,
-                            const int ip4,
-                            const int ipar )
-  {
-    const fptype& out = kernelAccessIp4IparConst_s( buffer, ip4, ipar );
-#ifndef MGONGPU_CPPSIMD
-    return out;
-#else
-    constexpr int neppM = MemoryAccessMomentaBase::neppM;
-    constexpr bool useContiguousEventsIfPossible = true; // DEFAULT
-    //constexpr bool useContiguousEventsIfPossible = false; // FOR PERFORMANCE TESTS (treat as arbitrary array even if it is an AOSOA)
-    // Use c++17 "if constexpr": compile-time branching
-    if constexpr( useContiguousEventsIfPossible && ( neppM >= neppV ) && ( neppM % neppV == 0 ) )
     {
-      //constexpr bool skipAlignmentCheck = true; // FASTEST (SEGFAULTS IF MISALIGNED ACCESS, NEEDS A SANITY CHECK ELSEWHERE!)
-      constexpr bool skipAlignmentCheck = false; // DEFAULT: A BIT SLOWER BUT SAFER [ALLOWS MISALIGNED ACCESS]
-      if constexpr( skipAlignmentCheck )
+      const fptype& out = kernelAccessIp4IparConst_s( buffer, ip4, ipar );
+#ifndef MGONGPU_CPPSIMD
+      return out;
+#else
+      constexpr int neppM = MemoryAccessMomentaBase::neppM;
+      constexpr bool useContiguousEventsIfPossible = true; // DEFAULT
+      //constexpr bool useContiguousEventsIfPossible = false; // FOR PERFORMANCE TESTS (treat as arbitrary array even if it is an AOSOA)
+      // Use c++17 "if constexpr": compile-time branching
+      if constexpr( useContiguousEventsIfPossible && ( neppM >= neppV ) && ( neppM % neppV == 0 ) )
       {
-        //static bool first=true; if( first ){ std::cout << "WARNING! assume aligned AOSOA, skip check" << std::endl; first=false; } // SLOWER (5.06E6)
-        // FASTEST? (5.09E6 in eemumu 512y)
-        // This assumes alignment for momenta1d without checking - causes segmentation fault in reinterpret_cast if not aligned!
-        return mg5amcCpu::fptypevFromAlignedArray( out ); // use reinterpret_cast
-      }
-      else if( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 )
-      {
-        //static bool first=true; if( first ){ std::cout << "WARNING! aligned AOSOA, reinterpret cast" << std::endl; first=false; } // SLOWER (5.00E6)
-        // DEFAULT! A tiny bit (<1%) slower because of the alignment check (5.07E6 in eemumu 512y)
-        // This explicitly checks buffer alignment to avoid segmentation faults in reinterpret_cast
-        return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+        //constexpr bool skipAlignmentCheck = true; // FASTEST (SEGFAULTS IF MISALIGNED ACCESS, NEEDS A SANITY CHECK ELSEWHERE!)
+        constexpr bool skipAlignmentCheck = false; // DEFAULT: A BIT SLOWER BUT SAFER [ALLOWS MISALIGNED ACCESS]
+        if constexpr( skipAlignmentCheck )
+        {
+          //static bool first=true; if( first ){ std::cout << "WARNING! assume aligned AOSOA, skip check" << std::endl; first=false; } // SLOWER (5.06E6)
+          // FASTEST? (5.09E6 in eemumu 512y)
+          // This assumes alignment for momenta1d without checking - causes segmentation fault in reinterpret_cast if not aligned!
+          return mg5amcCpu::fptypevFromAlignedArray( out ); // use reinterpret_cast
+        }
+        else if( (size_t)( buffer ) % mgOnGpu::cppAlign == 0 )
+        {
+          //static bool first=true; if( first ){ std::cout << "WARNING! aligned AOSOA, reinterpret cast" << std::endl; first=false; } // SLOWER (5.00E6)
+          // DEFAULT! A tiny bit (<1%) slower because of the alignment check (5.07E6 in eemumu 512y)
+          // This explicitly checks buffer alignment to avoid segmentation faults in reinterpret_cast
+          return mg5amcCpu::fptypevFromAlignedArray( out ); // SIMD bulk load of neppV, use reinterpret_cast
+        }
+        else
+        {
+          //static bool first=true; if( first ){ std::cout << "WARNING! AOSOA but no reinterpret cast" << std::endl; first=false; } // SLOWER (4.93E6)
+          // A bit (1%) slower (5.05E6 in eemumu 512y)
+          // This does not require buffer alignment, but it requires AOSOA with neppM>=neppV and neppM%neppV==0
+          return mg5amcCpu::fptypevFromUnalignedArray( out ); // SIMD bulk load of neppV, do not use reinterpret_cast (fewer SIMD operations)
+        }
       }
       else
       {
-        //static bool first=true; if( first ){ std::cout << "WARNING! AOSOA but no reinterpret cast" << std::endl; first=false; } // SLOWER (4.93E6)
-        // A bit (1%) slower (5.05E6 in eemumu 512y)
-        // This does not require buffer alignment, but it requires AOSOA with neppM>=neppV and neppM%neppV==0
-        return mg5amcCpu::fptypevFromUnalignedArray( out ); // SIMD bulk load of neppV, do not use reinterpret_cast (fewer SIMD operations)
+        //static bool first=true; if( first ){ std::cout << "WARNING! arbitrary array" << std::endl; first=false; } // SLOWER (5.08E6)
+        // ?!Used to be much slower, now a tiny bit faster for AOSOA?! (5.11E6 for AOSOA, 4.64E6 for AOS in eemumu 512y)
+        // This does not even require AOSOA with neppM>=neppV and neppM%neppV==0 (e.g. can be used with AOS neppM==1)
+        constexpr int ievt0 = 0; // just make it explicit in the code that buffer refers to a given ievt0 and decoderIeppV fetches event ievt0+ieppV
+        auto decoderIeppv = [buffer, ip4, ipar]( int ieppV )
+          -> const fptype&
+                            { return MemoryAccessMomenta::ieventAccessIp4IparConst( buffer, ievt0 + ieppV, ip4, ipar ); };
+        return mg5amcCpu::fptypevFromArbitraryArray( decoderIeppv ); // iterate over ieppV in neppV (no SIMD)
       }
-    }
-    else
-    {
-      //static bool first=true; if( first ){ std::cout << "WARNING! arbitrary array" << std::endl; first=false; } // SLOWER (5.08E6)
-      // ?!Used to be much slower, now a tiny bit faster for AOSOA?! (5.11E6 for AOSOA, 4.64E6 for AOS in eemumu 512y)
-      // This does not even require AOSOA with neppM>=neppV and neppM%neppV==0 (e.g. can be used with AOS neppM==1)
-      constexpr int ievt0 = 0; // just make it explicit in the code that buffer refers to a given ievt0 and decoderIeppV fetches event ievt0+ieppV
-      auto decoderIeppv = [buffer, ip4, ipar]( int ieppV )
-        -> const fptype&
-      { return MemoryAccessMomenta::ieventAccessIp4IparConst( buffer, ievt0 + ieppV, ip4, ipar ); };
-      return mg5amcCpu::fptypevFromArbitraryArray( decoderIeppv ); // iterate over ieppV in neppV (no SIMD)
-    }
 #endif
-  }
+    }
 
-  // Is this a HostAccess or DeviceAccess class?
-  // [this is only needed for a warning printout in rambo.h for nparf==1 #358]
-  static __host__ __device__ inline constexpr bool
-  isOnDevice()
-  {
-    return onDevice;
-  }
-};
+    // Is this a HostAccess or DeviceAccess class?
+    // [this is only needed for a warning printout in rambo.h for nparf==1 #358]
+    static __host__ __device__ inline constexpr bool
+    isOnDevice()
+    {
+      return onDevice;
+    }
+  };
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-typedef KernelAccessMomenta<false> HostAccessMomenta;
-typedef KernelAccessMomenta<true> DeviceAccessMomenta;
+  typedef KernelAccessMomenta<false> HostAccessMomenta;
+  typedef KernelAccessMomenta<true> DeviceAccessMomenta;
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessMomenta_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessWavefunctions.h
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/MemoryAccessWavefunctions.h
@@ -14,147 +14,157 @@
 
 #define MGONGPU_TRIVIAL_WAVEFUNCTIONS 1
 
-//----------------------------------------------------------------------------
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
+{
+
+  //----------------------------------------------------------------------------
 
 #ifndef MGONGPU_TRIVIAL_WAVEFUNCTIONS
 
-// A class describing the internal layout of memory buffers for wavefunctions
-// This implementation uses an AOSOA[npagW][nw6][nx2][neppW] where nevt=npagW*neppW
-// [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
-class MemoryAccessWavefunctionsBase //_AOSOAv1
-{
-public:
-
-  // Number of Events Per Page in the wavefunction AOSOA memory buffer layout
-  static constexpr int neppW = 1; // AOS (just a test...)
-
-private:
-
-  friend class MemoryAccessHelper<MemoryAccessWavefunctionsBase>;
-  friend class KernelAccessHelper<MemoryAccessWavefunctionsBase, true>;
-  friend class KernelAccessHelper<MemoryAccessWavefunctionsBase, false>;
-
-  // The number of components of a (fermion or vector) wavefunction
-  static constexpr int nw6 = mgOnGpu::nw6;
-
-  // The number of floating point components of a complex number
-  static constexpr int nx2 = mgOnGpu::nx2;
-
-  //--------------------------------------------------------------------------
-  // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
-  // (in other words: first locate the event record for a given event, then locate an element in that record)
-  //--------------------------------------------------------------------------
-
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static __host__ __device__ inline fptype*
-  ieventAccessRecord( fptype* buffer,
-                      const int ievt )
+  // A class describing the internal layout of memory buffers for wavefunctions
+  // This implementation uses an AOSOA[npagW][nw6][nx2][neppW] where nevt=npagW*neppW
+  // [If many implementations are used, a suffix _AOSOAv1 should be appended to the class name]
+  class MemoryAccessWavefunctionsBase //_AOSOAv1
   {
-    const int ipagW = ievt / neppW; // #event "W-page"
-    const int ieppW = ievt % neppW; // #event in the current event W-page
-    constexpr int iw6 = 0;
-    constexpr int ix2 = 0;
-    return &( buffer[ipagW * nw6 * nx2 * neppW + iw6 * nx2 * neppW + ix2 * neppW + ieppW] ); // AOSOA[ipagW][iw6][ix2][ieppW]
-  }
+  public:
 
-  //--------------------------------------------------------------------------
+    // Number of Events Per Page in the wavefunction AOSOA memory buffer layout
+    static constexpr int neppW = 1; // AOS (just a test...)
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
-  // [NB: expand variadic template "Ts... args" to "const int iw6, const int ix2" and rename "Field" as "Iw6Ix2"]
-  static __host__ __device__ inline fptype&
-  decodeRecord( fptype* buffer,
-                const int iw6,
-                const int ix2 )
+  private:
+
+    friend class MemoryAccessHelper<MemoryAccessWavefunctionsBase>;
+    friend class KernelAccessHelper<MemoryAccessWavefunctionsBase, true>;
+    friend class KernelAccessHelper<MemoryAccessWavefunctionsBase, false>;
+
+    // The number of components of a (fermion or vector) wavefunction
+    static constexpr int nw6 = mgOnGpu::nw6;
+
+    // The number of floating point components of a complex number
+    static constexpr int nx2 = mgOnGpu::nx2;
+
+    //--------------------------------------------------------------------------
+    // NB all KernelLaunchers assume that memory access can be decomposed as "accessField = decodeRecord( accessRecord )"
+    // (in other words: first locate the event record for a given event, then locate an element in that record)
+    //--------------------------------------------------------------------------
+
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static __host__ __device__ inline fptype*
+    ieventAccessRecord( fptype* buffer,
+                        const int ievt )
+    {
+      const int ipagW = ievt / neppW; // #event "W-page"
+      const int ieppW = ievt % neppW; // #event in the current event W-page
+      constexpr int iw6 = 0;
+      constexpr int ix2 = 0;
+      return &( buffer[ipagW * nw6 * nx2 * neppW + iw6 * nx2 * neppW + ix2 * neppW + ieppW] ); // AOSOA[ipagW][iw6][ix2][ieppW]
+    }
+
+    //--------------------------------------------------------------------------
+
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, Ts... args ) <===]
+    // [NB: expand variadic template "Ts... args" to "const int iw6, const int ix2" and rename "Field" as "Iw6Ix2"]
+    static __host__ __device__ inline fptype&
+    decodeRecord( fptype* buffer,
+                  const int iw6,
+                  const int ix2 )
+    {
+      constexpr int ipagW = 0;
+      constexpr int ieppW = 0;
+      return buffer[ipagW * nw6 * nx2 * neppW + iw6 * nx2 * neppW + ix2 * neppW + ieppW]; // AOSOA[ipagW][iw6][ix2][ieppW]
+    }
+  };
+
+  //----------------------------------------------------------------------------
+
+  // A class providing access to memory buffers for a given event, based on explicit event numbers
+  // Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
+  class MemoryAccessWavefunctions : public MemoryAccessWavefunctionsBase
   {
-    constexpr int ipagW = 0;
-    constexpr int ieppW = 0;
-    return buffer[ipagW * nw6 * nx2 * neppW + iw6 * nx2 * neppW + ix2 * neppW + ieppW]; // AOSOA[ipagW][iw6][ix2][ieppW]
-  }
-};
+  public:
 
-//----------------------------------------------------------------------------
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::ieventAccessRecord;
 
-// A class providing access to memory buffers for a given event, based on explicit event numbers
-// Its methods use the MemoryAccessHelper templates - note the use of the template keyword in template function instantiations
-class MemoryAccessWavefunctions : public MemoryAccessWavefunctionsBase
-{
-public:
+    // Locate an event record (output) in a memory buffer (input) from the given event number (input)
+    // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
+    static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::ieventAccessRecordConst;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (non-const) ===> fptype* ieventAccessRecord( fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecord = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::ieventAccessRecord;
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int iw6, const int ix2 ) <===]
+    static constexpr auto decodeRecordIw6Ix2 = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::decodeRecord;
 
-  // Locate an event record (output) in a memory buffer (input) from the given event number (input)
-  // [Signature (const) ===> const fptype* ieventAccessRecordConst( const fptype* buffer, const int ievt ) <===]
-  static constexpr auto ieventAccessRecordConst = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::ieventAccessRecordConst;
+    // Locate a field (output) of an event record (input) from the given field indexes (input)
+    // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int iw6, const int ix2 ) <===]
+    static constexpr auto decodeRecordIw6Ix2Const =
+      MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template decodeRecordConst<int, int>;
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (non-const) ===> fptype& decodeRecord( fptype* buffer, const int iw6, const int ix2 ) <===]
-  static constexpr auto decodeRecordIw6Ix2 = MemoryAccessHelper<MemoryAccessWavefunctionsBase>::decodeRecord;
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& ieventAccessIw6Ix2( fptype* buffer, const ievt, const int iw6, const int ix2 ) <===]
+    static constexpr auto ieventAccessIw6Ix2 =
+      MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template ieventAccessField<int, int>;
 
-  // Locate a field (output) of an event record (input) from the given field indexes (input)
-  // [Signature (const) ===> const fptype& decodeRecordConst( const fptype* buffer, const int iw6, const int ix2 ) <===]
-  static constexpr auto decodeRecordIw6Ix2Const =
-    MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template decodeRecordConst<int, int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& ieventAccessIw6Ix2( fptype* buffer, const ievt, const int iw6, const int ix2 ) <===]
-  static constexpr auto ieventAccessIw6Ix2 =
-    MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template ieventAccessField<int, int>;
-
-  // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& ieventAccessIw6Ix2Const( const fptype* buffer, const ievt, const int iw6, const int ix2 ) <===]
-  static constexpr auto ieventAccessIw6Ix2Const =
-    MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template ieventAccessFieldConst<int, int>;
-};
+    // Locate a field (output) in a memory buffer (input) from the given event number (input) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& ieventAccessIw6Ix2Const( const fptype* buffer, const ievt, const int iw6, const int ix2 ) <===]
+    static constexpr auto ieventAccessIw6Ix2Const =
+      MemoryAccessHelper<MemoryAccessWavefunctionsBase>::template ieventAccessFieldConst<int, int>;
+  };
 
 #endif // #ifndef MGONGPU_TRIVIAL_WAVEFUNCTIONS
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-// A class providing access to memory buffers for a given event, based on implicit kernel rules
-// Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
-template<bool onDevice>
-class KernelAccessWavefunctions
-{
-public:
+  // A class providing access to memory buffers for a given event, based on implicit kernel rules
+  // Its methods use the KernelAccessHelper template - note the use of the template keyword in template function instantiations
+  template<bool onDevice>
+  class KernelAccessWavefunctions
+  {
+  public:
 
 #ifndef MGONGPU_TRIVIAL_WAVEFUNCTIONS
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (non-const) ===> fptype& kernelAccessIw6Ix2( fptype* buffer, const int iw6, const int ix2 ) <===]
-  static constexpr auto kernelAccessIw6Ix2 =
-    KernelAccessHelper<MemoryAccessWavefunctionsBase, onDevice>::template kernelAccessField<int, int>;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (non-const) ===> fptype& kernelAccessIw6Ix2( fptype* buffer, const int iw6, const int ix2 ) <===]
+    static constexpr auto kernelAccessIw6Ix2 =
+      KernelAccessHelper<MemoryAccessWavefunctionsBase, onDevice>::template kernelAccessField<int, int>;
 
-  // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
-  // [Signature (const) ===> const fptype& kernelAccessIw6Ix2Const( const fptype* buffer, const int iw6, const int ix2 ) <===]
-  static constexpr auto kernelAccessIw6Ix2Const =
-    KernelAccessHelper<MemoryAccessWavefunctionsBase, onDevice>::template kernelAccessFieldConst<int, int>;
+    // Locate a field (output) in a memory buffer (input) from a kernel event-indexing mechanism (internal) and the given field indexes (input)
+    // [Signature (const) ===> const fptype& kernelAccessIw6Ix2Const( const fptype* buffer, const int iw6, const int ix2 ) <===]
+    static constexpr auto kernelAccessIw6Ix2Const =
+      KernelAccessHelper<MemoryAccessWavefunctionsBase, onDevice>::template kernelAccessFieldConst<int, int>;
 
 #else
 
-  static __host__ __device__ inline cxtype_sv*
-  kernelAccess( fptype* buffer )
-  {
-    return reinterpret_cast<cxtype_sv*>( buffer );
-  }
+    static __host__ __device__ inline cxtype_sv*
+    kernelAccess( fptype* buffer )
+    {
+      return reinterpret_cast<cxtype_sv*>( buffer );
+    }
 
-  static __host__ __device__ inline const cxtype_sv*
-  kernelAccessConst( const fptype* buffer )
-  {
-    return reinterpret_cast<const cxtype_sv*>( buffer );
-  }
+    static __host__ __device__ inline const cxtype_sv*
+    kernelAccessConst( const fptype* buffer )
+    {
+      return reinterpret_cast<const cxtype_sv*>( buffer );
+    }
 
 #endif // #ifndef MGONGPU_TRIVIAL_WAVEFUNCTIONS
-};
+  };
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-typedef KernelAccessWavefunctions<false> HostAccessWavefunctions;
-typedef KernelAccessWavefunctions<true> DeviceAccessWavefunctions;
+  typedef KernelAccessWavefunctions<false> HostAccessWavefunctions;
+  typedef KernelAccessWavefunctions<true> DeviceAccessWavefunctions;
 
-//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MemoryAccessWavefunctions_H

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/cudacpp.mk
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/cudacpp.mk
@@ -142,6 +142,7 @@ else
   override CUINC=
   override CURANDLIBFLAGS=
 endif
+export NVCC
 
 # Set the host C++ compiler for nvcc via "-ccbin <host-compiler>"
 # (NB issue #505: this must be a single word, "clang++ --gcc-toolchain..." is not supported)

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/testmisc.cc
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/testmisc.cc
@@ -25,32 +25,50 @@
 
 #define XTESTID( s ) TESTID( s )
 
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
+{
+
 #ifdef MGONGPU_CPPSIMD /* clang-format off */
 #define EXPECT_TRUE_sv( cond ) { bool_v mask( cond ); EXPECT_TRUE( maskand( mask ) ); }
 #else
 #define EXPECT_TRUE_sv( cond ) { EXPECT_TRUE( cond ); }
 #endif /* clang-format on */
 
-inline const std::string
-boolTF( const bool& b )
-{
-  return ( b ? "T" : "F" );
-}
+  inline const std::string
+  boolTF( const bool& b )
+  {
+    return ( b ? "T" : "F" );
+  }
 
 #ifdef MGONGPU_CPPSIMD
-inline const std::string
-boolTF( const bool_v& v )
-{
-  std::stringstream out;
-  out << "{ " << ( v[0] ? "T" : "F" );
-  for( int i = 1; i < neppV; i++ ) out << ", " << ( v[i] ? "T" : "F" );
-  out << " }";
-  return out.str();
-}
+  inline const std::string
+  boolTF( const bool_v& v )
+  {
+    std::stringstream out;
+    out << "{ " << ( v[0] ? "T" : "F" );
+    for( int i = 1; i < neppV; i++ ) out << ", " << ( v[i] ? "T" : "F" );
+    out << " }";
+    return out.str();
+  }
 #endif
 
+}
+
 TEST( XTESTID( MG_EPOCH_PROCESS_ID ), testmisc )
-{
+{  
+#ifdef __CUDACC__
+  using namespace mg5amcGpu;
+#else
+  using namespace mg5amcCpu;
+#endif
+
+  //--------------------------------------------------------------------------
+
   EXPECT_TRUE( true );
 
   //--------------------------------------------------------------------------

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/testmisc.cc
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/testmisc.cc
@@ -26,7 +26,6 @@
 #define XTESTID( s ) TESTID( s )
 
 #ifdef MGONGPU_CPPSIMD /* clang-format off */
-bool maskand( const bool_v& mask ){ bool out = true; for ( int i=0; i<neppV; i++ ) out = out && mask[i]; return out; }
 #define EXPECT_TRUE_sv( cond ) { bool_v mask( cond ); EXPECT_TRUE( maskand( mask ) ); }
 #else
 #define EXPECT_TRUE_sv( cond ) { EXPECT_TRUE( cond ); }

--- a/epochX/cudacpp/gg_tt.sa/SubProcesses/testxxx.cc
+++ b/epochX/cudacpp/gg_tt.sa/SubProcesses/testxxx.cc
@@ -30,12 +30,16 @@
 
 TEST( XTESTID( MG_EPOCH_PROCESS_ID ), testxxx )
 {
+#ifdef __CUDACC__
+  using namespace mg5amcGpu;
+#else
+  using namespace mg5amcCpu;
+#endif
   constexpr bool dumpEvents = false;       // dump the expected output of the test?
   constexpr bool testEvents = !dumpEvents; // run the test?
   constexpr fptype toleranceXXXs = std::is_same<fptype, double>::value ? 1.E-15 : 1.E-5;
   // Constant parameters
   constexpr int neppM = MemoryAccessMomenta::neppM; // AOSOA layout
-  using mgOnGpu::neppV;
   constexpr int np4 = CPPProcess::np4;
   const int nevt = 16;         // 12 independent tests plus 4 duplicates (need a multiple of 8 for floats or for '512z')
   assert( nevt % neppM == 0 ); // nevt must be a multiple of neppM

--- a/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.cc
+++ b/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.cc
@@ -17,6 +17,12 @@
 #include <iomanip>
 #include <iostream>
 
+#ifdef __CUDACC__
+using namespace mg5amcGpu;
+#else
+using namespace mg5amcCpu;
+#endif
+
 #ifndef MGONGPU_HARDCODE_PARAM
 
 // Initialize static instance

--- a/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.h
+++ b/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.h
@@ -262,37 +262,30 @@ namespace mg5amcCpu
 
   //==========================================================================
 
-#ifdef __CUDACC__
-  namespace mg5amcGpu
-#else
-  namespace mg5amcCpu
-#endif
-  {
 #pragma GCC diagnostic push
 #ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable" // e.g. <<warning: variable ‘couplings_sv’ set but not used [-Wunused-but-set-variable]>>
 #endif
-    // Compute the output couplings (e.g. gc10 and gc11) from the input gs
-    template<class G_ACCESS, class C_ACCESS>
-    __device__ inline void
-    G2COUP( const fptype gs[],
-            fptype couplings[] )
-    {
-      mgDebug( 0, __FUNCTION__ );
-      using namespace Parameters_sm_dependentCouplings;
-      const fptype_sv& gs_sv = G_ACCESS::kernelAccessConst( gs );
-      DependentCouplings_sv couplings_sv = computeDependentCouplings_fromG( gs_sv );
-      fptype* GC_10s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_10 );
-      fptype* GC_11s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_11 );
-      cxtype_sv_ref GC_10s_sv = C_ACCESS::kernelAccess( GC_10s );
-      cxtype_sv_ref GC_11s_sv = C_ACCESS::kernelAccess( GC_11s );
-      GC_10s_sv = couplings_sv.GC_10;
-      GC_11s_sv = couplings_sv.GC_11;
-      mgDebug( 1, __FUNCTION__ );
-      return;
-    }
-#pragma GCC diagnostic pop
+  // Compute the output couplings (e.g. gc10 and gc11) from the input gs
+  template<class G_ACCESS, class C_ACCESS>
+  __device__ inline void
+  G2COUP( const fptype gs[],
+          fptype couplings[] )
+  {
+    mgDebug( 0, __FUNCTION__ );
+    using namespace Parameters_sm_dependentCouplings;
+    const fptype_sv& gs_sv = G_ACCESS::kernelAccessConst( gs );
+    DependentCouplings_sv couplings_sv = computeDependentCouplings_fromG( gs_sv );
+    fptype* GC_10s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_10 );
+    fptype* GC_11s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_11 );
+    cxtype_sv_ref GC_10s_sv = C_ACCESS::kernelAccess( GC_10s );
+    cxtype_sv_ref GC_11s_sv = C_ACCESS::kernelAccess( GC_11s );
+    GC_10s_sv = couplings_sv.GC_10;
+    GC_11s_sv = couplings_sv.GC_11;
+    mgDebug( 1, __FUNCTION__ );
+    return;
   }
+#pragma GCC diagnostic pop
 
 } // end namespace mg5amcGpu/mg5amcCpu
 

--- a/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.h
+++ b/epochX/cudacpp/gg_tt.sa/src/Parameters_sm.h
@@ -26,188 +26,196 @@
 
 #include "read_slha.h"
 
-class Parameters_sm
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
-public:
 
-  static Parameters_sm* getInstance();
+  class Parameters_sm
+  {
+  public:
 
-  // Define "zero"
-  double zero, ZERO;
+    static Parameters_sm* getInstance();
 
-  // Model parameters independent of aS
-  //double aS; // now retrieved event-by-event (as G) from Fortran (running alphas #373)
-  double mdl_WH, mdl_WW, mdl_WZ, mdl_WT, mdl_ymtau, mdl_ymt, mdl_ymb, mdl_Gf, aEWM1, mdl_MH, mdl_MZ, mdl_MTA, mdl_MT, mdl_MB, mdl_conjg__CKM3x3, mdl_conjg__CKM1x1, mdl_CKM3x3, mdl_MZ__exp__2, mdl_MZ__exp__4, mdl_sqrt__2, mdl_MH__exp__2, mdl_aEW, mdl_MW, mdl_sqrt__aEW, mdl_ee, mdl_MW__exp__2, mdl_sw2, mdl_cw, mdl_sqrt__sw2, mdl_sw, mdl_g1, mdl_gw, mdl_vev, mdl_vev__exp__2, mdl_lam, mdl_yb, mdl_yt, mdl_ytau, mdl_muH, mdl_ee__exp__2, mdl_sw__exp__2, mdl_cw__exp__2;
-  cxsmpl<double> mdl_complexi, mdl_I1x33, mdl_I2x33, mdl_I3x33, mdl_I4x33;
+    // Define "zero"
+    double zero, ZERO;
 
-  // Model couplings independent of aS
-  // (none)
+    // Model parameters independent of aS
+    //double aS; // now retrieved event-by-event (as G) from Fortran (running alphas #373)
+    double mdl_WH, mdl_WW, mdl_WZ, mdl_WT, mdl_ymtau, mdl_ymt, mdl_ymb, mdl_Gf, aEWM1, mdl_MH, mdl_MZ, mdl_MTA, mdl_MT, mdl_MB, mdl_conjg__CKM3x3, mdl_conjg__CKM1x1, mdl_CKM3x3, mdl_MZ__exp__2, mdl_MZ__exp__4, mdl_sqrt__2, mdl_MH__exp__2, mdl_aEW, mdl_MW, mdl_sqrt__aEW, mdl_ee, mdl_MW__exp__2, mdl_sw2, mdl_cw, mdl_sqrt__sw2, mdl_sw, mdl_g1, mdl_gw, mdl_vev, mdl_vev__exp__2, mdl_lam, mdl_yb, mdl_yt, mdl_ytau, mdl_muH, mdl_ee__exp__2, mdl_sw__exp__2, mdl_cw__exp__2;
+    cxsmpl<double> mdl_complexi, mdl_I1x33, mdl_I2x33, mdl_I3x33, mdl_I4x33;
 
-  // Model parameters dependent on aS
-  //double mdl_sqrt__aS, G, mdl_G__exp__2; // now computed event-by-event (running alphas #373)
+    // Model couplings independent of aS
+    // (none)
 
-  // Model couplings dependent on aS
-  //cxsmpl<double> GC_10, GC_11; // now computed event-by-event (running alphas #373)
+    // Model parameters dependent on aS
+    //double mdl_sqrt__aS, G, mdl_G__exp__2; // now computed event-by-event (running alphas #373)
 
-  // Set parameters that are unchanged during the run
-  void setIndependentParameters( SLHAReader& slha );
+    // Model couplings dependent on aS
+    //cxsmpl<double> GC_10, GC_11; // now computed event-by-event (running alphas #373)
 
-  // Set couplings that are unchanged during the run
-  void setIndependentCouplings();
+    // Set parameters that are unchanged during the run
+    void setIndependentParameters( SLHAReader& slha );
 
-  // Set parameters that are changed event by event
-  //void setDependentParameters(); // now computed event-by-event (running alphas #373)
+    // Set couplings that are unchanged during the run
+    void setIndependentCouplings();
 
-  // Set couplings that are changed event by event
-  //void setDependentCouplings(); // now computed event-by-event (running alphas #373)
+    // Set parameters that are changed event by event
+    //void setDependentParameters(); // now computed event-by-event (running alphas #373)
 
-  // Print parameters that are unchanged during the run
-  void printIndependentParameters();
+    // Set couplings that are changed event by event
+    //void setDependentCouplings(); // now computed event-by-event (running alphas #373)
 
-  // Print couplings that are unchanged during the run
-  void printIndependentCouplings();
+    // Print parameters that are unchanged during the run
+    void printIndependentParameters();
 
-  // Print parameters that are changed event by event
-  //void printDependentParameters(); // now computed event-by-event (running alphas #373)
+    // Print couplings that are unchanged during the run
+    void printIndependentCouplings();
 
-  // Print couplings that are changed event by event
-  //void printDependentCouplings(); // now computed event-by-event (running alphas #373)
+    // Print parameters that are changed event by event
+    //void printDependentParameters(); // now computed event-by-event (running alphas #373)
 
-private:
+    // Print couplings that are changed event by event
+    //void printDependentCouplings(); // now computed event-by-event (running alphas #373)
 
-  static Parameters_sm* instance;
-};
+  private:
+
+    static Parameters_sm* instance;
+  };
 
 #else
 
 #include <cassert>
 #include <limits>
 
-// Hardcoded constexpr physics parameters
-namespace Parameters_sm // keep the same name rather than HardcodedParameters_sm for simplicity
-{
-  // Constexpr implementation of sqrt (see https://stackoverflow.com/a/34134071)
-  double constexpr sqrtNewtonRaphson( double x, double curr, double prev )
+  // Hardcoded constexpr physics parameters
+  namespace Parameters_sm // keep the same name rather than HardcodedParameters_sm for simplicity
   {
-    return curr == prev ? curr : sqrtNewtonRaphson( x, 0.5 * ( curr + x / curr ), curr );
+    // Constexpr implementation of sqrt (see https://stackoverflow.com/a/34134071)
+    double constexpr sqrtNewtonRaphson( double x, double curr, double prev )
+    {
+      return curr == prev ? curr : sqrtNewtonRaphson( x, 0.5 * ( curr + x / curr ), curr );
+    }
+    double constexpr constexpr_sqrt( double x )
+    {
+      return x >= 0 // && x < std::numeric_limits<double>::infinity() // avoid -Wtautological-constant-compare warning in fast math
+        ? sqrtNewtonRaphson( x, x, 0 )
+        : std::numeric_limits<double>::quiet_NaN();
+    }
+
+    // Constexpr implementation of floor (see https://stackoverflow.com/a/66146159)
+    constexpr int constexpr_floor( double d )
+    {
+      const int i = static_cast<int>( d );
+      return d < i ? i - 1 : i;
+    }
+
+    // Constexpr implementation of pow
+    constexpr double constexpr_pow( double base, double exp )
+    {
+      // NB(1): this implementation of constexpr_pow requires exponent >= 0
+      assert( exp >= 0 ); // NB would fail at compile time with "error: call to non-‘constexpr’ function ‘void __assert_fail'"
+      // NB(2): this implementation of constexpr_pow requires an integer exponent
+      const int iexp = constexpr_floor( exp );
+      assert( static_cast<double>( iexp ) == exp ); // NB would fail at compile time with "error: call to non-‘constexpr’ function ‘void __assert_fail'"
+      // Iterative implementation of pow if exp is a non negative integer
+      return iexp == 0 ? 1 : base * constexpr_pow( base, iexp - 1 );
+    }
+
+    // Model parameters independent of aS
+    constexpr double zero = 0;
+    constexpr double ZERO = 0;
+    constexpr double mdl_WH = 6.382339e-03;
+    constexpr double mdl_WW = 2.047600e+00;
+    constexpr double mdl_WZ = 2.441404e+00;
+    constexpr double mdl_WT = 1.491500e+00;
+    constexpr double mdl_ymtau = 1.777000e+00;
+    constexpr double mdl_ymt = 1.730000e+02;
+    constexpr double mdl_ymb = 4.700000e+00;
+    //constexpr double aS = 1.180000e-01; // now retrieved event-by-event (as G) from Fortran (running alphas #373)
+    constexpr double mdl_Gf = 1.166390e-05;
+    constexpr double aEWM1 = 1.325070e+02;
+    constexpr double mdl_MH = 1.250000e+02;
+    constexpr double mdl_MZ = 9.118800e+01;
+    constexpr double mdl_MTA = 1.777000e+00;
+    constexpr double mdl_MT = 1.730000e+02;
+    constexpr double mdl_MB = 4.700000e+00;
+    constexpr double mdl_conjg__CKM3x3 = 1.;
+    constexpr double mdl_conjg__CKM1x1 = 1.;
+    constexpr double mdl_CKM3x3 = 1.;
+    constexpr cxsmpl<double> mdl_complexi = cxsmpl<double>( 0., 1. );
+    constexpr double mdl_MZ__exp__2 = ( ( mdl_MZ ) * ( mdl_MZ ) );
+    constexpr double mdl_MZ__exp__4 = ( ( mdl_MZ ) * ( mdl_MZ ) * ( mdl_MZ ) * ( mdl_MZ ) );
+    constexpr double mdl_sqrt__2 = constexpr_sqrt( 2. );
+    constexpr double mdl_MH__exp__2 = ( ( mdl_MH ) * ( mdl_MH ) );
+    constexpr double mdl_aEW = 1. / aEWM1;
+    constexpr double mdl_MW = constexpr_sqrt( mdl_MZ__exp__2 / 2. + constexpr_sqrt( mdl_MZ__exp__4 / 4. - ( mdl_aEW * M_PI * mdl_MZ__exp__2 ) / ( mdl_Gf * mdl_sqrt__2 ) ) );
+    constexpr double mdl_sqrt__aEW = constexpr_sqrt( mdl_aEW );
+    constexpr double mdl_ee = 2. * mdl_sqrt__aEW * constexpr_sqrt( M_PI );
+    constexpr double mdl_MW__exp__2 = ( ( mdl_MW ) * ( mdl_MW ) );
+    constexpr double mdl_sw2 = 1. - mdl_MW__exp__2 / mdl_MZ__exp__2;
+    constexpr double mdl_cw = constexpr_sqrt( 1. - mdl_sw2 );
+    constexpr double mdl_sqrt__sw2 = constexpr_sqrt( mdl_sw2 );
+    constexpr double mdl_sw = mdl_sqrt__sw2;
+    constexpr double mdl_g1 = mdl_ee / mdl_cw;
+    constexpr double mdl_gw = mdl_ee / mdl_sw;
+    constexpr double mdl_vev = ( 2. * mdl_MW * mdl_sw ) / mdl_ee;
+    constexpr double mdl_vev__exp__2 = ( ( mdl_vev ) * ( mdl_vev ) );
+    constexpr double mdl_lam = mdl_MH__exp__2 / ( 2. * mdl_vev__exp__2 );
+    constexpr double mdl_yb = ( mdl_ymb * mdl_sqrt__2 ) / mdl_vev;
+    constexpr double mdl_yt = ( mdl_ymt * mdl_sqrt__2 ) / mdl_vev;
+    constexpr double mdl_ytau = ( mdl_ymtau * mdl_sqrt__2 ) / mdl_vev;
+    constexpr double mdl_muH = constexpr_sqrt( mdl_lam * mdl_vev__exp__2 );
+    constexpr cxsmpl<double> mdl_I1x33 = mdl_yb * mdl_conjg__CKM3x3;
+    constexpr cxsmpl<double> mdl_I2x33 = mdl_yt * mdl_conjg__CKM3x3;
+    constexpr cxsmpl<double> mdl_I3x33 = mdl_CKM3x3 * mdl_yt;
+    constexpr cxsmpl<double> mdl_I4x33 = mdl_CKM3x3 * mdl_yb;
+    constexpr double mdl_ee__exp__2 = ( ( mdl_ee ) * ( mdl_ee ) );
+    constexpr double mdl_sw__exp__2 = ( ( mdl_sw ) * ( mdl_sw ) );
+    constexpr double mdl_cw__exp__2 = ( ( mdl_cw ) * ( mdl_cw ) );
+
+    // Model couplings independent of aS
+    // (none)
+
+    // Model parameters dependent on aS
+    //constexpr double mdl_sqrt__aS = //constexpr_sqrt( aS ); // now computed event-by-event (running alphas #373)
+    //constexpr double G = 2. * mdl_sqrt__aS * //constexpr_sqrt( M_PI ); // now computed event-by-event (running alphas #373)
+    //constexpr double mdl_G__exp__2 = ( ( G ) * ( G ) ); // now computed event-by-event (running alphas #373)
+
+    // Model couplings dependent on aS
+    //constexpr cxsmpl<double> GC_10 = -G; // now computed event-by-event (running alphas #373)
+    //constexpr cxsmpl<double> GC_11 = mdl_complexi * G; // now computed event-by-event (running alphas #373)
+
+    // Print parameters that are unchanged during the run
+    void printIndependentParameters();
+
+    // Print couplings that are unchanged during the run
+    void printIndependentCouplings();
+
+    // Print parameters that are changed event by event
+    //void printDependentParameters(); // now computed event-by-event (running alphas #373)
+
+    // Print couplings that are changed event by event
+    //void printDependentCouplings(); // now computed event-by-event (running alphas #373)
   }
-  double constexpr constexpr_sqrt( double x )
-  {
-    return x >= 0 // && x < std::numeric_limits<double>::infinity() // avoid -Wtautological-constant-compare warning in fast math
-      ? sqrtNewtonRaphson( x, x, 0 )
-      : std::numeric_limits<double>::quiet_NaN();
-  }
-
-  // Constexpr implementation of floor (see https://stackoverflow.com/a/66146159)
-  constexpr int constexpr_floor( double d )
-  {
-    const int i = static_cast<int>( d );
-    return d < i ? i - 1 : i;
-  }
-
-  // Constexpr implementation of pow
-  constexpr double constexpr_pow( double base, double exp )
-  {
-    // NB(1): this implementation of constexpr_pow requires exponent >= 0
-    assert( exp >= 0 ); // NB would fail at compile time with "error: call to non-‘constexpr’ function ‘void __assert_fail'"
-    // NB(2): this implementation of constexpr_pow requires an integer exponent
-    const int iexp = constexpr_floor( exp );
-    assert( static_cast<double>( iexp ) == exp ); // NB would fail at compile time with "error: call to non-‘constexpr’ function ‘void __assert_fail'"
-    // Iterative implementation of pow if exp is a non negative integer
-    return iexp == 0 ? 1 : base * constexpr_pow( base, iexp - 1 );
-  }
-
-  // Model parameters independent of aS
-  constexpr double zero = 0;
-  constexpr double ZERO = 0;
-  constexpr double mdl_WH = 6.382339e-03;
-  constexpr double mdl_WW = 2.047600e+00;
-  constexpr double mdl_WZ = 2.441404e+00;
-  constexpr double mdl_WT = 1.491500e+00;
-  constexpr double mdl_ymtau = 1.777000e+00;
-  constexpr double mdl_ymt = 1.730000e+02;
-  constexpr double mdl_ymb = 4.700000e+00;
-  //constexpr double aS = 1.180000e-01; // now retrieved event-by-event (as G) from Fortran (running alphas #373)
-  constexpr double mdl_Gf = 1.166390e-05;
-  constexpr double aEWM1 = 1.325070e+02;
-  constexpr double mdl_MH = 1.250000e+02;
-  constexpr double mdl_MZ = 9.118800e+01;
-  constexpr double mdl_MTA = 1.777000e+00;
-  constexpr double mdl_MT = 1.730000e+02;
-  constexpr double mdl_MB = 4.700000e+00;
-  constexpr double mdl_conjg__CKM3x3 = 1.;
-  constexpr double mdl_conjg__CKM1x1 = 1.;
-  constexpr double mdl_CKM3x3 = 1.;
-  constexpr cxsmpl<double> mdl_complexi = cxsmpl<double>( 0., 1. );
-  constexpr double mdl_MZ__exp__2 = ( ( mdl_MZ ) * ( mdl_MZ ) );
-  constexpr double mdl_MZ__exp__4 = ( ( mdl_MZ ) * ( mdl_MZ ) * ( mdl_MZ ) * ( mdl_MZ ) );
-  constexpr double mdl_sqrt__2 = constexpr_sqrt( 2. );
-  constexpr double mdl_MH__exp__2 = ( ( mdl_MH ) * ( mdl_MH ) );
-  constexpr double mdl_aEW = 1. / aEWM1;
-  constexpr double mdl_MW = constexpr_sqrt( mdl_MZ__exp__2 / 2. + constexpr_sqrt( mdl_MZ__exp__4 / 4. - ( mdl_aEW * M_PI * mdl_MZ__exp__2 ) / ( mdl_Gf * mdl_sqrt__2 ) ) );
-  constexpr double mdl_sqrt__aEW = constexpr_sqrt( mdl_aEW );
-  constexpr double mdl_ee = 2. * mdl_sqrt__aEW * constexpr_sqrt( M_PI );
-  constexpr double mdl_MW__exp__2 = ( ( mdl_MW ) * ( mdl_MW ) );
-  constexpr double mdl_sw2 = 1. - mdl_MW__exp__2 / mdl_MZ__exp__2;
-  constexpr double mdl_cw = constexpr_sqrt( 1. - mdl_sw2 );
-  constexpr double mdl_sqrt__sw2 = constexpr_sqrt( mdl_sw2 );
-  constexpr double mdl_sw = mdl_sqrt__sw2;
-  constexpr double mdl_g1 = mdl_ee / mdl_cw;
-  constexpr double mdl_gw = mdl_ee / mdl_sw;
-  constexpr double mdl_vev = ( 2. * mdl_MW * mdl_sw ) / mdl_ee;
-  constexpr double mdl_vev__exp__2 = ( ( mdl_vev ) * ( mdl_vev ) );
-  constexpr double mdl_lam = mdl_MH__exp__2 / ( 2. * mdl_vev__exp__2 );
-  constexpr double mdl_yb = ( mdl_ymb * mdl_sqrt__2 ) / mdl_vev;
-  constexpr double mdl_yt = ( mdl_ymt * mdl_sqrt__2 ) / mdl_vev;
-  constexpr double mdl_ytau = ( mdl_ymtau * mdl_sqrt__2 ) / mdl_vev;
-  constexpr double mdl_muH = constexpr_sqrt( mdl_lam * mdl_vev__exp__2 );
-  constexpr cxsmpl<double> mdl_I1x33 = mdl_yb * mdl_conjg__CKM3x3;
-  constexpr cxsmpl<double> mdl_I2x33 = mdl_yt * mdl_conjg__CKM3x3;
-  constexpr cxsmpl<double> mdl_I3x33 = mdl_CKM3x3 * mdl_yt;
-  constexpr cxsmpl<double> mdl_I4x33 = mdl_CKM3x3 * mdl_yb;
-  constexpr double mdl_ee__exp__2 = ( ( mdl_ee ) * ( mdl_ee ) );
-  constexpr double mdl_sw__exp__2 = ( ( mdl_sw ) * ( mdl_sw ) );
-  constexpr double mdl_cw__exp__2 = ( ( mdl_cw ) * ( mdl_cw ) );
-
-  // Model couplings independent of aS
-  // (none)
-
-  // Model parameters dependent on aS
-  //constexpr double mdl_sqrt__aS = //constexpr_sqrt( aS ); // now computed event-by-event (running alphas #373)
-  //constexpr double G = 2. * mdl_sqrt__aS * //constexpr_sqrt( M_PI ); // now computed event-by-event (running alphas #373)
-  //constexpr double mdl_G__exp__2 = ( ( G ) * ( G ) ); // now computed event-by-event (running alphas #373)
-
-  // Model couplings dependent on aS
-  //constexpr cxsmpl<double> GC_10 = -G; // now computed event-by-event (running alphas #373)
-  //constexpr cxsmpl<double> GC_11 = mdl_complexi * G; // now computed event-by-event (running alphas #373)
-
-  // Print parameters that are unchanged during the run
-  void printIndependentParameters();
-
-  // Print couplings that are unchanged during the run
-  void printIndependentCouplings();
-
-  // Print parameters that are changed event by event
-  //void printDependentParameters(); // now computed event-by-event (running alphas #373)
-
-  // Print couplings that are changed event by event
-  //void printDependentCouplings(); // now computed event-by-event (running alphas #373)
-}
 
 #endif
 
-//==========================================================================
+  //==========================================================================
 
-namespace Parameters_sm_dependentCouplings
-{
-  constexpr size_t ndcoup = 2; // #couplings that vary event by event because they depend on the running alphas QCD
-  constexpr size_t idcoup_GC_10 = 0;
-  constexpr size_t idcoup_GC_11 = 1;
-  struct DependentCouplings_sv
+  namespace Parameters_sm_dependentCouplings
   {
-    cxtype_sv GC_10;
-    cxtype_sv GC_11;
-  };
+    constexpr size_t ndcoup = 2; // #couplings that vary event by event because they depend on the running alphas QCD
+    constexpr size_t idcoup_GC_10 = 0;
+    constexpr size_t idcoup_GC_11 = 1;
+    struct DependentCouplings_sv
+    {
+      cxtype_sv GC_10;
+      cxtype_sv GC_11;
+    };
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"  // e.g. <<warning: unused variable ‘mdl_G__exp__2’ [-Wunused-variable]>>
 #pragma GCC diagnostic ignored "-Wunused-parameter" // e.g. <<warning: unused parameter ‘G’ [-Wunused-parameter]>>
@@ -215,76 +223,78 @@ namespace Parameters_sm_dependentCouplings
 #pragma nv_diagnostic push
 #pragma nv_diag_suppress 177 // e.g. <<warning #177-D: variable "mdl_G__exp__2" was declared but never referenced>>
 #endif
-  __host__ __device__ inline const DependentCouplings_sv computeDependentCouplings_fromG( const fptype_sv& G_sv )
-  {
-#ifdef MGONGPU_HARDCODE_PARAM
-    using namespace Parameters_sm;
-#endif
-    // NB: hardcode cxtype cI(0,1) instead of cxtype (or hardcoded cxsmpl) mdl_complexi (which exists in Parameters_sm) because:
-    // (1) mdl_complexi is always (0,1); (2) mdl_complexi is undefined in device code; (3) need cxsmpl conversion to cxtype in code below
-    const cxtype cI( 0., 1. );
-    DependentCouplings_sv out;
-    // Begin SM implementation - no special handling of vectors of floats as in EFT (#439)
+    __host__ __device__ inline const DependentCouplings_sv computeDependentCouplings_fromG( const fptype_sv& G_sv )
     {
-      const fptype_sv& G = G_sv;
-      // Model parameters dependent on aS
-      //const fptype_sv mdl_sqrt__aS = constexpr_sqrt( aS );
-      //const fptype_sv G = 2. * mdl_sqrt__aS * constexpr_sqrt( M_PI );
-      const fptype_sv mdl_G__exp__2 = ( ( G ) * ( G ) );
-      // Model couplings dependent on aS
-      out.GC_10 = -G;
-      out.GC_11 = cI * G;
+#ifdef MGONGPU_HARDCODE_PARAM
+      using namespace Parameters_sm;
+#endif
+      // NB: hardcode cxtype cI(0,1) instead of cxtype (or hardcoded cxsmpl) mdl_complexi (which exists in Parameters_sm) because:
+      // (1) mdl_complexi is always (0,1); (2) mdl_complexi is undefined in device code; (3) need cxsmpl conversion to cxtype in code below
+      const cxtype cI( 0., 1. );
+      DependentCouplings_sv out;
+      // Begin SM implementation - no special handling of vectors of floats as in EFT (#439)
+      {
+        const fptype_sv& G = G_sv;
+        // Model parameters dependent on aS
+        //const fptype_sv mdl_sqrt__aS = constexpr_sqrt( aS );
+        //const fptype_sv G = 2. * mdl_sqrt__aS * constexpr_sqrt( M_PI );
+        const fptype_sv mdl_G__exp__2 = ( ( G ) * ( G ) );
+        // Model couplings dependent on aS
+        out.GC_10 = -G;
+        out.GC_11 = cI * G;
+      }
+      // End SM implementation - no special handling of vectors of floats as in EFT (#439)
+      return out;
     }
-    // End SM implementation - no special handling of vectors of floats as in EFT (#439)
-    return out;
-  }
 #ifdef __CUDACC__
 #pragma GCC diagnostic pop
 #pragma nv_diagnostic pop
 #endif
-}
+  }
 
-//==========================================================================
+  //==========================================================================
 
-namespace Parameters_sm_independentCouplings
-{
-  constexpr size_t nicoup = 0; // #couplings that are fixed for all events because they do not depend on the running alphas QCD
-  // NB: there are no aS-independent couplings in this physics process
-}
+  namespace Parameters_sm_independentCouplings
+  {
+    constexpr size_t nicoup = 0; // #couplings that are fixed for all events because they do not depend on the running alphas QCD
+    // NB: there are no aS-independent couplings in this physics process
+  }
 
-//==========================================================================
+  //==========================================================================
 
 #ifdef __CUDACC__
-namespace mg5amcGpu
+  namespace mg5amcGpu
 #else
-namespace mg5amcCpu
+  namespace mg5amcCpu
 #endif
-{
+  {
 #pragma GCC diagnostic push
 #ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable" // e.g. <<warning: variable ‘couplings_sv’ set but not used [-Wunused-but-set-variable]>>
 #endif
-  // Compute the output couplings (e.g. gc10 and gc11) from the input gs
-  template<class G_ACCESS, class C_ACCESS>
-  __device__ inline void
-  G2COUP( const fptype gs[],
-          fptype couplings[] )
-  {
-    mgDebug( 0, __FUNCTION__ );
-    using namespace Parameters_sm_dependentCouplings;
-    const fptype_sv& gs_sv = G_ACCESS::kernelAccessConst( gs );
-    DependentCouplings_sv couplings_sv = computeDependentCouplings_fromG( gs_sv );
-    fptype* GC_10s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_10 );
-    fptype* GC_11s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_11 );
-    cxtype_sv_ref GC_10s_sv = C_ACCESS::kernelAccess( GC_10s );
-    cxtype_sv_ref GC_11s_sv = C_ACCESS::kernelAccess( GC_11s );
-    GC_10s_sv = couplings_sv.GC_10;
-    GC_11s_sv = couplings_sv.GC_11;
-    mgDebug( 1, __FUNCTION__ );
-    return;
-  }
+    // Compute the output couplings (e.g. gc10 and gc11) from the input gs
+    template<class G_ACCESS, class C_ACCESS>
+    __device__ inline void
+    G2COUP( const fptype gs[],
+            fptype couplings[] )
+    {
+      mgDebug( 0, __FUNCTION__ );
+      using namespace Parameters_sm_dependentCouplings;
+      const fptype_sv& gs_sv = G_ACCESS::kernelAccessConst( gs );
+      DependentCouplings_sv couplings_sv = computeDependentCouplings_fromG( gs_sv );
+      fptype* GC_10s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_10 );
+      fptype* GC_11s = C_ACCESS::idcoupAccessBuffer( couplings, idcoup_GC_11 );
+      cxtype_sv_ref GC_10s_sv = C_ACCESS::kernelAccess( GC_10s );
+      cxtype_sv_ref GC_11s_sv = C_ACCESS::kernelAccess( GC_11s );
+      GC_10s_sv = couplings_sv.GC_10;
+      GC_11s_sv = couplings_sv.GC_11;
+      mgDebug( 1, __FUNCTION__ );
+      return;
+    }
 #pragma GCC diagnostic pop
-}
+  }
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 //==========================================================================
 

--- a/epochX/cudacpp/gg_tt.sa/src/cudacpp_src.mk
+++ b/epochX/cudacpp/gg_tt.sa/src/cudacpp_src.mk
@@ -38,7 +38,13 @@ endif
 
 #-------------------------------------------------------------------------------
 
-#=== Configure ccache for CUDA and C++ builds
+#=== Configure the CUDA compiler (note: NVCC is already exported including ccache)
+
+###$(info NVCC=$(NVCC))
+
+#-------------------------------------------------------------------------------
+
+#=== Configure ccache for C++ builds (note: NVCC is already exported including ccache)
 
 # Enable ccache if USECCACHE=1
 ifeq ($(USECCACHE)$(shell echo $(CXX) | grep ccache),1)
@@ -46,11 +52,6 @@ ifeq ($(USECCACHE)$(shell echo $(CXX) | grep ccache),1)
 endif
 #ifeq ($(USECCACHE)$(shell echo $(AR) | grep ccache),1)
 #  override AR:=ccache $(AR)
-#endif
-#ifneq ($(NVCC),)
-#  ifeq ($(USECCACHE)$(shell echo $(NVCC) | grep ccache),1)
-#    override NVCC:=ccache $(NVCC)
-#  endif
 #endif
 
 #-------------------------------------------------------------------------------
@@ -238,16 +239,30 @@ $(LIBDIR)/.build.$(TAG):
 # Generic target and build rules: objects from C++ compilation
 $(BUILDDIR)/%.o : %.cc *.h $(BUILDDIR)/.build.$(TAG)
 	@if [ ! -d $(BUILDDIR) ]; then mkdir -p $(BUILDDIR); fi
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fPIC -c $< -o $@
+
+# Generic target and build rules: objects from C++ compilation
+$(BUILDDIR)/%.o : %.cu *.h $(BUILDDIR)/.build.$(TAG)
+	@if [ ! -d $(BUILDDIR) ]; then mkdir -p $(BUILDDIR); fi
+	$(NVCC) $(CPPFLAGS) $(CUFLAGS) -Xcompiler -fPIC -c $< -o $@
 
 #-------------------------------------------------------------------------------
 
 cxx_objects=$(addprefix $(BUILDDIR)/, Parameters_sm.o read_slha.o)
+ifneq ($(NVCC),)
+cu_objects=$(addprefix $(BUILDDIR)/, gParameters_sm.o)
+endif
 
 # Target (and build rules): common (src) library
+ifneq ($(NVCC),)
+$(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects) $(cu_objects)
+	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi
+	$(NVCC) -shared -o $@ $(cxx_objects) $(cu_objects)
+else
 $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects)
 	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi
-	$(CXX) -shared -o$@ $(cxx_objects)
+	$(CXX) -shared -o $@ $(cxx_objects)
+endif
 
 #-------------------------------------------------------------------------------
 

--- a/epochX/cudacpp/gg_tt.sa/src/gParameters_sm.cu
+++ b/epochX/cudacpp/gg_tt.sa/src/gParameters_sm.cu
@@ -1,0 +1,1 @@
+Parameters_sm.cc

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuConfig.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuConfig.h
@@ -98,6 +98,7 @@
 #endif
 #endif
 
+// NB: namespace mgOnGpu includes types which are defined in exactly the same way for CPU and GPU builds (see #318 and #725)
 namespace mgOnGpu
 {
 

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -89,7 +89,7 @@ namespace mg5amcCpu
 #endif
 {
   template<typename FP>
-  inline __host__ __device__ std::ostream&
+  inline __host__ std::ostream&
   operator<<( std::ostream& out, const cxsmpl<FP>& c )
   {
     out << std::complex( c.real(), c.imag() );

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -46,6 +46,9 @@
 // NB: namespace mgOnGpu includes types which are defined in exactly the same way for CPU and GPU builds (see #318 and #725)
 namespace mgOnGpu /* clang-format off */
 {
+  // The number of floating point types in a complex type (real, imaginary)
+  constexpr int nx2 = 2;
+
   // --- Type definition (simple complex type derived from cxtype_v)
   template<typename FP>
   class cxsmpl
@@ -234,11 +237,8 @@ namespace mg5amcCpu
 #endif
 #endif
 
-  // The number of floating point types in a complex type (real, imaginary)
-  constexpr int nx2 = 2;
-
   // SANITY CHECK: memory access may be based on casts of fptype[2] to cxtype (e.g. for wavefunctions)
-  static_assert( sizeof( cxtype ) == nx2 * sizeof( fptype ), "sizeof(cxtype) is not 2*sizeof(fptype)" );
+  static_assert( sizeof( cxtype ) == mgOnGpu::nx2 * sizeof( fptype ), "sizeof(cxtype) is not 2*sizeof(fptype)" );
 }
 
 // DANGEROUS! this was mixing different cxtype definitions for CPU and GPU builds (see #318 and #725)

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -645,15 +645,16 @@ namespace mg5amcCpu
   private:
     fptype *m_preal, *m_pimag; // RI
   };
-}
 
-// Printout to stream for user defined types
-inline __host__ __device__ std::ostream&
-operator<<( std::ostream& out, const mgOnGpu::cxtype_ref& c )
-{
-  out << (cxtype)c;
-  return out;
-}
+  // Printout to stream for user defined types
+  inline __host__ __device__ std::ostream&
+  operator<<( std::ostream& out, const mgOnGpu::cxtype_ref& c )
+  {
+    out << (cxtype)c;
+    return out;
+  }
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 //==========================================================================
 

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -621,7 +621,12 @@ namespace mg5amcCpu
 // COMPLEX TYPES: WRAPPER OVER RI FLOATING POINT PAIR (cxtype_ref)
 //==========================================================================
 
-namespace mgOnGpu /* clang-format off */
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
   // The cxtype_ref class (a non-const reference to two fp variables) was originally designed for cxtype_v::operator[]
   // It used to be included in the code only when MGONGPU_HAS_CPPCXTYPEV_BRK (originally MGONGPU_HAS_CPPCXTYPE_REF) is defined
@@ -640,7 +645,7 @@ namespace mgOnGpu /* clang-format off */
   private:
     fptype *m_preal, *m_pimag; // RI
   };
-} /* clang-format on */
+}
 
 // Printout to stream for user defined types
 inline __host__ __device__ std::ostream&

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -242,370 +242,380 @@ namespace mg5amcCpu
 // COMPLEX TYPES: (PLATFORM-SPECIFIC) FUNCTIONS AND OPERATORS
 //==========================================================================
 
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
+{
+
 #if defined MGONGPU_CUCXTYPE_CXSMPL or defined MGONGPU_CPPCXTYPE_CXSMPL
 
-//------------------------------
-// CUDA or C++ - using cxsmpl
-//------------------------------
+  //------------------------------
+  // CUDA or C++ - using cxsmpl
+  //------------------------------
 
-inline __host__ __device__ cxtype
-cxmake( const fptype& r, const fptype& i )
-{
-  return cxtype( r, i ); // cxsmpl constructor
-}
+  inline __host__ __device__ cxtype
+  cxmake( const fptype& r, const fptype& i )
+  {
+    return cxtype( r, i ); // cxsmpl constructor
+  }
 
-inline __host__ __device__ fptype
-cxreal( const cxtype& c )
-{
-  return c.real(); // cxsmpl::real()
-}
+  inline __host__ __device__ fptype
+  cxreal( const cxtype& c )
+  {
+    return c.real(); // cxsmpl::real()
+  }
 
-inline __host__ __device__ fptype
-cximag( const cxtype& c )
-{
-  return c.imag(); // cxsmpl::imag()
-}
+  inline __host__ __device__ fptype
+  cximag( const cxtype& c )
+  {
+    return c.imag(); // cxsmpl::imag()
+  }
 
-inline __host__ __device__ cxtype
-cxconj( const cxtype& c )
-{
-  return conj( c ); // conj( cxsmpl )
-}
+  inline __host__ __device__ cxtype
+  cxconj( const cxtype& c )
+  {
+    return conj( c ); // conj( cxsmpl )
+  }
 
-inline __host__ cxtype                 // NOT __device__
-cxmake( const std::complex<float>& c ) // std::complex to cxsmpl (float-to-float or float-to-double)
-{
-  return cxmake( c.real(), c.imag() );
-}
+  inline __host__ cxtype                 // NOT __device__
+  cxmake( const std::complex<float>& c ) // std::complex to cxsmpl (float-to-float or float-to-double)
+  {
+    return cxmake( c.real(), c.imag() );
+  }
 
-inline __host__ cxtype                  // NOT __device__
-cxmake( const std::complex<double>& c ) // std::complex to cxsmpl (double-to-float or double-to-double)
-{
-  return cxmake( c.real(), c.imag() );
-}
+  inline __host__ cxtype                  // NOT __device__
+  cxmake( const std::complex<double>& c ) // std::complex to cxsmpl (double-to-float or double-to-double)
+  {
+    return cxmake( c.real(), c.imag() );
+  }
 
 #endif // #if defined MGONGPU_CUCXTYPE_CXSMPL or defined MGONGPU_CPPCXTYPE_CXSMPL
 
-//==========================================================================
+  //==========================================================================
 
 #if defined __CUDACC__ and defined MGONGPU_CUCXTYPE_THRUST // cuda + thrust
 
-//------------------------------
-// CUDA - using thrust::complex
-//------------------------------
+  //------------------------------
+  // CUDA - using thrust::complex
+  //------------------------------
 
-inline __host__ __device__ cxtype
-cxmake( const fptype& r, const fptype& i )
-{
-  return cxtype( r, i ); // thrust::complex<fptype> constructor
-}
+  inline __host__ __device__ cxtype
+  cxmake( const fptype& r, const fptype& i )
+  {
+    return cxtype( r, i ); // thrust::complex<fptype> constructor
+  }
 
-inline __host__ __device__ fptype
-cxreal( const cxtype& c )
-{
-  return c.real(); // thrust::complex<fptype>::real()
-}
+  inline __host__ __device__ fptype
+  cxreal( const cxtype& c )
+  {
+    return c.real(); // thrust::complex<fptype>::real()
+  }
 
-inline __host__ __device__ fptype
-cximag( const cxtype& c )
-{
-  return c.imag(); // thrust::complex<fptype>::imag()
-}
+  inline __host__ __device__ fptype
+  cximag( const cxtype& c )
+  {
+    return c.imag(); // thrust::complex<fptype>::imag()
+  }
 
-inline __host__ __device__ cxtype
-cxconj( const cxtype& c )
-{
-  return conj( c ); // conj( thrust::complex<fptype> )
-}
+  inline __host__ __device__ cxtype
+  cxconj( const cxtype& c )
+  {
+    return conj( c ); // conj( thrust::complex<fptype> )
+  }
 
-inline __host__ __device__ const cxtype&
-cxmake( const cxtype& c )
-{
-  return c;
-}
+  inline __host__ __device__ const cxtype&
+  cxmake( const cxtype& c )
+  {
+    return c;
+  }
 
 #endif // #if defined __CUDACC__ and defined MGONGPU_CUCXTYPE_THRUST
 
-//==========================================================================
+  //==========================================================================
 
 #if defined __CUDACC__ and defined MGONGPU_CUCXTYPE_CUCOMPLEX // cuda + cucomplex
 
-//------------------------------
-// CUDA - using cuComplex
-//------------------------------
+  //------------------------------
+  // CUDA - using cuComplex
+  //------------------------------
 
 #if defined MGONGPU_FPTYPE_DOUBLE // cuda + cucomplex + double
 
-//+++++++++++++++++++++++++
-// cuDoubleComplex ONLY
-//+++++++++++++++++++++++++
+  //+++++++++++++++++++++++++
+  // cuDoubleComplex ONLY
+  //+++++++++++++++++++++++++
 
-inline __host__ __device__ cxtype
-cxmake( const fptype& r, const fptype& i )
-{
-  return make_cuDoubleComplex( r, i );
-}
+  inline __host__ __device__ cxtype
+  cxmake( const fptype& r, const fptype& i )
+  {
+    return make_cuDoubleComplex( r, i );
+  }
 
-inline __host__ __device__ fptype
-cxreal( const cxtype& c )
-{
-  return cuCreal( c ); // returns by value
-}
+  inline __host__ __device__ fptype
+  cxreal( const cxtype& c )
+  {
+    return cuCreal( c ); // returns by value
+  }
 
-inline __host__ __device__ fptype
-cximag( const cxtype& c )
-{
-  return cuCimag( c ); // returns by value
-}
+  inline __host__ __device__ fptype
+  cximag( const cxtype& c )
+  {
+    return cuCimag( c ); // returns by value
+  }
 
-inline __host__ __device__ cxtype
-operator+( const cxtype& a, const cxtype& b )
-{
-  return cuCadd( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator+( const cxtype& a, const cxtype& b )
+  {
+    return cuCadd( a, b );
+  }
 
-inline __host__ __device__ cxtype&
-operator+=( cxtype& a, const cxtype& b )
-{
-  a = cuCadd( a, b );
-  return a;
-}
+  inline __host__ __device__ cxtype&
+  operator+=( cxtype& a, const cxtype& b )
+  {
+    a = cuCadd( a, b );
+    return a;
+  }
 
-inline __host__ __device__ cxtype
-operator-( const cxtype& a, const cxtype& b )
-{
-  return cuCsub( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator-( const cxtype& a, const cxtype& b )
+  {
+    return cuCsub( a, b );
+  }
 
-inline __host__ __device__ cxtype&
-operator-=( cxtype& a, const cxtype& b )
-{
-  a = cuCsub( a, b );
-  return a;
-}
+  inline __host__ __device__ cxtype&
+  operator-=( cxtype& a, const cxtype& b )
+  {
+    a = cuCsub( a, b );
+    return a;
+  }
 
-inline __host__ __device__ cxtype
-operator*( const cxtype& a, const cxtype& b )
-{
-  return cuCmul( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator*( const cxtype& a, const cxtype& b )
+  {
+    return cuCmul( a, b );
+  }
 
-inline __host__ __device__ cxtype
-operator/( const cxtype& a, const cxtype& b )
-{
-  return cuCdiv( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator/( const cxtype& a, const cxtype& b )
+  {
+    return cuCdiv( a, b );
+  }
 
 #elif defined MGONGPU_FPTYPE_FLOAT // cuda + cucomplex + float
 
-//+++++++++++++++++++++++++
-// cuFloatComplex ONLY
-//+++++++++++++++++++++++++
+  //+++++++++++++++++++++++++
+  // cuFloatComplex ONLY
+  //+++++++++++++++++++++++++
 
-inline __host__ __device__ cxtype
-cxmake( const fptype& r, const fptype& i )
-{
-  return make_cuFloatComplex( r, i );
-}
+  inline __host__ __device__ cxtype
+  cxmake( const fptype& r, const fptype& i )
+  {
+    return make_cuFloatComplex( r, i );
+  }
 
-inline __host__ __device__ fptype
-cxreal( const cxtype& c )
-{
-  return cuCrealf( c ); // returns by value
-}
+  inline __host__ __device__ fptype
+  cxreal( const cxtype& c )
+  {
+    return cuCrealf( c ); // returns by value
+  }
 
-inline __host__ __device__ fptype
-cximag( const cxtype& c )
-{
-  return cuCimagf( c ); // returns by value
-}
+  inline __host__ __device__ fptype
+  cximag( const cxtype& c )
+  {
+    return cuCimagf( c ); // returns by value
+  }
 
-inline __host__ __device__ cxtype
-operator+( const cxtype& a, const cxtype& b )
-{
-  return cuCaddf( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator+( const cxtype& a, const cxtype& b )
+  {
+    return cuCaddf( a, b );
+  }
 
-inline __host__ __device__ cxtype&
-operator+=( cxtype& a, const cxtype& b )
-{
-  a = cuCaddf( a, b );
-  return a;
-}
+  inline __host__ __device__ cxtype&
+  operator+=( cxtype& a, const cxtype& b )
+  {
+    a = cuCaddf( a, b );
+    return a;
+  }
 
-inline __host__ __device__ cxtype
-operator-( const cxtype& a, const cxtype& b )
-{
-  return cuCsubf( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator-( const cxtype& a, const cxtype& b )
+  {
+    return cuCsubf( a, b );
+  }
 
-inline __host__ __device__ cxtype&
-operator-=( cxtype& a, const cxtype& b )
-{
-  a = cuCsubf( a, b );
-  return a;
-}
+  inline __host__ __device__ cxtype&
+  operator-=( cxtype& a, const cxtype& b )
+  {
+    a = cuCsubf( a, b );
+    return a;
+  }
 
-inline __host__ __device__ cxtype
-operator*( const cxtype& a, const cxtype& b )
-{
-  return cuCmulf( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator*( const cxtype& a, const cxtype& b )
+  {
+    return cuCmulf( a, b );
+  }
 
-inline __host__ __device__ cxtype
-operator/( const cxtype& a, const cxtype& b )
-{
-  return cuCdivf( a, b );
-}
+  inline __host__ __device__ cxtype
+  operator/( const cxtype& a, const cxtype& b )
+  {
+    return cuCdivf( a, b );
+  }
 
-inline __host__ cxtype                  // NOT __device__
-cxmake( const std::complex<double>& c ) // std::complex to cucomplex (cast double-to-float)
-{
-  return cxmake( (fptype)c.real(), (fptype)c.imag() );
-}
+  inline __host__ cxtype                  // NOT __device__
+  cxmake( const std::complex<double>& c ) // std::complex to cucomplex (cast double-to-float)
+  {
+    return cxmake( (fptype)c.real(), (fptype)c.imag() );
+  }
 
 #endif
 
-//+++++++++++++++++++++++++
-// cuDoubleComplex OR
-// cuFloatComplex
-//+++++++++++++++++++++++++
+  //+++++++++++++++++++++++++
+  // cuDoubleComplex OR
+  // cuFloatComplex
+  //+++++++++++++++++++++++++
 
-inline __host__ __device__ cxtype
-operator+( const cxtype a )
-{
-  return a;
-}
+  inline __host__ __device__ cxtype
+  operator+( const cxtype a )
+  {
+    return a;
+  }
 
-inline __host__ __device__ cxtype
-operator-( const cxtype& a )
-{
-  return cxmake( -cxreal( a ), -cximag( a ) );
-}
+  inline __host__ __device__ cxtype
+  operator-( const cxtype& a )
+  {
+    return cxmake( -cxreal( a ), -cximag( a ) );
+  }
 
-inline __host__ __device__ cxtype
-operator+( const fptype& a, const cxtype& b )
-{
-  return cxmake( a, 0 ) + b;
-}
+  inline __host__ __device__ cxtype
+  operator+( const fptype& a, const cxtype& b )
+  {
+    return cxmake( a, 0 ) + b;
+  }
 
-inline __host__ __device__ cxtype
-operator-( const fptype& a, const cxtype& b )
-{
-  return cxmake( a, 0 ) - b;
-}
+  inline __host__ __device__ cxtype
+  operator-( const fptype& a, const cxtype& b )
+  {
+    return cxmake( a, 0 ) - b;
+  }
 
-inline __host__ __device__ cxtype
-operator*( const fptype& a, const cxtype& b )
-{
-  return cxmake( a, 0 ) * b;
-}
+  inline __host__ __device__ cxtype
+  operator*( const fptype& a, const cxtype& b )
+  {
+    return cxmake( a, 0 ) * b;
+  }
 
-inline __host__ __device__ cxtype
-operator/( const fptype& a, const cxtype& b )
-{
-  return cxmake( a, 0 ) / b;
-}
+  inline __host__ __device__ cxtype
+  operator/( const fptype& a, const cxtype& b )
+  {
+    return cxmake( a, 0 ) / b;
+  }
 
-inline __host__ __device__ cxtype
-operator+( const cxtype& a, const fptype& b )
-{
-  return a + cxmake( b, 0 );
-}
+  inline __host__ __device__ cxtype
+  operator+( const cxtype& a, const fptype& b )
+  {
+    return a + cxmake( b, 0 );
+  }
 
-inline __host__ __device__ cxtype
-operator-( const cxtype& a, const fptype& b )
-{
-  return a - cxmake( b, 0 );
-}
+  inline __host__ __device__ cxtype
+  operator-( const cxtype& a, const fptype& b )
+  {
+    return a - cxmake( b, 0 );
+  }
 
-inline __host__ __device__ cxtype
-operator*( const cxtype& a, const fptype& b )
-{
-  return a * cxmake( b, 0 );
-}
+  inline __host__ __device__ cxtype
+  operator*( const cxtype& a, const fptype& b )
+  {
+    return a * cxmake( b, 0 );
+  }
 
-inline __host__ __device__ cxtype
-operator/( const cxtype& a, const fptype& b )
-{
-  return a / cxmake( b, 0 );
-}
+  inline __host__ __device__ cxtype
+  operator/( const cxtype& a, const fptype& b )
+  {
+    return a / cxmake( b, 0 );
+  }
 
-inline __host__ __device__ cxtype
-cxconj( const cxtype& c )
-{
-  return cxmake( cxreal( c ), -cximag( c ) );
-}
+  inline __host__ __device__ cxtype
+  cxconj( const cxtype& c )
+  {
+    return cxmake( cxreal( c ), -cximag( c ) );
+  }
 
-inline __host__ cxtype                  // NOT __device__
-cxmake( const std::complex<fptype>& c ) // std::complex to cucomplex (float-to-float or double-to-double)
-{
-  return cxmake( c.real(), c.imag() );
-}
+  inline __host__ cxtype                  // NOT __device__
+  cxmake( const std::complex<fptype>& c ) // std::complex to cucomplex (float-to-float or double-to-double)
+  {
+    return cxmake( c.real(), c.imag() );
+  }
 
 #endif // #if defined __CUDACC__ and defined MGONGPU_CUCXTYPE_CUCOMPLEX
 
-//==========================================================================
+  //==========================================================================
 
 #if not defined __CUDACC__ and defined MGONGPU_CPPCXTYPE_STDCOMPLEX // c++ + stdcomplex
 
-//------------------------------
-// C++ - using std::complex
-//------------------------------
+  //------------------------------
+  // C++ - using std::complex
+  //------------------------------
 
-inline cxtype
-cxmake( const fptype& r, const fptype& i )
-{
-  return cxtype( r, i ); // std::complex<fptype> constructor
-}
+  inline cxtype
+  cxmake( const fptype& r, const fptype& i )
+  {
+    return cxtype( r, i ); // std::complex<fptype> constructor
+  }
 
-inline fptype
-cxreal( const cxtype& c )
-{
-  return c.real(); // std::complex<fptype>::real()
-}
+  inline fptype
+  cxreal( const cxtype& c )
+  {
+    return c.real(); // std::complex<fptype>::real()
+  }
 
-inline fptype
-cximag( const cxtype& c )
-{
-  return c.imag(); // std::complex<fptype>::imag()
-}
+  inline fptype
+  cximag( const cxtype& c )
+  {
+    return c.imag(); // std::complex<fptype>::imag()
+  }
 
-inline cxtype
-cxconj( const cxtype& c )
-{
-  return conj( c ); // conj( std::complex<fptype> )
-}
+  inline cxtype
+  cxconj( const cxtype& c )
+  {
+    return conj( c ); // conj( std::complex<fptype> )
+  }
 
-inline const cxtype&
-cxmake( const cxtype& c ) // std::complex to std::complex (float-to-float or double-to-double)
-{
-  return c;
-}
+  inline const cxtype&
+  cxmake( const cxtype& c ) // std::complex to std::complex (float-to-float or double-to-double)
+  {
+    return c;
+  }
 
 #if defined MGONGPU_FPTYPE_FLOAT
-inline cxtype
-cxmake( const std::complex<double>& c ) // std::complex to std::complex (cast double-to-float)
-{
-  return cxmake( (fptype)c.real(), (fptype)c.imag() );
-}
+  inline cxtype
+  cxmake( const std::complex<double>& c ) // std::complex to std::complex (cast double-to-float)
+  {
+    return cxmake( (fptype)c.real(), (fptype)c.imag() );
+  }
 #endif
 
 #endif // #if not defined __CUDACC__ and defined MGONGPU_CPPCXTYPE_STDCOMPLEX
 
-//==========================================================================
+  //==========================================================================
 
-inline __host__ __device__ const cxtype
-cxmake( const cxsmpl<float>& c ) // cxsmpl to cxtype (float-to-float or float-to-double)
-{
-  return cxmake( c.real(), c.imag() );
-}
+  inline __host__ __device__ const cxtype
+  cxmake( const cxsmpl<float>& c ) // cxsmpl to cxtype (float-to-float or float-to-double)
+  {
+    return cxmake( c.real(), c.imag() );
+  }
 
-inline __host__ __device__ const cxtype
-cxmake( const cxsmpl<double>& c ) // cxsmpl to cxtype (double-to-float or double-to-double)
-{
-  return cxmake( c.real(), c.imag() );
-}
+  inline __host__ __device__ const cxtype
+  cxmake( const cxsmpl<double>& c ) // cxsmpl to cxtype (double-to-float or double-to-double)
+  {
+    return cxmake( c.real(), c.imag() );
+  }
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 //==========================================================================
 // COMPLEX TYPES: WRAPPER OVER RI FLOATING POINT PAIR (cxtype_ref)

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -79,12 +79,19 @@ namespace mgOnGpu /* clang-format off */
 using mgOnGpu::cxsmpl;
 
 // Printout to stream for user defined types
-template<typename FP>
-inline __host__ __device__ std::ostream&
-operator<<( std::ostream& out, const cxsmpl<FP>& c )
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
-  out << std::complex( c.real(), c.imag() );
-  return out;
+  template<typename FP>
+  inline __host__ __device__ std::ostream&
+  operator<<( std::ostream& out, const cxsmpl<FP>& c )
+  {
+    out << std::complex( c.real(), c.imag() );
+    return out;
+  }
 }
 
 // Operators for cxsmpl

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -95,113 +95,114 @@ namespace mg5amcCpu
     out << std::complex( c.real(), c.imag() );
     return out;
   }
-}
 
-// Operators for cxsmpl
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator+( const cxsmpl<FP> a )
-{
-  return a;
-}
+  // Operators for cxsmpl
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator+( const cxsmpl<FP> a )
+  {
+    return a;
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator-( const cxsmpl<FP>& a )
-{
-  return cxsmpl<FP>( -a.real(), -a.imag() );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator-( const cxsmpl<FP>& a )
+  {
+    return cxsmpl<FP>( -a.real(), -a.imag() );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator+( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a.real() + b.real(), a.imag() + b.imag() );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator+( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a.real() + b.real(), a.imag() + b.imag() );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator+( const FP& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a, 0 ) + b;
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator+( const FP& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a, 0 ) + b;
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator-( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a.real() - b.real(), a.imag() - b.imag() );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator-( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a.real() - b.real(), a.imag() - b.imag() );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator-( const FP& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a, 0 ) - b;
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator-( const FP& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a, 0 ) - b;
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator*( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator*( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator*( const FP& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a, 0 ) * b;
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator*( const FP& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a, 0 ) * b;
+  }
 
-inline __host__ __device__ constexpr cxsmpl<float>
-operator*( const double& a, const cxsmpl<float>& b )
-{
-  return cxsmpl<float>( a, 0 ) * b;
-}
+  inline __host__ __device__ constexpr cxsmpl<float>
+  operator*( const double& a, const cxsmpl<float>& b )
+  {
+    return cxsmpl<float>( a, 0 ) * b;
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator/( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
-{
-  FP bnorm = b.real() * b.real() + b.imag() * b.imag();
-  return cxsmpl<FP>( ( a.real() * b.real() + a.imag() * b.imag() ) / bnorm,
-                     ( a.imag() * b.real() - a.real() * b.imag() ) / bnorm );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator/( const cxsmpl<FP>& a, const cxsmpl<FP>& b )
+  {
+    FP bnorm = b.real() * b.real() + b.imag() * b.imag();
+    return cxsmpl<FP>( ( a.real() * b.real() + a.imag() * b.imag() ) / bnorm,
+                       ( a.imag() * b.real() - a.real() * b.imag() ) / bnorm );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator/( const FP& a, const cxsmpl<FP>& b )
-{
-  return cxsmpl<FP>( a, 0 ) / b;
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator/( const FP& a, const cxsmpl<FP>& b )
+  {
+    return cxsmpl<FP>( a, 0 ) / b;
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator+( const cxsmpl<FP>& a, const FP& b )
-{
-  return a + cxsmpl<FP>( b, 0 );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator+( const cxsmpl<FP>& a, const FP& b )
+  {
+    return a + cxsmpl<FP>( b, 0 );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator-( const cxsmpl<FP>& a, const FP& b )
-{
-  return a - cxsmpl<FP>( b, 0 );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator-( const cxsmpl<FP>& a, const FP& b )
+  {
+    return a - cxsmpl<FP>( b, 0 );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator*( const cxsmpl<FP>& a, const FP& b )
-{
-  return a * cxsmpl<FP>( b, 0 );
-}
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator*( const cxsmpl<FP>& a, const FP& b )
+  {
+    return a * cxsmpl<FP>( b, 0 );
+  }
 
-template<typename FP>
-inline __host__ __device__ constexpr cxsmpl<FP>
-operator/( const cxsmpl<FP>& a, const FP& b )
-{
-  return a / cxsmpl<FP>( b, 0 );
+  template<typename FP>
+  inline __host__ __device__ constexpr cxsmpl<FP>
+  operator/( const cxsmpl<FP>& a, const FP& b )
+  {
+    return a / cxsmpl<FP>( b, 0 );
+  }
+
 }
 
 //==========================================================================
@@ -215,7 +216,6 @@ namespace mg5amcGpu
 namespace mg5amcCpu
 #endif
 {
-
   // --- Type definitions (complex type: cxtype)
 #ifdef __CUDACC__ // cuda
 #if defined MGONGPU_CUCXTYPE_THRUST

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -43,6 +43,7 @@
 // COMPLEX TYPES: SIMPLE COMPLEX CLASS (cxsmpl)
 //==========================================================================
 
+// NB: namespace mgOnGpu includes types which are defined in exactly the same way for CPU and GPU builds (see #318 and #725)
 namespace mgOnGpu /* clang-format off */
 {
   // --- Type definition (simple complex type derived from cxtype_v)
@@ -197,7 +198,12 @@ operator/( const cxsmpl<FP>& a, const FP& b )
 // COMPLEX TYPES: (PLATFORM-SPECIFIC) TYPEDEFS
 //==========================================================================
 
-namespace mgOnGpu
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
 
   // --- Type definitions (complex type: cxtype)
@@ -228,8 +234,9 @@ namespace mgOnGpu
   static_assert( sizeof( cxtype ) == nx2 * sizeof( fptype ), "sizeof(cxtype) is not 2*sizeof(fptype)" );
 }
 
-// Expose typedefs and operators outside the namespace
-using mgOnGpu::cxtype;
+// DANGEROUS! this was mixing different cxtype definitions for CPU and GPU builds (see #318 and #725)
+// DO NOT expose typedefs and operators outside the namespace
+//using mgOnGpu::cxtype;
 
 //==========================================================================
 // COMPLEX TYPES: (PLATFORM-SPECIFIC) FUNCTIONS AND OPERATORS

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuCxtypes.h
@@ -648,7 +648,7 @@ namespace mg5amcCpu
 
   // Printout to stream for user defined types
   inline __host__ __device__ std::ostream&
-  operator<<( std::ostream& out, const mgOnGpu::cxtype_ref& c )
+  operator<<( std::ostream& out, const cxtype_ref& c )
   {
     out << (cxtype)c;
     return out;

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuFptypes.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuFptypes.h
@@ -11,82 +11,92 @@
 #include <algorithm>
 #include <cmath>
 
-//==========================================================================
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
+{
+
+  //==========================================================================
 
 #ifdef __CUDACC__ // cuda
 
-//------------------------------
-// Floating point types - Cuda
-//------------------------------
+  //------------------------------
+  // Floating point types - Cuda
+  //------------------------------
 
-/*
-inline __host__ __device__ fptype
-fpmax( const fptype& a, const fptype& b )
-{
-  return max( a, b );
-}
+  /*
+  inline __host__ __device__ fptype
+  fpmax( const fptype& a, const fptype& b )
+  {
+    return max( a, b );
+  }
 
-inline __host__ __device__ fptype
-fpmin( const fptype& a, const fptype& b )
-{
-  return min( a, b );
-}
-*/
+  inline __host__ __device__ fptype
+  fpmin( const fptype& a, const fptype& b )
+  {
+    return min( a, b );
+  }
+  */
 
-inline __host__ __device__ const fptype&
-fpmax( const fptype& a, const fptype& b )
-{
-  return ( ( b < a ) ? a : b );
-}
+  inline __host__ __device__ const fptype&
+  fpmax( const fptype& a, const fptype& b )
+  {
+    return ( ( b < a ) ? a : b );
+  }
 
-inline __host__ __device__ const fptype&
-fpmin( const fptype& a, const fptype& b )
-{
-  return ( ( a < b ) ? a : b );
-}
+  inline __host__ __device__ const fptype&
+  fpmin( const fptype& a, const fptype& b )
+  {
+    return ( ( a < b ) ? a : b );
+  }
 
-inline __host__ __device__ fptype
-fpsqrt( const fptype& f )
-{
+  inline __host__ __device__ fptype
+  fpsqrt( const fptype& f )
+  {
 #if defined MGONGPU_FPTYPE_FLOAT
-  // See https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html
-  return sqrtf( f );
+    // See https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html
+    return sqrtf( f );
 #else
-  // See https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html
-  return sqrt( f );
+    // See https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html
+    return sqrt( f );
 #endif
-}
+  }
 
 #endif // #ifdef __CUDACC__
 
-//==========================================================================
+  //==========================================================================
 
 #ifndef __CUDACC__
 
-//------------------------------
-// Floating point types - C++
-//------------------------------
+  //------------------------------
+  // Floating point types - C++
+  //------------------------------
 
-inline const fptype&
-fpmax( const fptype& a, const fptype& b )
-{
-  return std::max( a, b );
-}
+  inline const fptype&
+  fpmax( const fptype& a, const fptype& b )
+  {
+    return std::max( a, b );
+  }
 
-inline const fptype&
-fpmin( const fptype& a, const fptype& b )
-{
-  return std::min( a, b );
-}
+  inline const fptype&
+  fpmin( const fptype& a, const fptype& b )
+  {
+    return std::min( a, b );
+  }
 
-inline fptype
-fpsqrt( const fptype& f )
-{
-  return std::sqrt( f );
-}
+  inline fptype
+  fpsqrt( const fptype& f )
+  {
+    return std::sqrt( f );
+  }
 
 #endif // #ifndef __CUDACC__
 
-//==========================================================================
+  //==========================================================================
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MGONGPUFPTYPES_H

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
@@ -827,19 +827,19 @@ namespace mg5amcCpu
   typedef fptype fptype_sv;
   typedef fptype2 fptype2_sv;
   typedef cxtype cxtype_sv;
-  typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
+  typedef cxtype_ref cxtype_sv_ref;
 #elif defined MGONGPU_CPPSIMD
   typedef bool_v bool_sv;
   typedef fptype_v fptype_sv;
   typedef fptype2_v fptype2_sv;
   typedef cxtype_v cxtype_sv;
-  typedef mgOnGpu::cxtype_v_ref cxtype_sv_ref;
+  typedef cxtype_v_ref cxtype_sv_ref;
 #else
   typedef bool bool_sv;
   typedef fptype fptype_sv;
   typedef fptype2 fptype2_sv;
   typedef cxtype cxtype_sv;
-  typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
+  typedef cxtype_ref cxtype_sv_ref;
 #endif
 
   // Scalar-or-vector zeros: scalar in CUDA, vector or scalar in C++

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
@@ -564,6 +564,14 @@ maskor( const bool_v& mask )
 }
 */
 
+inline bool
+maskand( const bool_v& mask )
+{
+  bool out = true;
+  for ( int i=0; i<neppV; i++ ) out = out && mask[i];
+  return out;
+}
+
 #else // i.e. #ifndef MGONGPU_CPPSIMD
 
 inline fptype
@@ -585,6 +593,12 @@ maskor( const bool& mask )
   return mask;
 }
 */
+
+inline bool
+maskand( const bool& mask )
+{
+  return mask;
+}
 
 #endif // #ifdef MGONGPU_CPPSIMD
 

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
@@ -800,6 +800,12 @@ cxternary( const bool& mask, const cxtype& a, const cxtype& b )
   return ( mask ? a : b );
 }
 
+inline __host__ __device__ bool
+maskand( const bool& mask )
+{
+  return mask;
+}
+
 #endif // #ifdef __CUDACC__
 
 //==========================================================================

--- a/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
+++ b/epochX/cudacpp/gg_tt.sa/src/mgOnGpuVectors.h
@@ -31,7 +31,12 @@
 //#undef MGONGPU_HAS_CPPCXTYPEV_BRK // gcc test (very slightly slower? issue #172)
 #endif
 
-namespace mgOnGpu /* clang-format off */
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
+#endif
 {
 #ifdef MGONGPU_CPPSIMD
 
@@ -114,545 +119,552 @@ namespace mgOnGpu /* clang-format off */
 
 #endif // #ifdef MGONGPU_CPPSIMD
 
-} /* clang-format on */
+}
 
 //--------------------------------------------------------------------------
 
-// Expose typedefs outside the namespace
-using mgOnGpu::neppV;
-#ifdef MGONGPU_CPPSIMD
-using mgOnGpu::fptype_v;
-using mgOnGpu::fptype2_v;
-using mgOnGpu::cxtype_v;
-using mgOnGpu::bool_v;
+// DANGEROUS! this was mixing different cxtype definitions for CPU and GPU builds (see #318 and #725)
+// DO NOT expose typedefs outside the namespace
+//using mgOnGpu::neppV;
+//#ifdef MGONGPU_CPPSIMD
+//using mgOnGpu::fptype_v;
+//using mgOnGpu::fptype2_v;
+//using mgOnGpu::cxtype_v;
+//using mgOnGpu::bool_v;
+//#endif
+
+//==========================================================================
+
+// NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
+#ifdef __CUDACC__
+namespace mg5amcGpu
+#else
+namespace mg5amcCpu
 #endif
-
-//--------------------------------------------------------------------------
+{
 
 #ifndef __CUDACC__
 
-// Printout to stream for user defined types
+  // Printout to stream for user defined types
 
 #ifndef MGONGPU_CPPCXTYPE_CXSMPL // operator<< for cxsmpl has already been defined!
-inline std::ostream&
-operator<<( std::ostream& out, const cxtype& c )
-{
-  out << "[" << cxreal( c ) << "," << cximag( c ) << "]";
-  //out << cxreal(c) << "+i" << cximag(c);
-  return out;
-}
+  inline std::ostream&
+  operator<<( std::ostream& out, const cxtype& c )
+  {
+    out << "[" << cxreal( c ) << "," << cximag( c ) << "]";
+    //out << cxreal(c) << "+i" << cximag(c);
+    return out;
+  }
 #endif
 
-/*
+  /*
 #ifdef MGONGPU_CPPSIMD
-inline std::ostream&
-operator<<( std::ostream& out, const bool_v& v )
-{
-  out << "{ " << v[0];
-  for ( int i=1; i<neppV; i++ ) out << ", " << (bool)(v[i]);
-  out << " }";
-  return out;
-}
+  inline std::ostream&
+  operator<<( std::ostream& out, const bool_v& v )
+  {
+    out << "{ " << v[0];
+    for ( int i=1; i<neppV; i++ ) out << ", " << (bool)(v[i]);
+    out << " }";
+    return out;
+  }
 #endif
-*/
+  */
 
 #ifdef MGONGPU_CPPSIMD
-inline std::ostream&
-operator<<( std::ostream& out, const fptype_v& v )
-{
-  out << "{ " << v[0];
-  for( int i = 1; i < neppV; i++ ) out << ", " << v[i];
-  out << " }";
-  return out;
-}
+  inline std::ostream&
+  operator<<( std::ostream& out, const fptype_v& v )
+  {
+    out << "{ " << v[0];
+    for( int i = 1; i < neppV; i++ ) out << ", " << v[i];
+    out << " }";
+    return out;
+  }
 #endif
 
 #ifdef MGONGPU_CPPSIMD
-inline std::ostream&
-operator<<( std::ostream& out, const cxtype_v& v )
-{
+  inline std::ostream&
+  operator<<( std::ostream& out, const cxtype_v& v )
+  {
 #ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
-  out << "{ " << v[0];
-  for( int i = 1; i < neppV; i++ ) out << ", " << v[i];
+    out << "{ " << v[0];
+    for( int i = 1; i < neppV; i++ ) out << ", " << v[i];
 #else
-  out << "{ " << cxmake( v.real()[0], v.imag()[0] );
-  for( int i = 1; i < neppV; i++ ) out << ", " << cxmake( v.real()[i], v.imag()[i] );
+    out << "{ " << cxmake( v.real()[0], v.imag()[0] );
+    for( int i = 1; i < neppV; i++ ) out << ", " << cxmake( v.real()[i], v.imag()[i] );
 #endif
-  out << " }";
-  return out;
-}
+    out << " }";
+    return out;
+  }
 #endif
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-/*
-// Printout to std::cout for user defined types
+  /*
+  // Printout to std::cout for user defined types
 
-inline void print( const fptype& f ) { std::cout << f << std::endl; }
+  inline void print( const fptype& f ) { std::cout << f << std::endl; }
 
 #ifdef MGONGPU_CPPSIMD
-inline void print( const fptype_v& v ) { std::cout << v << std::endl; }
+  inline void print( const fptype_v& v ) { std::cout << v << std::endl; }
 #endif
 
-inline void print( const cxtype& c ) { std::cout << c << std::endl; }
+  inline void print( const cxtype& c ) { std::cout << c << std::endl; }
 
 #ifdef MGONGPU_CPPSIMD
-inline void print( const cxtype_v& v ) { std::cout << v << std::endl; }
+  inline void print( const cxtype_v& v ) { std::cout << v << std::endl; }
 #endif
-*/
+  */
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Functions and operators for fptype_v
+  // Functions and operators for fptype_v
 
 #ifdef MGONGPU_CPPSIMD
-inline fptype_v
-fpsqrt( const fptype_v& v )
-{
-  // See https://stackoverflow.com/questions/18921049/gcc-vector-extensions-sqrt
-  fptype_v out = {}; // avoid warning 'out' may be used uninitialized: see #594
-  for( int i = 0; i < neppV; i++ ) out[i] = fpsqrt( v[i] );
-  return out;
-}
+  inline fptype_v
+  fpsqrt( const fptype_v& v )
+  {
+    // See https://stackoverflow.com/questions/18921049/gcc-vector-extensions-sqrt
+    fptype_v out = {}; // avoid warning 'out' may be used uninitialized: see #594
+    for( int i = 0; i < neppV; i++ ) out[i] = fpsqrt( v[i] );
+    return out;
+  }
 #endif
 
-/*
+  /*
 #ifdef MGONGPU_CPPSIMD
-inline fptype_v
-fpvmake( const fptype v[neppV] )
-{
-  fptype_v out = {}; // see #594
-  for ( int i=0; i<neppV; i++ ) out[i] = v[i];
-  return out;
-}
+  inline fptype_v
+  fpvmake( const fptype v[neppV] )
+  {
+    fptype_v out = {}; // see #594
+    for ( int i=0; i<neppV; i++ ) out[i] = v[i];
+    return out;
+  }
 #endif
-*/
+  */
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Functions and operators for cxtype_v
+  // Functions and operators for cxtype_v
 
 #ifdef MGONGPU_CPPSIMD
 
-/*
-inline cxtype_v
-cxvmake( const cxtype c )
-{
-  cxtype_v out;
-  for ( int i=0; i<neppV; i++ ) out[i] = c;
-  return out;
-}
-*/
+  /*
+  inline cxtype_v
+  cxvmake( const cxtype c )
+  {
+    cxtype_v out;
+    for ( int i=0; i<neppV; i++ ) out[i] = c;
+    return out;
+  }
+  */
 
-inline cxtype_v
-cxmake( const fptype_v& r, const fptype_v& i )
-{
-  return cxtype_v( r, i );
-}
+  inline cxtype_v
+  cxmake( const fptype_v& r, const fptype_v& i )
+  {
+    return cxtype_v( r, i );
+  }
 
-inline cxtype_v
-cxmake( const fptype_v& r, const fptype& i )
-{
-  //return cxtype_v( r, fptype_v{i} ); // THIS WAS A BUG! #339
-  return cxtype_v( r, fptype_v{} + i ); // IIII=0000+i=iiii
-}
+  inline cxtype_v
+  cxmake( const fptype_v& r, const fptype& i )
+  {
+    //return cxtype_v( r, fptype_v{i} ); // THIS WAS A BUG! #339
+    return cxtype_v( r, fptype_v{} + i ); // IIII=0000+i=iiii
+  }
 
-inline cxtype_v
-cxmake( const fptype& r, const fptype_v& i )
-{
-  //return cxtype_v( fptype_v{r}, i ); // THIS WAS A BUG! #339
-  return cxtype_v( fptype_v{} + r, i ); // IIII=0000+r=rrrr
-}
+  inline cxtype_v
+  cxmake( const fptype& r, const fptype_v& i )
+  {
+    //return cxtype_v( fptype_v{r}, i ); // THIS WAS A BUG! #339
+    return cxtype_v( fptype_v{} + r, i ); // IIII=0000+r=rrrr
+  }
 
-inline const fptype_v&
-cxreal( const cxtype_v& c )
-{
-  return c.real(); // returns by reference
-}
+  inline const fptype_v&
+  cxreal( const cxtype_v& c )
+  {
+    return c.real(); // returns by reference
+  }
 
-inline const fptype_v&
-cximag( const cxtype_v& c )
-{
-  return c.imag(); // returns by reference
-}
+  inline const fptype_v&
+  cximag( const cxtype_v& c )
+  {
+    return c.imag(); // returns by reference
+  }
 
-inline const cxtype_v
-cxconj( const cxtype_v& c )
-{
-  return cxtype_v( c.real(), -c.imag() );
-}
+  inline const cxtype_v
+  cxconj( const cxtype_v& c )
+  {
+    return cxtype_v( c.real(), -c.imag() );
+  }
 
-inline cxtype_v
-operator+( const cxtype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a.real() + b.real(), a.imag() + b.imag() );
-}
+  inline cxtype_v
+  operator+( const cxtype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() + b.real(), a.imag() + b.imag() );
+  }
 
-inline cxtype_v
-operator+( const fptype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a + b.real(), b.imag() );
-}
+  inline cxtype_v
+  operator+( const fptype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a + b.real(), b.imag() );
+  }
 
-inline cxtype_v
-operator+( const cxtype_v& a, const fptype_v& b )
-{
-  return cxtype_v( a.real() + b, a.imag() );
-}
+  inline cxtype_v
+  operator+( const cxtype_v& a, const fptype_v& b )
+  {
+    return cxtype_v( a.real() + b, a.imag() );
+  }
 
-inline const cxtype_v&
-operator+( const cxtype_v& a )
-{
-  return a;
-}
+  inline const cxtype_v&
+  operator+( const cxtype_v& a )
+  {
+    return a;
+  }
 
-inline cxtype_v
-operator-( const cxtype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a.real() - b.real(), a.imag() - b.imag() );
-}
+  inline cxtype_v
+  operator-( const cxtype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() - b.real(), a.imag() - b.imag() );
+  }
 
-inline cxtype_v
-operator-( const fptype& a, const cxtype_v& b )
-{
-  return cxtype_v( a - b.real(), -b.imag() );
-}
+  inline cxtype_v
+  operator-( const fptype& a, const cxtype_v& b )
+  {
+    return cxtype_v( a - b.real(), -b.imag() );
+  }
 
-inline cxtype_v
-operator-( const cxtype_v& a )
-{
-  return 0 - a;
-}
+  inline cxtype_v
+  operator-( const cxtype_v& a )
+  {
+    return 0 - a;
+  }
 
-inline cxtype_v
-operator-( const cxtype_v& a, const fptype& b )
-{
-  return cxtype_v( a.real() - b, a.imag() );
-}
+  inline cxtype_v
+  operator-( const cxtype_v& a, const fptype& b )
+  {
+    return cxtype_v( a.real() - b, a.imag() );
+  }
 
-inline cxtype_v
-operator-( const fptype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a - b.real(), -b.imag() );
-}
+  inline cxtype_v
+  operator-( const fptype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a - b.real(), -b.imag() );
+  }
 
-inline cxtype_v
-operator-( const cxtype_v& a, const fptype_v& b )
-{
-  return cxtype_v( a.real() - b, a.imag() );
-}
+  inline cxtype_v
+  operator-( const cxtype_v& a, const fptype_v& b )
+  {
+    return cxtype_v( a.real() - b, a.imag() );
+  }
 
-inline cxtype_v
-operator-( const fptype_v& a, const cxtype& b )
-{
-  return cxtype_v( a - b.real(), fptype_v{} - b.imag() ); // IIII=0000-b.imag()
-}
+  inline cxtype_v
+  operator-( const fptype_v& a, const cxtype& b )
+  {
+    return cxtype_v( a - b.real(), fptype_v{} - b.imag() ); // IIII=0000-b.imag()
+  }
 
-inline cxtype_v
-operator*( const cxtype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
-}
+  inline cxtype_v
+  operator*( const cxtype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const cxtype& a, const cxtype_v& b )
-{
-  return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
-}
+  inline cxtype_v
+  operator*( const cxtype& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const cxtype_v& a, const cxtype& b )
-{
-  return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
-}
+  inline cxtype_v
+  operator*( const cxtype_v& a, const cxtype& b )
+  {
+    return cxtype_v( a.real() * b.real() - a.imag() * b.imag(), a.imag() * b.real() + a.real() * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const fptype& a, const cxtype_v& b )
-{
-  return cxtype_v( a * b.real(), a * b.imag() );
-}
+  inline cxtype_v
+  operator*( const fptype& a, const cxtype_v& b )
+  {
+    return cxtype_v( a * b.real(), a * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const cxtype_v& a, const fptype& b )
-{
-  return cxtype_v( a.real() * b, a.imag() * b );
-}
+  inline cxtype_v
+  operator*( const cxtype_v& a, const fptype& b )
+  {
+    return cxtype_v( a.real() * b, a.imag() * b );
+  }
 
-inline cxtype_v
-operator*( const fptype_v& a, const cxtype_v& b )
-{
-  return cxtype_v( a * b.real(), a * b.imag() );
-}
+  inline cxtype_v
+  operator*( const fptype_v& a, const cxtype_v& b )
+  {
+    return cxtype_v( a * b.real(), a * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const cxtype_v& a, const fptype_v& b )
-{
-  return cxtype_v( a.real() * b, a.imag() * b );
-}
+  inline cxtype_v
+  operator*( const cxtype_v& a, const fptype_v& b )
+  {
+    return cxtype_v( a.real() * b, a.imag() * b );
+  }
 
-inline cxtype_v
-operator*( const fptype_v& a, const cxtype& b )
-{
-  return cxtype_v( a * b.real(), a * b.imag() );
-}
+  inline cxtype_v
+  operator*( const fptype_v& a, const cxtype& b )
+  {
+    return cxtype_v( a * b.real(), a * b.imag() );
+  }
 
-inline cxtype_v
-operator*( const cxtype& a, const fptype_v& b )
-{
-  return cxtype_v( a.real() * b, a.imag() * b );
-}
+  inline cxtype_v
+  operator*( const cxtype& a, const fptype_v& b )
+  {
+    return cxtype_v( a.real() * b, a.imag() * b );
+  }
 
-inline cxtype_v
-operator/( const cxtype_v& a, const cxtype_v& b )
-{
-  fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
-  return cxtype_v( ( a.real() * b.real() + a.imag() * b.imag() ) / bnorm,
-                   ( a.imag() * b.real() - a.real() * b.imag() ) / bnorm );
-}
+  inline cxtype_v
+  operator/( const cxtype_v& a, const cxtype_v& b )
+  {
+    fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
+    return cxtype_v( ( a.real() * b.real() + a.imag() * b.imag() ) / bnorm,
+                     ( a.imag() * b.real() - a.real() * b.imag() ) / bnorm );
+  }
 
-inline cxtype_v
-operator/( const cxtype& a, const cxtype_v& b )
-{
-  fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
-  return cxtype_v( ( cxreal( a ) * b.real() + cximag( a ) * b.imag() ) / bnorm,
-                   ( cximag( a ) * b.real() - cxreal( a ) * b.imag() ) / bnorm );
-}
+  inline cxtype_v
+  operator/( const cxtype& a, const cxtype_v& b )
+  {
+    fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
+    return cxtype_v( ( cxreal( a ) * b.real() + cximag( a ) * b.imag() ) / bnorm,
+                     ( cximag( a ) * b.real() - cxreal( a ) * b.imag() ) / bnorm );
+  }
 
-inline cxtype_v
-operator/( const fptype& a, const cxtype_v& b )
-{
-  fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
-  return cxtype_v( ( a * b.real() ) / bnorm, ( -a * b.imag() ) / bnorm );
-}
+  inline cxtype_v
+  operator/( const fptype& a, const cxtype_v& b )
+  {
+    fptype_v bnorm = b.real() * b.real() + b.imag() * b.imag();
+    return cxtype_v( ( a * b.real() ) / bnorm, ( -a * b.imag() ) / bnorm );
+  }
 
-inline cxtype_v
-operator/( const cxtype_v& a, const fptype_v& b )
-{
-  return cxtype_v( a.real() / b, a.imag() / b );
-}
+  inline cxtype_v
+  operator/( const cxtype_v& a, const fptype_v& b )
+  {
+    return cxtype_v( a.real() / b, a.imag() / b );
+  }
 
-inline cxtype_v
-operator/( const cxtype_v& a, const fptype& b )
-{
-  return cxtype_v( a.real() / b, a.imag() / b );
-}
+  inline cxtype_v
+  operator/( const cxtype_v& a, const fptype& b )
+  {
+    return cxtype_v( a.real() / b, a.imag() / b );
+  }
 
 #endif // #ifdef MGONGPU_CPPSIMD
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Functions and operators for bool_v (ternary and masks)
+  // Functions and operators for bool_v (ternary and masks)
 
 #ifdef MGONGPU_CPPSIMD
 
-inline fptype_v
-fpternary( const bool_v& mask, const fptype_v& a, const fptype_v& b )
-{
-  fptype_v out = {}; // see #594
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b[i] );
-  return out;
-}
-
-inline fptype_v
-fpternary( const bool_v& mask, const fptype_v& a, const fptype& b )
-{
-  fptype_v out = {}; // see #594
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b );
-  return out;
-}
-
-inline fptype_v
-fpternary( const bool_v& mask, const fptype& a, const fptype_v& b )
-{
-  fptype_v out = {}; // see #594
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b[i] );
-  return out;
-}
-
-inline fptype_v
-fpternary( const bool_v& mask, const fptype& a, const fptype& b )
-{
-  fptype_v out = {}; // see #594
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b );
-  return out;
-}
-
-inline cxtype_v
-cxternary( const bool_v& mask, const cxtype_v& a, const cxtype_v& b )
-{
-#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
-  cxtype_v out;
-  //for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b[i] ); // OLD error-prone depends on "cxtype_ref& operator=( cxtype_ref&& c )"
-  for( int i = 0; i < neppV; i++ ) out[i] = cxtype( mask[i] ? a[i] : b[i] );
-  return out;
-#else
-  fptype_v outr = {}; // see #594
-  fptype_v outi = {}; // see #594
-  for( int i = 0; i < neppV; i++ )
+  inline fptype_v
+  fpternary( const bool_v& mask, const fptype_v& a, const fptype_v& b )
   {
-    outr[i] = ( mask[i] ? a.real()[i] : b.real()[i] );
-    outi[i] = ( mask[i] ? a.imag()[i] : b.imag()[i] );
+    fptype_v out = {}; // see #594
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b[i] );
+    return out;
   }
-  return cxtype_v( outr, outi );
-#endif
-}
 
-inline cxtype_v
-cxternary( const bool_v& mask, const cxtype_v& a, const cxtype& b )
-{
-#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
-  cxtype_v out;
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b );
-  return out;
-#else
-  fptype_v outr = {}; // see #594
-  fptype_v outi = {}; // see #594
-  for( int i = 0; i < neppV; i++ )
+  inline fptype_v
+  fpternary( const bool_v& mask, const fptype_v& a, const fptype& b )
   {
-    outr[i] = ( mask[i] ? a.real()[i] : b.real() );
-    outi[i] = ( mask[i] ? a.imag()[i] : b.imag() );
+    fptype_v out = {}; // see #594
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b );
+    return out;
   }
-  return cxtype_v( outr, outi );
-#endif
-}
 
-inline cxtype_v
-cxternary( const bool_v& mask, const cxtype& a, const cxtype_v& b )
-{
-#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
-  cxtype_v out;
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b[i] );
-  return out;
-#else
-  fptype_v outr = {}; // see #594
-  fptype_v outi = {}; // see #594
-  for( int i = 0; i < neppV; i++ )
+  inline fptype_v
+  fpternary( const bool_v& mask, const fptype& a, const fptype_v& b )
   {
-    outr[i] = ( mask[i] ? a.real() : b.real()[i] );
-    outi[i] = ( mask[i] ? a.imag() : b.imag()[i] );
+    fptype_v out = {}; // see #594
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b[i] );
+    return out;
   }
-  return cxtype_v( outr, outi );
-#endif
-}
 
-inline cxtype_v
-cxternary( const bool_v& mask, const cxtype& a, const cxtype& b )
-{
-#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
-  cxtype_v out;
-  for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b );
-  return out;
-#else
-  fptype_v outr = {}; // see #594
-  fptype_v outi = {}; // see #594
-  for( int i = 0; i < neppV; i++ )
+  inline fptype_v
+  fpternary( const bool_v& mask, const fptype& a, const fptype& b )
   {
-    outr[i] = ( mask[i] ? a.real() : b.real() );
-    outi[i] = ( mask[i] ? a.imag() : b.imag() );
+    fptype_v out = {}; // see #594
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b );
+    return out;
   }
-  return cxtype_v( outr, outi );
+
+  inline cxtype_v
+  cxternary( const bool_v& mask, const cxtype_v& a, const cxtype_v& b )
+  {
+#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
+    cxtype_v out;
+    //for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b[i] ); // OLD error-prone depends on "cxtype_ref& operator=( cxtype_ref&& c )"
+    for( int i = 0; i < neppV; i++ ) out[i] = cxtype( mask[i] ? a[i] : b[i] );
+    return out;
+#else
+    fptype_v outr = {}; // see #594
+    fptype_v outi = {}; // see #594
+    for( int i = 0; i < neppV; i++ )
+    {
+      outr[i] = ( mask[i] ? a.real()[i] : b.real()[i] );
+      outi[i] = ( mask[i] ? a.imag()[i] : b.imag()[i] );
+    }
+    return cxtype_v( outr, outi );
 #endif
-}
+  }
 
-/*
-inline bool
-maskor( const bool_v& mask )
-{
-  bool out = false;
-  for ( int i=0; i<neppV; i++ ) out = out || mask[i];
-  return out;
-}
-*/
+  inline cxtype_v
+  cxternary( const bool_v& mask, const cxtype_v& a, const cxtype& b )
+  {
+#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
+    cxtype_v out;
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a[i] : b );
+    return out;
+#else
+    fptype_v outr = {}; // see #594
+    fptype_v outi = {}; // see #594
+    for( int i = 0; i < neppV; i++ )
+    {
+      outr[i] = ( mask[i] ? a.real()[i] : b.real() );
+      outi[i] = ( mask[i] ? a.imag()[i] : b.imag() );
+    }
+    return cxtype_v( outr, outi );
+#endif
+  }
 
-inline bool
-maskand( const bool_v& mask )
-{
-  bool out = true;
-  for ( int i=0; i<neppV; i++ ) out = out && mask[i];
-  return out;
-}
+  inline cxtype_v
+  cxternary( const bool_v& mask, const cxtype& a, const cxtype_v& b )
+  {
+#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
+    cxtype_v out;
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b[i] );
+    return out;
+#else
+    fptype_v outr = {}; // see #594
+    fptype_v outi = {}; // see #594
+    for( int i = 0; i < neppV; i++ )
+    {
+      outr[i] = ( mask[i] ? a.real() : b.real()[i] );
+      outi[i] = ( mask[i] ? a.imag() : b.imag()[i] );
+    }
+    return cxtype_v( outr, outi );
+#endif
+  }
+
+  inline cxtype_v
+  cxternary( const bool_v& mask, const cxtype& a, const cxtype& b )
+  {
+#ifdef MGONGPU_HAS_CPPCXTYPEV_BRK
+    cxtype_v out;
+    for( int i = 0; i < neppV; i++ ) out[i] = ( mask[i] ? a : b );
+    return out;
+#else
+    fptype_v outr = {}; // see #594
+    fptype_v outi = {}; // see #594
+    for( int i = 0; i < neppV; i++ )
+    {
+      outr[i] = ( mask[i] ? a.real() : b.real() );
+      outi[i] = ( mask[i] ? a.imag() : b.imag() );
+    }
+    return cxtype_v( outr, outi );
+#endif
+  }
+
+  /*
+  inline bool
+  maskor( const bool_v& mask )
+  {
+    bool out = false;
+    for ( int i=0; i<neppV; i++ ) out = out || mask[i];
+    return out;
+  }
+  */
+
+  inline bool
+  maskand( const bool_v& mask )
+  {
+    bool out = true;
+    for ( int i=0; i<neppV; i++ ) out = out && mask[i];
+    return out;
+  }
 
 #else // i.e. #ifndef MGONGPU_CPPSIMD
 
-inline fptype
-fpternary( const bool& mask, const fptype& a, const fptype& b )
-{
-  return ( mask ? a : b );
-}
+  inline fptype
+  fpternary( const bool& mask, const fptype& a, const fptype& b )
+  {
+    return ( mask ? a : b );
+  }
 
-inline cxtype
-cxternary( const bool& mask, const cxtype& a, const cxtype& b )
-{
-  return ( mask ? a : b );
-}
+  inline cxtype
+  cxternary( const bool& mask, const cxtype& a, const cxtype& b )
+  {
+    return ( mask ? a : b );
+  }
 
-/*
-inline bool
-maskor( const bool& mask )
-{
-  return mask;
-}
-*/
+  /*
+  inline bool
+  maskor( const bool& mask )
+  {
+    return mask;
+  }
+  */
 
-inline bool
-maskand( const bool& mask )
-{
-  return mask;
-}
+  inline bool
+  maskand( const bool& mask )
+  {
+    return mask;
+  }
 
 #endif // #ifdef MGONGPU_CPPSIMD
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Functions and operators for fptype_v (min/max)
+  // Functions and operators for fptype_v (min/max)
 
 #ifdef MGONGPU_CPPSIMD
 
-inline fptype_v
-fpmax( const fptype_v& a, const fptype_v& b )
-{
-  return fpternary( ( b < a ), a, b );
-}
+  inline fptype_v
+  fpmax( const fptype_v& a, const fptype_v& b )
+  {
+    return fpternary( ( b < a ), a, b );
+  }
 
-inline fptype_v
-fpmax( const fptype_v& a, const fptype& b )
-{
-  return fpternary( ( b < a ), a, b );
-}
+  inline fptype_v
+  fpmax( const fptype_v& a, const fptype& b )
+  {
+    return fpternary( ( b < a ), a, b );
+  }
 
-/*
-inline fptype_v
-fpmax( const fptype& a, const fptype_v& b )
-{
-  return fpternary( ( b < a ), a, b );
-}
-*/
+  /*
+  inline fptype_v
+  fpmax( const fptype& a, const fptype_v& b )
+  {
+    return fpternary( ( b < a ), a, b );
+  }
+  */
 
-inline fptype_v
-fpmin( const fptype_v& a, const fptype_v& b )
-{
-  return fpternary( ( a < b ), a, b );
-}
+  inline fptype_v
+  fpmin( const fptype_v& a, const fptype_v& b )
+  {
+    return fpternary( ( a < b ), a, b );
+  }
 
-/*
-inline fptype_v
-fpmin( const fptype_v& a, const fptype& b )
-{
-  return fpternary( ( a < b ), a, b );
-}
+  /*
+  inline fptype_v
+  fpmin( const fptype_v& a, const fptype& b )
+  {
+    return fpternary( ( a < b ), a, b );
+  }
 
-inline fptype_v
-fpmin( const fptype& a, const fptype_v& b )
-{
-  return fpternary( ( a < b ), a, b );
-}
-*/
+  inline fptype_v
+  fpmin( const fptype& a, const fptype_v& b )
+  {
+    return fpternary( ( a < b ), a, b );
+  }
+  */
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Vector wrapper over RRRRIIII floating point vectors (cxtype_v_ref)
-namespace mgOnGpu /* clang-format off */
-{
+  // Vector wrapper over RRRRIIII floating point vectors (cxtype_v_ref)
   // The cxtype_v_ref class (a non-const reference to two fptype_v variables) was originally designed for MemoryAccessCouplings.
   class cxtype_v_ref
   {
@@ -668,187 +680,188 @@ namespace mgOnGpu /* clang-format off */
   private:
     fptype_v *m_preal, *m_pimag; // RRRRIIII
   };
-} /* clang-format on */
 
 #endif // #ifdef MGONGPU_CPPSIMD
 
-//--------------------------------------------------------------------------
+  //--------------------------------------------------------------------------
 
-// Functions and operators for fptype2_v
+  // Functions and operators for fptype2_v
 
 #if defined MGONGPU_CPPSIMD and defined MGONGPU_FPTYPE_DOUBLE and defined MGONGPU_FPTYPE2_FLOAT
 
-inline fptype2_v
-fpvmerge( const fptype_v& v1, const fptype_v& v2 )
-{
-  // This code is not very efficient! It makes mixed precision FFV/color not faster than double on C++ (#537).
-  // I considered various alternatives, including
-  // - in gcc12 and clang, __builtin_shufflevector (works with different vector lengths, BUT the same fptype...)
-  // - casting vector(4)double to vector(4)float and then assigning via reinterpret_cast... but how to do the cast?
-  // Probably the best solution is intrinsics?
-  // - see https://stackoverflow.com/questions/5139363
-  // - see https://stackoverflow.com/questions/54518744
-  /*
-  fptype2_v out;
-  for( int ieppV = 0; ieppV < neppV; ieppV++ )
+  inline fptype2_v
+  fpvmerge( const fptype_v& v1, const fptype_v& v2 )
   {
-    out[ieppV] = v1[ieppV];
-    out[ieppV+neppV] = v2[ieppV];
-  }
-  return out;
-  */
+    // This code is not very efficient! It makes mixed precision FFV/color not faster than double on C++ (#537).
+    // I considered various alternatives, including
+    // - in gcc12 and clang, __builtin_shufflevector (works with different vector lengths, BUT the same fptype...)
+    // - casting vector(4)double to vector(4)float and then assigning via reinterpret_cast... but how to do the cast?
+    // Probably the best solution is intrinsics?
+    // - see https://stackoverflow.com/questions/5139363
+    // - see https://stackoverflow.com/questions/54518744
+    /*
+    fptype2_v out;
+    for( int ieppV = 0; ieppV < neppV; ieppV++ )
+    {
+      out[ieppV] = v1[ieppV];
+      out[ieppV+neppV] = v2[ieppV];
+    }
+    return out;
+    */
 #if MGONGPU_CPPSIMD == 2
-  fptype2_v out =
-    { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v2[0], (fptype2)v2[1] };
+    fptype2_v out =
+      { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v2[0], (fptype2)v2[1] };
 #elif MGONGPU_CPPSIMD == 4
-  fptype2_v out =
-    { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v1[2], (fptype2)v1[3], (fptype2)v2[0], (fptype2)v2[1], (fptype2)v2[2], (fptype2)v2[3] };
+    fptype2_v out =
+      { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v1[2], (fptype2)v1[3], (fptype2)v2[0], (fptype2)v2[1], (fptype2)v2[2], (fptype2)v2[3] };
 #elif MGONGPU_CPPSIMD == 8
-  fptype2_v out =
-    { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v1[2], (fptype2)v1[3], (fptype2)v1[4], (fptype2)v1[5], (fptype2)v1[6], (fptype2)v1[7], (fptype2)v2[0], (fptype2)v2[1], (fptype2)v2[2], (fptype2)v2[3], (fptype2)v2[4], (fptype2)v2[5], (fptype2)v2[6], (fptype2)v2[7] };
+    fptype2_v out =
+      { (fptype2)v1[0], (fptype2)v1[1], (fptype2)v1[2], (fptype2)v1[3], (fptype2)v1[4], (fptype2)v1[5], (fptype2)v1[6], (fptype2)v1[7], (fptype2)v2[0], (fptype2)v2[1], (fptype2)v2[2], (fptype2)v2[3], (fptype2)v2[4], (fptype2)v2[5], (fptype2)v2[6], (fptype2)v2[7] };
 #endif
-  return out;
-}
+    return out;
+  }
 
-inline fptype_v
-fpvsplit0( const fptype2_v& v )
-{
-  /*
-  fptype_v out = {}; // see #594
-  for( int ieppV = 0; ieppV < neppV; ieppV++ )
+  inline fptype_v
+  fpvsplit0( const fptype2_v& v )
   {
-    out[ieppV] = v[ieppV];
-  }
-  */
+    /*
+    fptype_v out = {}; // see #594
+    for( int ieppV = 0; ieppV < neppV; ieppV++ )
+    {
+      out[ieppV] = v[ieppV];
+    }
+    */
 #if MGONGPU_CPPSIMD == 2
-  fptype_v out =
-    { (fptype)v[0], (fptype)v[1] };
+    fptype_v out =
+      { (fptype)v[0], (fptype)v[1] };
 #elif MGONGPU_CPPSIMD == 4
-  fptype_v out =
-    { (fptype)v[0], (fptype)v[1], (fptype)v[2], (fptype)v[3] };
+    fptype_v out =
+      { (fptype)v[0], (fptype)v[1], (fptype)v[2], (fptype)v[3] };
 #elif MGONGPU_CPPSIMD == 8
-  fptype_v out =
-    { (fptype)v[0], (fptype)v[1], (fptype)v[2], (fptype)v[3], (fptype)v[4], (fptype)v[5], (fptype)v[6], (fptype)v[7] };
+    fptype_v out =
+      { (fptype)v[0], (fptype)v[1], (fptype)v[2], (fptype)v[3], (fptype)v[4], (fptype)v[5], (fptype)v[6], (fptype)v[7] };
 #endif
-  return out;
-}
+    return out;
+  }
 
-inline fptype_v
-fpvsplit1( const fptype2_v& v )
-{
-  /*
-  fptype_v out = {}; // see #594
-  for( int ieppV = 0; ieppV < neppV; ieppV++ )
+  inline fptype_v
+  fpvsplit1( const fptype2_v& v )
   {
-    out[ieppV] = v[ieppV+neppV];
-  }
-  */
+    /*
+    fptype_v out = {}; // see #594
+    for( int ieppV = 0; ieppV < neppV; ieppV++ )
+    {
+      out[ieppV] = v[ieppV+neppV];
+    }
+    */
 #if MGONGPU_CPPSIMD == 2
-  fptype_v out =
-    { (fptype)v[2], (fptype)v[3] };
+    fptype_v out =
+      { (fptype)v[2], (fptype)v[3] };
 #elif MGONGPU_CPPSIMD == 4
-  fptype_v out =
-    { (fptype)v[4], (fptype)v[5], (fptype)v[6], (fptype)v[7] };
+    fptype_v out =
+      { (fptype)v[4], (fptype)v[5], (fptype)v[6], (fptype)v[7] };
 #elif MGONGPU_CPPSIMD == 8
-  fptype_v out =
-    { (fptype)v[8], (fptype)v[9], (fptype)v[10], (fptype)v[11], (fptype)v[12], (fptype)v[13], (fptype)v[14], (fptype)v[15] };
+    fptype_v out =
+      { (fptype)v[8], (fptype)v[9], (fptype)v[10], (fptype)v[11], (fptype)v[12], (fptype)v[13], (fptype)v[14], (fptype)v[15] };
 #endif
-  return out;
-}
+    return out;
+  }
 
 #endif // #if defined MGONGPU_CPPSIMD and defined MGONGPU_FPTYPE_DOUBLE and defined MGONGPU_FPTYPE2_FLOAT
 
 #endif // #ifndef __CUDACC__
 
-//==========================================================================
+  //==========================================================================
 
 #ifdef __CUDACC__
 
-//------------------------------
-// Vector types - CUDA
-//------------------------------
+  //------------------------------
+  // Vector types - CUDA
+  //------------------------------
 
-// Printout to std::cout for user defined types
-inline __host__ __device__ void
-print( const fptype& f )
-{
-  printf( "%f\n", f );
-}
-inline __host__ __device__ void
-print( const cxtype& c )
-{
-  printf( "[%f, %f]\n", cxreal( c ), cximag( c ) );
-}
+  // Printout to std::cout for user defined types
+  inline __host__ __device__ void
+  print( const fptype& f )
+  {
+    printf( "%f\n", f );
+  }
+  inline __host__ __device__ void
+  print( const cxtype& c )
+  {
+    printf( "[%f, %f]\n", cxreal( c ), cximag( c ) );
+  }
 
-/*
-inline __host__ __device__ const cxtype&
-cxvmake( const cxtype& c )
-{
-  return c;
-}
-*/
+  /*
+  inline __host__ __device__ const cxtype&
+  cxvmake( const cxtype& c )
+  {
+    return c;
+  }
+  */
 
-inline __host__ __device__ fptype
-fpternary( const bool& mask, const fptype& a, const fptype& b )
-{
-  return ( mask ? a : b );
-}
+  inline __host__ __device__ fptype
+  fpternary( const bool& mask, const fptype& a, const fptype& b )
+  {
+    return ( mask ? a : b );
+  }
 
-inline __host__ __device__ cxtype
-cxternary( const bool& mask, const cxtype& a, const cxtype& b )
-{
-  return ( mask ? a : b );
-}
+  inline __host__ __device__ cxtype
+  cxternary( const bool& mask, const cxtype& a, const cxtype& b )
+  {
+    return ( mask ? a : b );
+  }
 
-inline __host__ __device__ bool
-maskand( const bool& mask )
-{
-  return mask;
-}
+  inline __host__ __device__ bool
+  maskand( const bool& mask )
+  {
+    return mask;
+  }
 
 #endif // #ifdef __CUDACC__
 
-//==========================================================================
+  //==========================================================================
 
-// Scalar-or-vector types: scalar in CUDA, vector or scalar in C++
+  // Scalar-or-vector types: scalar in CUDA, vector or scalar in C++
 #ifdef __CUDACC__
-typedef bool bool_sv;
-typedef fptype fptype_sv;
-typedef fptype2 fptype2_sv;
-typedef cxtype cxtype_sv;
-typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
+  typedef bool bool_sv;
+  typedef fptype fptype_sv;
+  typedef fptype2 fptype2_sv;
+  typedef cxtype cxtype_sv;
+  typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
 #elif defined MGONGPU_CPPSIMD
-typedef bool_v bool_sv;
-typedef fptype_v fptype_sv;
-typedef fptype2_v fptype2_sv;
-typedef cxtype_v cxtype_sv;
-typedef mgOnGpu::cxtype_v_ref cxtype_sv_ref;
+  typedef bool_v bool_sv;
+  typedef fptype_v fptype_sv;
+  typedef fptype2_v fptype2_sv;
+  typedef cxtype_v cxtype_sv;
+  typedef mgOnGpu::cxtype_v_ref cxtype_sv_ref;
 #else
-typedef bool bool_sv;
-typedef fptype fptype_sv;
-typedef fptype2 fptype2_sv;
-typedef cxtype cxtype_sv;
-typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
+  typedef bool bool_sv;
+  typedef fptype fptype_sv;
+  typedef fptype2 fptype2_sv;
+  typedef cxtype cxtype_sv;
+  typedef mgOnGpu::cxtype_ref cxtype_sv_ref;
 #endif
 
-// Scalar-or-vector zeros: scalar in CUDA, vector or scalar in C++
+  // Scalar-or-vector zeros: scalar in CUDA, vector or scalar in C++
 #ifdef __CUDACC__ /* clang-format off */
-inline __host__ __device__ cxtype cxzero_sv(){ return cxtype( 0, 0 ); }
+  inline __host__ __device__ cxtype cxzero_sv(){ return cxtype( 0, 0 ); }
 #elif defined MGONGPU_CPPSIMD
-inline cxtype_v cxzero_sv() { return cxtype_v(); } // RRRR=0000 IIII=0000
+  inline cxtype_v cxzero_sv() { return cxtype_v(); } // RRRR=0000 IIII=0000
 #else
-inline cxtype cxzero_sv() { return cxtype( 0, 0 ); }
+  inline cxtype cxzero_sv() { return cxtype( 0, 0 ); }
 #endif /* clang-format on */
 
-//==========================================================================
+  //==========================================================================
 
-// Functions and operators for cxtype_sv
-inline __host__ __device__ fptype_sv
-cxabs2( const cxtype_sv& c )
-{
-  return cxreal( c ) * cxreal( c ) + cximag( c ) * cximag( c );
-}
+  // Functions and operators for cxtype_sv
+  inline __host__ __device__ fptype_sv
+  cxabs2( const cxtype_sv& c )
+  {
+    return cxreal( c ) * cxreal( c ) + cximag( c ) * cximag( c );
+  }
 
-//==========================================================================
+  //==========================================================================
+
+} // end namespace mg5amcGpu/mg5amcCpu
 
 #endif // MGONGPUVECTORS_H


### PR DESCRIPTION
This is a WIP MR that fixes #725, ie the segfault in runtest.

It is a complete fix in ggtt.sa. I keep it in WIP hoever and will probably close it, because I have other MRs that may soon be committed and which this will also modify a lot (@Jooorgen 's HIP MR #718 and my FPE MR # 723, which is actually where I first noticed this issue).

I will most likely merge this into #723. And then discuss with Jorgen which one of HIP or FPE should go in first.

Note: this patch essentially extends the use of the two separate namespaces for CPU and GPU builds (as discussed in #318). While I am still not convinced that it is a good idea to mix both types of builds in a single executable (which is what was causing the segfault #725), at least now this is a bit safer. I am not sure if all issues are fixed, but ceratnly it is much better. A few details
- Now fptype_sv and cxtype_sv, and also cxtype, are defined in either a CPU or GPU namespace, where they have different definitions
- In #725 I was reporting not only a segfault, but also a strange mixup where some tests seemed to mix data arrays with different strutures, which is indeed  probably a side effect of having different vector sizes mixed
- I have no idea why we have not observed these errors before, and why they only show up in debug builds...
- I have also moved to separate GPU/CPU namespaces the Parameters class. For this I had to also build the Parameters class in CUDA in src.
- The CUDA build in src is done by simply exporting NVCC. This may be a good ides to simplify makefiles eventually in src also for AVX etc.
