### PR TITLE
Revert back to self-hosted runners temporarily

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -57,8 +57,9 @@ jobs:
     - name: make test
       run: make BACKEND=${{ matrix.backend }} OMPFLAGS= FPTYPE=${{ matrix.precision }} -C ${{ matrix.folder }} -f cudacpp.mk test
   GPU:
-    runs-on: madgraph5-h100
-    container: registry.cern.ch/ngt/lxplus-like:9
+    runs-on: self-hosted
+    # runs-on: madgraph5-h100
+    # container: registry.cern.ch/ngt/lxplus-like:9
     env:
       CUDA_HOME: /usr/local/cuda/
       FC: gfortran


### PR DESCRIPTION
PR to test the CI.
Before using the NGT runners, we wait for fixes in the waiting system for the CI.