### PR TITLE
fix a problem when using sm models which are not standard

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -886,7 +886,7 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
             replace_dict['dcoupsetdcoup2'] = '      // (none)'
             replace_dict['dcoupoutdcoup2'] = ''
         # Require HRDCOD=1 in EFT and special handling in EFT for fptype=float using SIMD
-        if self.model_name == 'sm' :
+        if self.model_name[:2] == 'sm' :
             replace_dict['efterror'] = ''
             replace_dict['eftspecial1'] = '      // Begin SM implementation - no special handling of vectors of floats as in EFT (#439)'
             replace_dict['eftspecial2'] = '      // End SM implementation - no special handling of vectors of floats as in EFT (#439)'


### PR DESCRIPTION
This fixes a problem when using a model which is sm but not standard, e.g. a line

```
import model sm-no_b_mass
```

would produce an error in the model_handling.py. This PR will fix the problem, but I'm a bit wary about this piece of code in general. I merge this PR anyway now to let our users continue working but I think would be good to discuss this in more depth. I open an issue for it. 