### PR TITLE
Fix mac os linking

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
@@ -37,7 +37,7 @@ OPTFLAGS = -O3 # this ends up in CUFLAGS too (should it?), cannot add -Ofast or 
 
 # Dependency on src directory
 MG5AMC_COMMONLIB = mg5amc_common
-LIBFLAGS = -L$(LIBDIR) -l$(MG5AMC_COMMONLIB)
+LIBFLAGS = -L$(LIBDIR) -l$(MG5AMC_COMMONLIB) $(LDEXTRAFLAGS)
 INCFLAGS += -I../../src
 
 # Compiler-specific googletest build directory (#125 and #738)

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_src.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_src.mk
@@ -259,11 +259,11 @@ endif
 ifneq ($(NVCC),)
 $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects) $(cu_objects)
 	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi
-	$(NVCC) -shared -o $@ $(cxx_objects) $(cu_objects)
+	$(NVCC) -shared -o $@ $(cxx_objects) $(cu_objects) $(LDEXTRAFLAGS)
 else
 $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects)
 	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi
-	$(CXX) -shared -o $@ $(cxx_objects)
+	$(CXX) -shared -o $@ $(cxx_objects) $(LDEXTRAFLAGS)
 endif
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
With the latest update of XCode on MacOS the building of the code broke. The linkflags need two extra options "-ld_classic -lstdc++". This fix introduces a variable LDEXTRAFLAGS which will be added to the link statements. The makefiles are currently being worked on by @Jooorgen and @hageboeck with separate PRs, I expect this to vanish anyway soon again with the two PRs merged.