### PR TITLE
Update __init__.py to (1,0,1)  and fix 'v1.00.01' tags - also remove untracked warnings for git submodule 

### DIFF
--- a/.github/workflows/archiver.sh
+++ b/.github/workflows/archiver.sh
@@ -26,8 +26,17 @@ mkdir ${outdir}
 outfile=${outdir}/VERSION.txt
 touch ${outfile}
 dateformat='%Y-%m-%d_%H:%M:%S UTC'
+cudacpp_major=$(cat __init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $1}')
+cudacpp_minor=$(cat __init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $2}')
+cudacpp_patch=$(cat __init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $3}')
+###echo "(From CUDACPP_OUTPUT/__init__.py)"
+###echo "cudacpp (major, minor, patch) = ( ${cudacpp_major}, ${cudacpp_minor}, ${cudacpp_patch} )"
+if [ ${cudacpp_major} -lt 0 ] || [ ${cudacpp_major} -gt 99 ]; then echo "ERROR! cudacpp_major is not in the [0,99] range"; exit 1; fi
+if [ ${cudacpp_minor} -lt 0 ] || [ ${cudacpp_minor} -gt 99 ]; then echo "ERROR! cudacpp_minor is not in the [0,99] range"; exit 1; fi
+if [ ${cudacpp_patch} -lt 0 ] || [ ${cudacpp_patch} -gt 99 ]; then echo "ERROR! cudacpp_patch is not in the [0,99] range"; exit 1; fi
+cudacpp_version=$(printf "%1d.%02d.%02d" ${cudacpp_major} ${cudacpp_minor} ${cudacpp_patch})
 echo "(From CUDACPP_OUTPUT/__init__.py)" >> ${outfile}
-echo "cudacpp_version              = $(cat __init__.py | awk '/__version__/{print $3}' | sed 's/(//' | sed 's/)//' | sed 's/,/./g')" >> ${outfile}
+echo "cudacpp_version              = ${cudacpp_version}" >> ${outfile}
 echo "mg5_version_minimal          = $(cat __init__.py | awk '/minimal_mg5amcnlo_version/{print $3}'  | sed 's/(//' | sed 's/)//' | sed 's/,/./g')" >> ${outfile}
 echo "mg5_version_latest_validated = $(cat __init__.py | awk '/latest_validated_version/{print $3}'  | sed 's/(//' | sed 's/)//' | sed 's/,/./g')" >> ${outfile}
 echo "" >> ${outfile}

--- a/.github/workflows/archiver.yml
+++ b/.github/workflows/archiver.yml
@@ -13,8 +13,8 @@ on:
   push:
 
     tags:
-    # Include version tags such as 'cudacpp_for3.6.0_v1.0.0' or 'cudacpp_for3.6.0_v1.0.0_test001'
-    # Include version tags such as 'valassi_cudacpp_for3.6.0_v1.0.0' or 'valassi_cudacpp_for3.6.0_v1.0.0_test001'
+    # Include version tags such as 'cudacpp_for3.6.0_v1.00.00' or 'cudacpp_for3.6.0_v1.00.00_test001'
+    # Include version tags such as 'valassi_cudacpp_for3.6.0_v1.00.00' or 'valassi_cudacpp_for3.6.0_v1.00.00_test001'
     - '*cudacpp_for*_v*'
 
     # Exclude running tags such as 'cudacpp_for3.6.0_latest'

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,5 @@
 	path = MG5aMC/mg5amcnlo
 	url = https://github.com/mg5amcnlo/mg5amcnlo
 	branch = gpucpp
+        # See https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submoduleltnamegtignore
+        ignore = untracked

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/CHANGELOG.md
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 
 - Updated cudacpp version to 1.00.01.
 
