### PR TITLE
avoid that mirroring is reset by the plugin

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -1299,9 +1299,10 @@ class PLUGIN_OneProcessExporter(PLUGIN_export_cpp.OneProcessExporterGPU):
             misc.sprint('self.include_multi_channel is already defined: this is madevent+second_exporter mode')
         else:
             misc.sprint('self.include_multi_channel is not yet defined: this is standalone_cudacpp mode') # see issue #473
-        if self.matrix_elements[0].get('has_mirror_process'):
-            self.matrix_elements[0].set('has_mirror_process', False)
-            self.nprocesses/=2
+            # I move those line to standalone_cudacpp mode (but do we need those at all???)
+            if self.matrix_elements[0].get('has_mirror_process'):
+                self.matrix_elements[0].set('has_mirror_process', False)
+                self.nprocesses/=2
         super(PLUGIN_export_cpp.OneProcessExporterGPU, self).generate_process_files()
         self.edit_CMakeLists()
         self.edit_check_sa()


### PR DESCRIPTION
Hi @valassi,

This is a PR to fix the issue that 
p p > t t~ returns the wrong cross-section (compare to pure madevent case: (see #678)

The issue that I found is that the plugin reset the "mirror" flag to False and since this is done "before" the creation of the madevent metadata file, the madevent loose track of such symmetry (and therefore of a part of the cross-section).
This explains why g g > t t~ was not impacted but that q q > t t~ was wrong by a factor of two.

The question is why did you implement such line (and what is going to break by removing such line).
To avoid too much side effect, I have just removed them for the madevent+cpp/cuda mode?
But we likely need to take a more drastic option here (but want your opinion on it)

Olivier
 