### PR TITLE
CI fix: move from gfortran-11 to gfortran-14 on Mac github-hosted runners

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,7 +38,7 @@ jobs:
   CPU_MAC:
     runs-on: macos-latest
     env:
-      FC: gfortran-11
+      FC: gfortran-14 # see #971
     strategy:
       matrix:
         folder: [ epochX/cudacpp/ee_mumu.mad/SubProcesses/P1_epem_mupmum, epochX/cudacpp/gg_ttgg.mad/SubProcesses/P1_gg_ttxgg ]


### PR DESCRIPTION
CI fix: move from gfortran-11 to gfortran-14 on Mac github-hosted runners

This is a possible fix for #971