### PR TITLE
WIP: if needed fix the order of couplings 

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -992,6 +992,12 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
         logger.info('Created file %s in directory %s' \
                     % (os.path.split(model_h_file)[-1], os.path.split(model_h_file)[0] ) )
 
+    def prepare_couplings(self, wanted_couplings = []):
+        super().prepare_couplings(wanted_couplings)
+        # the two lines below fix #748, i.e. they re-order the dictionary keys following the order in wanted_couplings
+        ordered_dict = [(k, self.coups_dep[k]) for k in wanted_couplings]
+        self.coups_dep = dict((x, y) for x, y in ordered_dict)
+
 #------------------------------------------------------------------------------------
 
 import madgraph.iolibs.files as files


### PR DESCRIPTION
override the prepare_couplings function in the in PLUGIN_UFOModelConverter class
the additional functionality will re-order the dictionary keys of the dependent couplings such that they follow the correct ordering. The wanted_couplings parameter of the function contains the correct ordering as it is discovered in the OneProcessExporter class

fixes #748 