+### Fixed
+
+- Infrastructure issues
+  - AV ([#1013]) Fix release scripts to create 'v1.00.01' tags from a '(1,0,1)' python tuple.
+
 --------------------------------------------------------------------------------
 
 ## [1.00.00] - 2024-10-03
@@ -52,3 +57,4 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 [#959]: https://github.com/madgraph5/madgraph4gpu/issues/959
 [#993]: https://github.com/madgraph5/madgraph4gpu/issues/993
 [#1011]: https://github.com/madgraph5/madgraph4gpu/issues/1011
+[#1013]: https://github.com/madgraph5/madgraph4gpu/issues/1013

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/CHANGELOG.md
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 
 --------------------------------------------------------------------------------
 
+## [Unreleased] - 2024-10-03
+
+### Changed
+
+- Updated cudacpp version to 1.00.01.
+
+--------------------------------------------------------------------------------
+
 ## [1.00.00] - 2024-10-03
 
 ### Added
@@ -35,6 +43,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 --------------------------------------------------------------------------------
 
 [1.00.00]: https://github.com/madgraph5/madgraph4gpu/releases/tag/cudacpp_for3.6.0_v1.00.00
+[Unreleased]: https://github.com/madgraph5/madgraph4gpu/releases/compare/cudacpp_for3.6.0_v1.00.00...HEAD
 
 [#601]: https://github.com/madgraph5/madgraph4gpu/issues/601
 [#846]: https://github.com/madgraph5/madgraph4gpu/issues/846

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py
@@ -66,7 +66,11 @@ else:
     __author__ = 'Andrea Valassi'
     __email__ = 'andrea.valassi@cern.ch'
 
-    __version__ = (1,00,01) # NB the release infrastructure expects 1-digit major and 2-digit minor and patch versions (n,nn,nn)
+    # Plugin version (major,minor,patch) where major>1, 0<=minor<=99 and 0<=patch<=99
+    # The release infrastructure expects 'vN.NN.NN' tags with 1-digit major and 2-digit minor and patch versions
+    # and it takes care of converting the python tuple '(1,0,1)' into a version string 'v1.00.01'
+    # NB! Do not use '(1,00,01)' here: leading zeros in decimal integer literals are not permitted in python (#1013)
+    __version__ = (1,0,1)
 
     minimal_mg5amcnlo_version = (3,6,0)
     maximal_mg5amcnlo_version = (1000,1000,1000)

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py
@@ -66,7 +66,7 @@ else:
     __author__ = 'Andrea Valassi'
     __email__ = 'andrea.valassi@cern.ch'
 
-    __version__ = (1,00,00) # NB the release infrastructure expects 1-digit major and 2-digit minor and patch versions (n,nn,nn)
+    __version__ = (1,00,01) # NB the release infrastructure expects 1-digit major and 2-digit minor and patch versions (n,nn,nn)
 
     minimal_mg5amcnlo_version = (3,6,0)
     maximal_mg5amcnlo_version = (1000,1000,1000)

--- a/epochX/cudacpp/gitTag.sh
+++ b/epochX/cudacpp/gitTag.sh
@@ -22,8 +22,8 @@ function usage()
 {
   echo "Usage (1): $0 [-f] <tagsuffix>"
   echo "Creates a new version tag (from the HEAD of the local branch) and pushes it to the remote repository"
-  echo "Valid formats for <tagsuffix> are 'n1.n2.n3' or 'n1.n2.n3_txt' where txt only contains letters or digits"
-  echo "Version number 'n1.n2.n3' must match that in the CUDACPP_OUTPUT/__init__.py file"
+  echo "Valid formats for <tagsuffix> are 'n.nn.nn' or 'n.nn.nn_txt' where txt only contains letters or digits)"
+  echo "Version number must match the (n1,n2,n3) specified with single digits in the CUDACPP_OUTPUT/__init__.py file"
   echo "For release tags (no trailing '_txt'), the github CI will then create also a running tag with '_latest' suffix"
   echo "Use the -f option to delete and recreate a version tag that already exists"
   echo ""
@@ -156,7 +156,13 @@ else
 
   # Determine cudacpp_version (as in archiver.sh)
   echo "INFO: determine cudacpp and mg5amc versions"
-  cudacpp_version=$(cat ${topdir}/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py | awk '/__version__/{print $3}' | sed 's/(//' | sed 's/)//' | sed 's/,/./g')
+  cudacpp_major=$(cat ${topdir}/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $1}')
+  cudacpp_minor=$(cat ${topdir}/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $2}')
+  cudacpp_patch=$(cat ${topdir}/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/__init__.py | grep __version__ | sed -r 's/(.*=|\(|\)|,)/ /g' | awk '{print $3}')
+  if [ ${cudacpp_major} -lt 0 ] || [ ${cudacpp_major} -gt 99 ]; then echo "ERROR! cudacpp_major is not in the [0,99] range"; exit 1; fi
+  if [ ${cudacpp_minor} -lt 0 ] || [ ${cudacpp_minor} -gt 99 ]; then echo "ERROR! cudacpp_minor is not in the [0,99] range"; exit 1; fi
+  if [ ${cudacpp_patch} -lt 0 ] || [ ${cudacpp_patch} -gt 99 ]; then echo "ERROR! cudacpp_patch is not in the [0,99] range"; exit 1; fi
+  cudacpp_version=$(printf "%1d.%02d.%02d" ${cudacpp_major} ${cudacpp_minor} ${cudacpp_patch})
   echo "> cudacpp_version = $cudacpp_version"
 
   # Determine mg5_version (as in HEPToolInstaller.py)


### PR DESCRIPTION
Hi @oliviermattelaer this is a small PR to update __init__.py to (1,0,1)

It also fixes the scripts to produce 'v1.00.01' tags (fixing #1013)

Should be non controversial I hope, can you have a look?

Thanks
Andrea