### PR TITLE
Downgrade oneprocess tests in the CI to ubuntu-22.04 because clang-format-18 is not yet supported

### DIFF
--- a/.github/workflows/testsuite_oneprocess.yml
+++ b/.github/workflows/testsuite_oneprocess.yml
@@ -96,7 +96,11 @@ jobs:
   #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
   codegen:
-    runs-on: ubuntu-latest
+    ###runs-on: ubuntu-latest
+    # Temporarely dowgrade ubuntu-latest to ubuntu-22.04 in codegen step because clang-format-18 is not yet supported (#1022)
+    # See https://github.com/actions/runner-images/issues/5490
+    # See https://github.com/actions/runner-images/issues/10636
+    runs-on: ubuntu-22.04
     needs: cleanup
 
     steps:

--- a/tools/mg-clang-format/mg-clang-format
+++ b/tools/mg-clang-format/mg-clang-format
@@ -20,6 +20,7 @@ if [ ${clangVersion} -ge 13 ] && [ ${clangVersion} -le 15 ]; then
 else
   if [ ! -d /cvmfs/sft.cern.ch/lcg/releases/clang ]; then
     echo "ERROR! clang-format version >= 13 and <= 15 is not installed and /cvmfs/sft.cern.ch/lcg/releases/clang is not reachable"
+    echo "ERROR! current clang-format version is '$clangVersion'"
     exit 1    
   fi
   redrel=$(cat /etc/redhat-release 2> /dev/null)


### PR DESCRIPTION
Debug github CI issues with clang-format

See https://github.com/madgraph5/madgraph4gpu/actions/runs/11304784032/job/31443586843
```

+++ Check code formatting in newly generated code ee_mumu.mad

ERROR! clang-format version >= 13 and <= 15 is not installed and /cvmfs/sft.cern.ch/lcg/releases/clang is not reachable
ERROR! mg-clang-format failed
ERROR! Auto-generated code does not respect formatting policies
 
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[testsuite_oneprocess.sh] codegen (ee_mumu.mad) finished with status=1 (NOT OK) at Sat Oct 12 10:07:47 UTC 2024
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Error: Process completed with exit code 1.
```