### PR TITLE
ensure that cpp data structure for is_LC is the same in fortran and cpp

### DIFF
--- a/.github/workflows/testsuite_oneprocess.sh
+++ b/.github/workflows/testsuite_oneprocess.sh
@@ -535,11 +535,11 @@ if [ $BYPASS_KNOWN_ISSUES -eq 1 ] && [ $status -ne 0 ]; then
   # Known issues in tmad_test
   if [ "$stage" == "tmad_test" ]; then
     # No cross section in susy_gg_t1t1 (#826)
-#    if [ "${proc%.mad}" == "susy_gg_t1t1" ]; then bypassIssue "No cross section in ${proc%.mad} for FPTYPE=d,f,m (#826)"; fi
+    if [ "${proc%.mad}" == "susy_gg_t1t1" ]; then bypassIssue "No cross section in ${proc%.mad} for FPTYPE=d,f,m (#826)"; fi
     # LHE color mismatch in gg_ttgg for iconfig=104 (#856)
 #    if [ "${proc%.mad}" == "gg_ttgg" ]; then bypassIssue "LHE color mismatch for iconfig=104 in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
     # Cross section mismatch in pp_tt012j for P2_gu_ttxgu (#872)
-#    if [ "${proc%.mad}" == "pp_tt012j" ]; then bypassIssue "Cross section mismatch for P2_gu_ttxgu in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
+    if [ "${proc%.mad}" == "pp_tt012j" ]; then bypassIssue "Cross section mismatch for P2_gu_ttxgu in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
     # Final printout
     if [ $status -ne 0 ]; then echo "[testsuite_oneprocess.sh] $stage ($proc) FPTYPE=${FPTYPE}: issue will not be bypassed, test has FAILED"; fi
   fi

--- a/.github/workflows/testsuite_oneprocess.sh
+++ b/.github/workflows/testsuite_oneprocess.sh
@@ -535,11 +535,11 @@ if [ $BYPASS_KNOWN_ISSUES -eq 1 ] && [ $status -ne 0 ]; then
   # Known issues in tmad_test
   if [ "$stage" == "tmad_test" ]; then
     # No cross section in susy_gg_t1t1 (#826)
-    if [ "${proc%.mad}" == "susy_gg_t1t1" ]; then bypassIssue "No cross section in ${proc%.mad} for FPTYPE=d,f,m (#826)"; fi
+#    if [ "${proc%.mad}" == "susy_gg_t1t1" ]; then bypassIssue "No cross section in ${proc%.mad} for FPTYPE=d,f,m (#826)"; fi
     # LHE color mismatch in gg_ttgg for iconfig=104 (#856)
-    if [ "${proc%.mad}" == "gg_ttgg" ]; then bypassIssue "LHE color mismatch for iconfig=104 in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
+#    if [ "${proc%.mad}" == "gg_ttgg" ]; then bypassIssue "LHE color mismatch for iconfig=104 in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
     # Cross section mismatch in pp_tt012j for P2_gu_ttxgu (#872)
-    if [ "${proc%.mad}" == "pp_tt012j" ]; then bypassIssue "Cross section mismatch for P2_gu_ttxgu in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
+#    if [ "${proc%.mad}" == "pp_tt012j" ]; then bypassIssue "Cross section mismatch for P2_gu_ttxgu in ${proc%.mad} for FPTYPE=d,f,m (#856)"; fi
     # Final printout
     if [ $status -ne 0 ]; then echo "[testsuite_oneprocess.sh] $stage ($proc) FPTYPE=${FPTYPE}: issue will not be bypassed, test has FAILED"; fi
   fi

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -1108,7 +1108,7 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
 
 import madgraph.iolibs.files as files
 import madgraph.various.misc as misc
-
+import madgraph.iolibs.export_v4 as export_v4
 # AV - define a custom OneProcessExporter
 # (NB: enable this via PLUGIN_ProcessExporter.oneprocessclass in output.py)
 # (NB: use this directly also in PLUGIN_UFOModelConverter.read_template_file)
@@ -1523,7 +1523,7 @@ class PLUGIN_OneProcessExporter(PLUGIN_export_cpp.OneProcessExporterGPU):
     def edit_coloramps(self, config_subproc_map):
         """Generate coloramps.h"""
 
