### PR TITLE
fix patch to be compatible with mg5 branch gpucpp_goodhel

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
@@ -304,13 +304,13 @@ index e73e654d4..27fbe7302 100644
  C     ----------
  
 +      call counters_smatrix1_start()
-       NTRY(IMIRROR)=NTRY(IMIRROR)+1
-       THIS_NTRY(IMIRROR) = THIS_NTRY(IMIRROR)+1
+       NTRY(1)=NTRY(1)+1
        DO I=1,NEXTERNAL
+         JC(I) = +1       
 @@ -217,6 +221,17 @@ C     ----------
            ENDIF
-           IF(NTRY(IMIRROR).EQ.MAXTRIES)THEN
-             ISHEL(IMIRROR)=MIN(ISUM_HEL,NGOOD(IMIRROR))
+           IF(NTRY(1).EQ.MAXTRIES)THEN
+             ISHEL=MIN(ISUM_HEL,NGOOD)
 +C           Print the number of good helicities
 +            IF (NGOODHEL(IMIRROR).EQ.-1) THEN
 +              NGOODHEL(IMIRROR)=0

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
@@ -82,9 +82,9 @@ index 4fbb8e6ba..f9e2335de 100644
 +     &      SELECTED_HEL2, SELECTED_COL2 )
 +          FIRST = .FALSE.
 +c         ! This is a workaround for https://github.com/oliviermattelaer/mg5amc_test/issues/22 (see PR #486)
-+          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
-+            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
-+          ENDIF
++c          IF( FBRIDGE_MODE .EQ. 1 ) THEN ! (CppOnly=1 : SMATRIX1 is not called at all)
++c            CALL RESET_CUMULATIVE_VARIABLE() ! mimic 'avoid bias of the initialization' within SMATRIX1
++c          ENDIF
 +          CALL FBRIDGEGETNGOODHEL(FBRIDGE_PBRIDGE,NGOODHEL,NTOTHEL)
 +          IF( NTOTHEL .NE. NCOMB ) THEN
 +            WRITE(6,*) 'ERROR! Cudacpp/Fortran mismatch',

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.P1
@@ -293,9 +293,9 @@ index e73e654d4..27fbe7302 100644
        EXTERNAL GET_CHANNEL_CUT
 -
 +C
-+      INTEGER NGOODHEL(2) ! -1 if not yet retrieved and printed
++      INTEGER NGOODHEL ! -1 if not yet retrieved and printed
 +      SAVE NGOODHEL
-+      DATA NGOODHEL/-1,-1/
++      DATA NGOODHEL/-1/
  C     
  C     This is just to temporarily store the reference grid for
  C      helicity of the DiscreteSampler so as to obtain its number of
@@ -312,14 +312,14 @@ index e73e654d4..27fbe7302 100644
            IF(NTRY(1).EQ.MAXTRIES)THEN
              ISHEL=MIN(ISUM_HEL,NGOOD)
 +C           Print the number of good helicities
-+            IF (NGOODHEL(IMIRROR).EQ.-1) THEN
-+              NGOODHEL(IMIRROR)=0
++            IF (NGOODHEL.EQ.-1) THEN
++              NGOODHEL=0
 +              DO I=1,NCOMB
-+                IF (GOODHEL(I,IMIRROR)) THEN
-+                  NGOODHEL(IMIRROR)=NGOODHEL(IMIRROR)+1
++                IF (GOODHEL(I,1)) THEN
++                  NGOODHEL=NGOODHEL+1
 +                ENDIF
 +              END DO
-+              WRITE (6,*) 'NGOODHEL =', NGOODHEL(IMIRROR) ! no need to print imirror?
++              WRITE (6,*) 'NGOODHEL =', NGOODHEL
 +              WRITE (6,*) 'NCOMB =', NCOMB
 +            ENDIF
            ENDIF

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.common
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/MG5aMC_patches/PROD/patch.common
@@ -1,17 +1,3 @@
-diff --git b/epochX/cudacpp/gg_tt.mad/Source/genps.inc a/epochX/cudacpp/gg_tt.mad/Source/genps.inc
-index a59181c70..af7e0efbc 100644
---- b/epochX/cudacpp/gg_tt.mad/Source/genps.inc
-+++ a/epochX/cudacpp/gg_tt.mad/Source/genps.inc
-@@ -30,7 +30,8 @@ c*************************************************************************
- c	Parameters for helicity sums in matrixN.f
- c*************************************************************************
-       REAL*8 LIMHEL
--      PARAMETER(LIMHEL=1e-8) ! ME threshold for helicity filtering
-+c     PARAMETER(LIMHEL=1e-8) ! ME threshold for helicity filtering (Fortran default)
-+      PARAMETER(LIMHEL=0) ! ME threshold for helicity filtering (force Fortran to mimic cudacpp, see #419)
-       INTEGER MAXTRIES
-       PARAMETER(MAXTRIES=25)
- C     To pass the helicity configuration chosen by the DiscreteSampler to 
 diff --git b/epochX/cudacpp/gg_tt.mad/Source/makefile a/epochX/cudacpp/gg_tt.mad/Source/makefile
 index 617f10b93..00c73099a 100644
 --- b/epochX/cudacpp/gg_tt.mad/Source/makefile

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/launch_plugin.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/launch_plugin.py
@@ -96,6 +96,7 @@ class CPPRunCard(banner_mod.RunCardLO):
         self['vector_size'] = 16 # already setup in default class (just change value)
         self['aloha_flag'] = '--fast-math'
         self['matrix_flag'] = '-O3'
+        self['limhel'] = 0
         self.display_block.append('simd')
         self.display_block.append('psoptim')
 


### PR DESCRIPTION
This is a simple patch to make the plugin work for the gpucpp_goodhel branch
(removing the double list for the helicity initialization and allowing limhel to be control from the run_card.)

The fact that limhel is now a user parameter makes it important to be correctly handle by the cudacpp interface as well which is not done in this PR.

