### PR TITLE
WIP: debug CUDA build warnings in the CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum , epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg ]
+        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum , epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg , epochX/cudacpp/pp_tt012j.mad/SubProcesses/P0_gg_ttx ]
         precision: [ d , f , m ]
       fail-fast: false
     steps:
@@ -38,7 +38,7 @@ jobs:
       FC: gfortran-11
     strategy:
       matrix:
-        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum, epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg ]
+        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum, epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg , epochX/cudacpp/pp_tt012j.mad/SubProcesses/P0_gg_ttx ]
         precision: [ d , f , m ]
       fail-fast: false
     steps:
@@ -57,7 +57,7 @@ jobs:
       REQUIRE_CUDA: 1
     strategy:
       matrix:
-        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum , epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg ]
+        folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum , epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg , epochX/cudacpp/pp_tt012j.mad/SubProcesses/P0_gg_ttx ]
         precision: [ d , f , m ]
       fail-fast: false
     steps:


### PR DESCRIPTION
Debug CUDA build warnings observed in the CI for PR #753

https://github.com/madgraph5/madgraph4gpu/actions/runs/6954971982/job/18922834648?pr=753
```
/usr/local/cuda//bin/nvcc -fPIC -std=c++17 --forward-unknown-to-host-compiler -Wall -Wshadow -Wextra -I/usr/local/cuda//include/ -DUSE_NVTX --generate-code arch=compute_70,code=compute_70 --generate-code arch=compute_70,code=sm_70 -ccbin /opt/rh/gcc-toolset-12/root/usr/bin/g++ -DMGONGPU_FPTYPE_DOUBLE -DMGONGPU_FPTYPE2_DOUBLE -O3 -ffast-math -use_fast_math -DNDEBUG -lineinfo -c -x cu Parameters_sm.cc -o build.cuda_d_inl0_hrd0/Parameters_sm_cu.o
/usr/local/cuda//include/thrust/detail/execute_with_dependencies.h: In constructor ‘thrust::detail::execute_with_dependencies<BaseSystem, Dependencies>::execute_with_dependencies(const super_t&, Dependencies&& ...)’:
/usr/local/cuda//include/thrust/detail/execute_with_dependencies.h:64:72: warning: declaration of ‘dependencies’ shadows a member of ‘thrust::detail::execute_with_dependencies<BaseSystem, Dependencies>’ [-Wshadow]
   64 |     execute_with_dependencies(super_t const &super, Dependencies && ...dependencies)
      |                                                         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~  
/usr/local/cuda//include/thrust/detail/execute_with_dependencies.h:60:57: note: shadowed declaration is here
   60 |     std::tuple<remove_cvref_t<Dependencies>...> dependencies;
      |                                                         ^~~~~       
```