### PR TITLE
Update c-cpp.yml workflow to run on NGT runners

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   debug_builds:
@@ -56,7 +57,8 @@ jobs:
     - name: make test
       run: make BACKEND=${{ matrix.backend }} OMPFLAGS= FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} -f cudacpp.mk test
   GPU:
-    runs-on: self-hosted
+    runs-on:
+      group: NGT
     env:
       CUDA_HOME: /usr/local/cuda/
       FC: gfortran


### PR DESCRIPTION
Add also `workflow_dispatch` trigger to be able to trigger it manually.

I created the pull request, so the workflow becomes available to test it.
Let's wait I can test it properly before merging.