### PR TITLE
remove symbolik links in the .sa directories makefile->kokkos.mk

### DIFF
--- a/epochX/kokkos/ee_mumu.sa/SubProcesses/P1_Sigma_sm_epem_mupmum/makefile
+++ b/epochX/kokkos/ee_mumu.sa/SubProcesses/P1_Sigma_sm_epem_mupmum/makefile
@@ -1,1 +1,0 @@
-kokkos.mk

--- a/epochX/kokkos/gg_tt.sa/SubProcesses/P1_Sigma_sm_gg_ttx/makefile
+++ b/epochX/kokkos/gg_tt.sa/SubProcesses/P1_Sigma_sm_gg_ttx/makefile
@@ -1,1 +1,0 @@
-kokkos.mk

--- a/epochX/kokkos/gg_ttg.sa/SubProcesses/P1_Sigma_sm_gg_ttxg/makefile
+++ b/epochX/kokkos/gg_ttg.sa/SubProcesses/P1_Sigma_sm_gg_ttxg/makefile
@@ -1,1 +1,0 @@
-kokkos.mk

--- a/epochX/kokkos/gg_ttgg.sa/SubProcesses/P1_Sigma_sm_gg_ttxgg/makefile
+++ b/epochX/kokkos/gg_ttgg.sa/SubProcesses/P1_Sigma_sm_gg_ttxgg/makefile
@@ -1,1 +1,0 @@
-kokkos.mk

--- a/epochX/kokkos/gg_ttggg.sa/SubProcesses/P1_Sigma_sm_gg_ttxggg/makefile
+++ b/epochX/kokkos/gg_ttggg.sa/SubProcesses/P1_Sigma_sm_gg_ttxggg/makefile
@@ -1,1 +1,0 @@
-kokkos.mk


### PR DESCRIPTION
because of the parallel existence of a file Makefile (upper case M) this creates a problem on standard MacOS filesystems which is case insensitive.