-
+        misc.sprint(config_subproc_map)
         ###misc.sprint('Entering PLUGIN_OneProcessExporter.edit_coloramps')
         template = open(pjoin(self.template_path,'gpu','coloramps.h'),'r').read()
         ff = open(pjoin(self.path, 'coloramps.h'),'w')
@@ -1566,18 +1566,9 @@ class PLUGIN_OneProcessExporter(PLUGIN_export_cpp.OneProcessExporterGPU):
         replace_dict['channelc2iconfig_lines'] = '\n'.join(lines)
 
         if self.include_multi_channel: # NB unnecessary as edit_coloramps is not called otherwise...
-            #multi_channel = self.get_multi_channel_dictionary(self.matrix_elements[0].get('diagrams'), self.include_multi_channel)
-            
-            subproc_to_confdiag = {}
-            for config in config_subproc_map:
-                for subproc, diag in enumerate(config):
-                    try:
-                        subproc_to_confdiag[subproc].append(diag)
-                    except KeyError:
-                        subproc_to_confdiag[subproc] = [diag]
-            
-            replace_dict['is_LC'] = self.get_icolamp_lines(subproc_to_confdiag[0], self.matrix_elements[0], 1)
-            replace_dict['nb_channel'] = len(subproc_to_confdiag[0])
+            subproc_to_confdiag = export_v4.ProcessExporterFortranMEGroup.get_confdiag_from_group_mapconfig(config_subproc_map, 0)             
+            replace_dict['is_LC'] = self.get_icolamp_lines(subproc_to_confdiag, self.matrix_elements[0], 1)
+            replace_dict['nb_channel'] = len(subproc_to_confdiag)
             replace_dict['nb_diag'] = max(config[0] for config in config_subproc_map)
             replace_dict['nb_color'] = max(1,len(self.matrix_elements[0].get('color_basis')))
             

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -1566,15 +1566,21 @@ class PLUGIN_OneProcessExporter(PLUGIN_export_cpp.OneProcessExporterGPU):
         replace_dict['channelc2iconfig_lines'] = '\n'.join(lines)
 
         if self.include_multi_channel: # NB unnecessary as edit_coloramps is not called otherwise...
-            multi_channel = self.get_multi_channel_dictionary(self.matrix_elements[0].get('diagrams'), self.include_multi_channel)
-            replace_dict['is_LC'] = self.get_icolamp_lines(multi_channel, self.matrix_elements[0], 1)
-            replace_dict['nb_channel'] = len(multi_channel)
+            #multi_channel = self.get_multi_channel_dictionary(self.matrix_elements[0].get('diagrams'), self.include_multi_channel)
+            
+            subproc_to_confdiag = {}
+            for config in config_subproc_map:
+                for subproc, diag in enumerate(config):
+                    try:
+                        subproc_to_confdiag[subproc].append(diag)
+                    except KeyError:
+                        subproc_to_confdiag[subproc] = [diag]
+            
+            replace_dict['is_LC'] = self.get_icolamp_lines(subproc_to_confdiag[0], self.matrix_elements[0], 1)
+            replace_dict['nb_channel'] = len(subproc_to_confdiag[0])
             replace_dict['nb_diag'] = max(config[0] for config in config_subproc_map)
             replace_dict['nb_color'] = max(1,len(self.matrix_elements[0].get('color_basis')))
             
-            misc.sprint(multi_channel)
-            misc.sprint(self.path, os.getcwd())
-            #raise Exception
             
             # AV extra formatting (e.g. gg_tt was "{{true,true};,{true,false};,{false,true};};")
             ###misc.sprint(replace_dict['is_LC'])


### PR DESCRIPTION
Adding a PR (in WIP) to see if the following branch does create issue. 
@valassi do we have a CI test for the missmatch of color?
Because, the point of this PR is to be able to fix such missmatch (I did not tested that part yet).

In particular, I want to test if I did break things for SA side (It would be weird...)

The idea of such patch is to ensure that the datastructure use to write the color (is_LC information) is the same on the fortran and cpp side. 

In the previous code, the function was called twice with two different type of data-structure. I do not understand why this was needed, so I fully removed the first call (which explains why I want to run the CI to check for side effect). (and change the datastructure of the second call)

