### PR TITLE
(NOT A FEATURE, doesn't need integration(?)) added support for fp128 through the quadmath library

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/aloha/template_files/gpu/helas.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/aloha/template_files/gpu/helas.h
@@ -5,7 +5,7 @@
 ! Copyright (C) 2020-2024 CERN and UCLouvain.
 ! Licensed under the GNU Lesser General Public License (version 3 or later).
 ! Modified by: O. Mattelaer (Mar 2020) for the MG5aMC CUDACPP plugin.
-! Further modified by: O. Mattelaer, A. Valassi (2020-2024) for the MG5aMC CUDACPP plugin.
+! Further modified by: O. Mattelaer, A. Valassi, Z. Wettersten (2020-2025) for the MG5aMC CUDACPP plugin.
 !==========================================================================
   //--------------------------------------------------------------------------
 
@@ -194,7 +194,8 @@
       if( pp == 0. )
       {
         // NB: Do not use "abs" for floats! It returns an integer with no build warning! Use std::abs!
-        fptype sqm[2] = { fpsqrt( std::abs( fmass ) ), 0. }; // possibility of negative fermion masses
+        // Aliased abs to allow __float128
+        fptype sqm[2] = { fpsqrt( fpabs( fmass ) ), 0. }; // possibility of negative fermion masses
         //sqm[1] = ( fmass < 0. ? -abs( sqm[0] ) : abs( sqm[0] ) ); // AV: why abs here?
         sqm[1] = ( fmass < 0. ? -sqm[0] : sqm[0] ); // AV: removed an abs here
         fi[2] = cxmake( ip * sqm[ip], 0 );
@@ -220,7 +221,8 @@
 #else
       // Branch A: pp == 0.
       // NB: Do not use "abs" for floats! It returns an integer with no build warning! Use std::abs!
-      fptype sqm[2] = { fpsqrt( std::abs( fmass ) ), 0 }; // possibility of negative fermion masses (NB: SCALAR!)
+      // Aliased abs to allow __float128 (irrelevant in SIMD but kept for consistency)
+      fptype sqm[2] = { fpsqrt( fpabs( fmass ) ), 0 }; // possibility of negative fermion masses (NB: SCALAR!)
       sqm[1] = ( fmass < 0 ? -sqm[0] : sqm[0] );          // AV: removed an abs here (as above)
       const cxtype fiA_2 = ip * sqm[ip];                  // scalar cxtype: real part initialised from fptype, imag part = 0
       const cxtype fiA_3 = im * nsf * sqm[ip];            // scalar cxtype: real part initialised from fptype, imag part = 0
@@ -436,8 +438,8 @@
     vc[1] = cxmake( pvec1 * (fptype)nsv, pvec2 * (fptype)nsv );
     if( vmass != 0. )
     {
-      const int nsvahl = nsv * std::abs( hel );
-      const fptype hel0 = 1. - std::abs( hel );
+      const int nsvahl = nsv * fpabs( hel );
+      const fptype hel0 = 1. - fpabs( hel );
 #ifndef MGONGPU_CPPSIMD
       const fptype_sv pt2 = ( pvec1 * pvec1 ) + ( pvec2 * pvec2 );
       const fptype_sv pp = fpmin( pvec0, fpsqrt( pt2 + ( pvec3 * pvec3 ) ) );
@@ -604,7 +606,8 @@
       if( pp == 0. )
       {
         // NB: Do not use "abs" for floats! It returns an integer with no build warning! Use std::abs!
-        fptype sqm[2] = { fpsqrt( std::abs( fmass ) ), 0. }; // possibility of negative fermion masses
+        // Aliased abs to allow __float128
+        fptype sqm[2] = { fpsqrt( fpabs( fmass ) ), 0. }; // possibility of negative fermion masses
         //sqm[1] = ( fmass < 0. ? -abs( sqm[0] ) : abs( sqm[0] ) ); // AV: why abs here?
         sqm[1] = ( fmass < 0. ? -sqm[0] : sqm[0] ); // AV: removed an abs here
         const int ip = -( ( 1 - nh ) / 2 ) * nhel;  // NB: Fortran sqm(0:1) also has indexes 0,1 as in C++
@@ -637,7 +640,8 @@
       const fptype_sv pp = fpmin( pvec0, fpsqrt( p2 ) );
       // Branch A: pp == 0.
       // NB: Do not use "abs" for floats! It returns an integer with no build warning! Use std::abs!
-      fptype sqm[2] = { fpsqrt( std::abs( fmass ) ), 0 }; // possibility of negative fermion masses
+      // Aliased abs to allow __float128 (irrelevant in SIMD, but for consistency)
+      fptype sqm[2] = { fpsqrt( fpabs( fmass ) ), 0 }; // possibility of negative fermion masses
       sqm[1] = ( fmass < 0 ? -sqm[0] : sqm[0] );          // AV: removed an abs here (as above)
       const int ipA = -( ( 1 - nh ) / 2 ) * nhel;
       const int imA = ( 1 + nh ) / 2 * nhel;

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/launch_plugin.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/launch_plugin.py
@@ -36,8 +36,13 @@ class CPPMEInterface(madevent_interface.MadEventCmdShell):
                 {'override FPTYPE': self.run_card['floating_type'] })
             misc.sprint('FPTYPE checked')
         cudacpp_supported_backends = [ 'fortran', 'cuda', 'hip', 'cpp', 'cppnone', 'cppsse4', 'cppavx2', 'cpp512y', 'cpp512z', 'cppauto' ]
+            
         if args and args[0][0] == 'madevent' and hasattr(self, 'run_card'):            
             cudacpp_backend = self.run_card['cudacpp_backend'].lower() # the default value is defined in launch_plugin.py
+            if self.run_card['floating_type'] == 'q':
+                if cudacpp_backend not in [ 'fortran', 'cppnone' ]:
+                    misc.sprint("WARNING: cudacpp_backend='%s' does not support quad precision. Switching to 'cppnone' backend."%cudacpp_backend)
+                    cudacpp_backend = 'cppnone'
             logger.info("Building madevent in madevent_interface.py with '%s' matrix elements"%cudacpp_backend)
             if cudacpp_backend in cudacpp_supported_backends :
                 args[0][0] = 'madevent_' + cudacpp_backend + '_link'
@@ -86,7 +91,7 @@ class CPPRunCard(banner_mod.RunCardLO):
         super().default_setup()
         self.add_param('floating_type', 'm', include=False, hidden=True,
                        fct_mod=(self.reset_makeopts,(),{}),
-                       allowed=['m','d','f'],
+                       allowed=['m','d','f', 'q'],
                        comment='floating point precision: f (single), d (double), m (mixed: double for amplitudes, single for colors)'
                        )
         cudacpp_supported_backends = [ 'fortran', 'cuda', 'hip', 'cpp', 'cppnone', 'cppsse4', 'cppavx2', 'cpp512y', 'cpp512z', 'cppauto' ]

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/check_sa.cc
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/check_sa.cc
@@ -4,7 +4,7 @@
 // Copyright (C) 2020-2024 CERN and UCLouvain.
 // Licensed under the GNU Lesser General Public License (version 3 or later).
 // Modified by: O. Mattelaer (Nov 2020) for the MG5aMC CUDACPP plugin.
-// Further modified by: S. Hageboeck, O. Mattelaer, S. Roiser, J. Teig, A. Valassi (2020-2024) for the MG5aMC CUDACPP plugin.
+// Further modified by: S. Hageboeck, O. Mattelaer, S. Roiser, J. Teig, A. Valassi, Z. Wettersten (2020-2025) for the MG5aMC CUDACPP plugin.
 //==========================================================================
 
 #include "mgOnGpuConfig.h"
@@ -704,6 +704,11 @@ main( int argc, char** argv )
     {
       if( verbose )
       {
+#ifdef MGONGPU_FPTYPE_QUAD
+size_t width = 42;
+#else
+size_t width = 14;
+#endif
         // Display momenta
         std::cout << "Momenta:" << std::endl;
         for( int ipar = 0; ipar < CPPProcess::npar; ipar++ )
@@ -711,10 +716,10 @@ main( int argc, char** argv )
           // NB: 'setw' affects only the next field (of any type)
           std::cout << std::scientific // fixed format: affects all floats (default precision: 6)
                     << std::setw( 4 ) << ipar + 1
-                    << std::setw( 14 ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 0, ipar )
-                    << std::setw( 14 ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 1, ipar )
-                    << std::setw( 14 ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 2, ipar )
-                    << std::setw( 14 ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 3, ipar )
+                    << std::setw( width ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 0, ipar )
+                    << std::setw( width ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 1, ipar )
+                    << std::setw( width ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 2, ipar )
+                    << std::setw( width ) << MemoryAccessMomenta::ieventAccessIp4IparConst( hstMomenta.data(), ievt, 3, ipar )
                     << std::endl
                     << std::defaultfloat; // default format: affects all floats
         }

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2025 CERN and UCLouvain.
 # Licensed under the GNU Lesser General Public License (version 3 or later).
 # Created by: S. Roiser (Feb 2020) for the MG5aMC CUDACPP plugin.
-# Further modified by: S. Hageboeck, D. Massaro, O. Mattelaer, S. Roiser, J. Teig, A. Valassi (2020-2025) for the MG5aMC CUDACPP plugin.
+# Further modified by: S. Hageboeck, D. Massaro, O. Mattelaer, S. Roiser, J. Teig, A. Valassi, Z. Wettersten (2020-2025) for the MG5aMC CUDACPP plugin.
 
 #=== Determine the name of this makefile (https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_17.html)
 #=== NB: use ':=' to ensure that the value of CUDACPP_MAKEFILE is not modified further down after including make_opts
@@ -11,6 +11,17 @@ override CUDACPP_MAKEFILE := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 
 #=== NB: different names (e.g. cudacpp.mk and cudacpp_src.mk) are used in the Subprocess and src directories
 override CUDACPP_SRC_MAKEFILE = cudacpp_src.mk
+
+#-------------------------------------------------------------------------------
+
+#=== Include the common MG5aMC Makefile options
+
+# OM: including make_opts is crucial for MG5aMC flag consistency/documentation
+# AV: disable the inclusion of make_opts if the file has not been generated (standalone cudacpp)
+# ZW: need to include make_opts prior to cudacpp_config.mk to pass flags for quadmath
+ifneq ($(wildcard ../../Source/make_opts),)
+  include ../../Source/make_opts
+endif
 
 #-------------------------------------------------------------------------------
 
@@ -41,16 +52,6 @@ UNAME_S := $(shell uname -s)
 # Detect architecture (x86_64, ppc64le...)
 UNAME_P := $(shell uname -p)
 ###$(info UNAME_P='$(UNAME_P)')
-
-#-------------------------------------------------------------------------------
-
-#=== Include the common MG5aMC Makefile options
-
-# OM: including make_opts is crucial for MG5aMC flag consistency/documentation
-# AV: disable the inclusion of make_opts if the file has not been generated (standalone cudacpp)
-ifneq ($(wildcard ../../Source/make_opts),)
-  include ../../Source/make_opts
-endif
 
 #-------------------------------------------------------------------------------
 
@@ -577,8 +578,10 @@ else ifeq ($(FPTYPE),f)
 else ifeq ($(FPTYPE),m)
   CXXFLAGS += -DMGONGPU_FPTYPE_DOUBLE -DMGONGPU_FPTYPE2_FLOAT
   GPUFLAGS += -DMGONGPU_FPTYPE_DOUBLE -DMGONGPU_FPTYPE2_FLOAT
-else
-  $(error Unknown FPTYPE='$(FPTYPE)': only 'd', 'f' and 'm' are supported)
+else ifeq ($(FPTYPE),q)
+  CXXFLAGS += -DMGONGPU_FPTYPE_QUAD
+else ifeq
+  $(error Unknown FPTYPE='$(FPTYPE)': only 'd', 'f', 'm' and 'q' are supported)
 endif
 
 # Set the build flags appropriate to each HELINL choice (example: "make HELINL=1")
@@ -811,7 +814,7 @@ endif
 # (NB do not include CUDA_INC here! add it only for NVTX or curand #679)
 $(BUILDDIR)/%%_cpp.o : %%.cc *.h ../../src/*.h $(BUILDDIR)/.build.$(TAG)
 	@if [ ! -d $(BUILDDIR) ]; then echo "mkdir -p $(BUILDDIR)"; mkdir -p $(BUILDDIR); fi
-	$(CXX) $(CPPFLAGS) $(INCFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(INCFLAGS) $(CXXFLAGS) -c $< -o $@ $(QUADFLAG)
 
 # Generic target and build rules: objects from CUDA or HIP compilation
 ifneq ($(GPUCC),)
@@ -847,7 +850,7 @@ endif
 $(LIBDIR)/lib$(MG5AMC_CXXLIB).so: $(BUILDDIR)/fbridge_cpp.o
 $(LIBDIR)/lib$(MG5AMC_CXXLIB).so: cxx_objects_lib += $(BUILDDIR)/fbridge_cpp.o
 $(LIBDIR)/lib$(MG5AMC_CXXLIB).so: $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so $(cxx_objects_lib)
-	$(CXX) -shared -o $@ $(cxx_objects_lib) $(CXXLIBFLAGSRPATH2) -L$(LIBDIR) -l$(MG5AMC_COMMONLIB)
+	$(CXX) -shared -o $@ $(cxx_objects_lib) $(CXXLIBFLAGSRPATH2) -L$(LIBDIR) -l$(MG5AMC_COMMONLIB) $(QUADFLAG)
 
 ifneq ($(GPUCC),)
 $(LIBDIR)/lib$(MG5AMC_GPULIB).so: $(BUILDDIR)/fbridge_$(GPUSUFFIX).o
@@ -875,7 +878,7 @@ endif
 ###$(cxx_checkmain): LIBFLAGS += $(CXXLIBFLAGSASAN)
 $(cxx_checkmain): LIBFLAGS += $(CXXLIBFLAGSRPATH) # avoid the need for LD_LIBRARY_PATH
 $(cxx_checkmain): $(BUILDDIR)/check_sa_cpp.o $(LIBDIR)/lib$(MG5AMC_CXXLIB).so $(cxx_objects_exe) $(BUILDDIR)/CurandRandomNumberKernel_cpp.o $(BUILDDIR)/HiprandRandomNumberKernel_cpp.o
-	$(CXX) -o $@ $(BUILDDIR)/check_sa_cpp.o $(OMPFLAGS) -ldl -pthread $(LIBFLAGS) -L$(LIBDIR) -l$(MG5AMC_CXXLIB) $(cxx_objects_exe) $(BUILDDIR)/CurandRandomNumberKernel_cpp.o $(BUILDDIR)/HiprandRandomNumberKernel_cpp.o $(RNDLIBFLAGS)
+	$(CXX) -o $@ $(BUILDDIR)/check_sa_cpp.o $(OMPFLAGS) -ldl -pthread $(LIBFLAGS) -L$(LIBDIR) -l$(MG5AMC_CXXLIB) $(cxx_objects_exe) $(BUILDDIR)/CurandRandomNumberKernel_cpp.o $(BUILDDIR)/HiprandRandomNumberKernel_cpp.o $(RNDLIBFLAGS) $(QUADFLAG)
 
 ifneq ($(GPUCC),)
 ###$(gpu_checkmain): LIBFLAGS += $(GPULIBFLAGSASAN)

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_config.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_config.mk
@@ -1,12 +1,20 @@
 # Copyright (C) 2020-2024 CERN and UCLouvain.
 # Licensed under the GNU Lesser General Public License (version 3 or later).
 # Created by: A. Valassi (Mar 2024) for the MG5aMC CUDACPP plugin.
-# Further modified by: A. Valassi (2024) for the MG5aMC CUDACPP plugin.
+# Further modified by: A. Valassi, Z. Wettersten (2024-2025) for the MG5aMC CUDACPP plugin.
 
 #-------------------------------------------------------------------------------
 
 #=== Check that the user-defined choices of BACKEND, FPTYPE, HELINL, HRDCOD are supported
 #=== Configure default values for these variables if no user-defined choices exist
+
+# Include libquadmath if FPTYPE=quad and set backend to cppnone
+ifeq ($(FPTYPE),q)
+  override QUADFLAG = -lquadmath
+  override BACKEND = cppnone
+else
+  override QUADFLAG =
+endif
 
 # Set the default BACKEND (CUDA, HIP or C++/SIMD) choice
 ifeq ($(BACKEND),)
@@ -39,7 +47,7 @@ ifneq ($(words $(filter $(BACKEND), $(SUPPORTED_BACKENDS))),1)
   $(error Invalid backend BACKEND='$(BACKEND)': supported backends are $(foreach backend,$(SUPPORTED_BACKENDS),'$(backend)'))
 endif
 
-override SUPPORTED_FPTYPES = d f m
+override SUPPORTED_FPTYPES = d f m q
 ifneq ($(words $(filter $(FPTYPE), $(SUPPORTED_FPTYPES))),1)
   $(error Invalid fptype FPTYPE='$(FPTYPE)': supported fptypes are $(foreach fptype,$(SUPPORTED_FPTYPES),'$(fptype)'))
 endif

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_src.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp_src.mk
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2024 CERN and UCLouvain.
 # Licensed under the GNU Lesser General Public License (version 3 or later).
 # Created by: S. Roiser (Feb 2020) for the MG5aMC CUDACPP plugin.
-# Further modified by: S. Hageboeck, O. Mattelaer, S. Roiser, J. Teig, A. Valassi (2020-2024) for the MG5aMC CUDACPP plugin.
+# Further modified by: S. Hageboeck, O. Mattelaer, S. Roiser, J. Teig, A. Valassi, Z. Wettersten (2020-2025) for the MG5aMC CUDACPP plugin.
 
 #=== Determine the name of this makefile (https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_17.html)
 #=== NB: assume that the same name (e.g. cudacpp.mk, Makefile...) is used in the Subprocess and src directories
@@ -132,7 +132,7 @@ $(LIBDIR)/.build.$(TAG):
 # Generic target and build rules: objects from C++ compilation
 $(BUILDDIR)/%%_cpp.o : %%.cc *.h $(BUILDDIR)/.build.$(TAG)
 	@if [ ! -d $(BUILDDIR) ]; then echo "mkdir -p $(BUILDDIR)"; mkdir -p $(BUILDDIR); fi
-	$(CXX) $(CPPFLAGS) $(INCFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(INCFLAGS) $(CXXFLAGS) -c $< -o $@ $(QUADFLAG)
 
 # Generic target and build rules: objects from CUDA compilation
 ifneq ($(GPUCC),)
@@ -154,7 +154,7 @@ endif
 ifeq ($(GPUCC),)
 $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects)
 	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi
-	$(CXX) -shared -o $@ $(cxx_objects) $(LDFLAGS)
+	$(CXX) -shared -o $@ $(cxx_objects) $(LDFLAGS) $(QUADFLAG)
 else
 $(LIBDIR)/lib$(MG5AMC_COMMONLIB).so : $(cxx_objects) $(gpu_objects)
 	@if [ ! -d $(LIBDIR) ]; then echo "mkdir -p $(LIBDIR)"; mkdir -p $(LIBDIR); fi

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/mgOnGpuFptypes.h
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/mgOnGpuFptypes.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2020-2024 CERN and UCLouvain.
 // Licensed under the GNU Lesser General Public License (version 3 or later).
 // Created by: A. Valassi (Jan 2022) for the MG5aMC CUDACPP plugin.
-// Further modified by: J. Teig, A. Valassi (2022-2024) for the MG5aMC CUDACPP plugin.
+// Further modified by: J. Teig, A. Valassi, Z. Wettersten (2022-2025) for the MG5aMC CUDACPP plugin.
 
 #ifndef MGONGPUFPTYPES_H
 #define MGONGPUFPTYPES_H 1
@@ -10,6 +10,10 @@
 
 #include <algorithm>
 #include <cmath>
+#ifdef MGONGPU_FPTYPE_QUAD
+#include <quadmath.h>
+#include <ostream> // for operator<< overloading
+#endif
 
 // NB: namespaces mg5amcGpu and mg5amcCpu includes types which are defined in different ways for CPU and GPU builds (see #318 and #725)
 #ifdef MGONGPUCPP_GPUIMPL // cuda
@@ -70,6 +74,101 @@ namespace mg5amcCpu
 
 #ifndef MGONGPUCPP_GPUIMPL
 
+#ifdef MGONGPU_FPTYPE_QUAD
+
+  //------------------------------
+  // Quad precision types - C++
+  //------------------------------
+
+  // quad max returns by value, not by reference
+  inline fptype
+  fpmax( const fptype& a, const fptype& b )
+  {
+    return fmaxq( a, b );
+  }
+
+  // quad min returns by value, not by reference
+  inline fptype
+  fpmin( const fptype& a, const fptype& b )
+  {
+    return fminq( a, b );
+  }
+
+  inline fptype
+  fpsqrt( const fptype& f )
+  {
+    return sqrtq( f );
+  }
+
+  inline fptype
+  fpabs( const fptype& f )
+  {
+    return fabsq( f );
+  }
+
+  inline fptype
+  fppow( const fptype& base, const int& exp )
+  {
+    // Special case for positive integer exponents
+    if ( exp >= 0 )
+    {
+      fptype result = static_cast<__float128>( 1.0 );
+      for ( int i = 0; i < exp; ++i )
+      {
+        result *= base;
+      }
+      return result;
+    }
+    // General case
+    return powq( base, static_cast<__float128>( exp ) );
+  }
+
+  inline fptype
+  fppow( const fptype& base, const fptype& exp )
+  {
+    return powq( base, exp );
+  }
+
+  // Overload operator<< for quad precision (need to convert to string first)
+  inline std::ostream&
+  operator<<( std::ostream& os, const fptype& f )
+  {
+    char buffer[128];
+    // Convert __float128 to string with 36 digits of precision
+    int n = quadmath_snprintf( buffer, sizeof( buffer ), "%.36Qg", f );
+    if ( n > 0 && n < static_cast<int>( sizeof( buffer ) ) )
+    {
+      os << buffer;
+    }
+    else
+    {
+      os << "ConversionError";
+    }
+    return os;
+  }
+
+  inline bool
+  fp_is_infinite( const fptype& fp )
+  {
+    return isinfq( fp );
+  }
+
+  inline bool
+  fp_is_nan( const fptype& fp )
+  {
+    return isnanq( fp );
+  }
+
+#define UNUSED(x) (void)(x)
+  inline bool
+  fp_is_normal( const fptype& fp )
+  {
+    UNUSED(fp);
+    return true; // no isnormalq in quadmath.h
+  }
+
+#else
+
   //------------------------------
   // Floating point types - C++
   //------------------------------
@@ -92,6 +191,40 @@ namespace mg5amcCpu
     return std::sqrt( f );
   }
 
+  inline fptype
+  fpabs( const fptype& f )
+  {
+    return std::abs( f );
+  }
+
+  inline fptype
+  fppow( const fptype& base, const int& exp )
+  {
+    return std::pow( base, static_cast<fptype>( exp ) );
+  }
+
+  inline bool
+  fp_is_infinite( const fptype& fp )
+  {
+    return std::isinf( fp );
+  }
+
+  inline bool
+  fp_is_nan( const fptype& fp )
+  {
+    //#pragma clang diagnostic push
+    //#pragma clang diagnostic ignored "-Wtautological-compare" // for icpx2021/clang13 (https://stackoverflow.com/a/15864661)
+    return std::isnan( fp ); // always false for clang in fast math mode (tautological compare)?
+    //#pragma clang diagnostic pop
+  }
+
+  inline bool
+  fp_is_normal( const fptype& fp )
+  {
+    return std::isnormal( fp );
+  }
+
+#endif // #ifdef MGONGPU_FPTYPE_QUAD
 #endif // #ifndef MGONGPUCPP_GPUIMPL
 
   //==========================================================================

--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/model_handling.py
@@ -201,7 +201,7 @@ class PLUGIN_ALOHAWriter(aloha_writers.ALOHAWriterForGPU):
                 list_arg = '[]' # AV from cxtype_sv to fptype array (running alphas #373)
                 point = self.type2def['pointer_coup']
                 args.append('%s %s%s%s'% (type, point, argname, list_arg))
-                args.append('double Ccoeff%s'% argname[7:]) # OM for 'unary minus' #628
+                args.append('fptype Ccoeff%s'% argname[7:]) # OM for 'unary minus' #628 | ZW: changed from 'double' to 'fptype' for quad
             else:
                 args.append('%s %s%s'% (type, argname, list_arg))
         if not self.offshell:
@@ -805,7 +805,7 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
         for param in params:
             res_strings.append( "%s" % param.expr )
         res = "\n".join(res_strings)
-        res = res.replace('ABS(','std::abs(') # for SMEFT #614 and #616
+        res = res.replace('ABS(','fpabs(') # for SMEFT #614 and #616
         return res
 
     # AV - replace export_cpp.UFOModelConverterCPP method (eventually split writing of parameters and fixes for Majorana particles #622)
@@ -823,7 +823,7 @@ class PLUGIN_UFOModelConverter(PLUGIN_export_cpp.UFOModelConverterGPU):
                     res_strings.append( prefix+"  constexpr double %(W)s = %(W)s_sign * %(W)s_abs;" % { 'W' : particle.get('width') } )
                 else:
                     res_strings.append( prefix+"  if( %s < 0 )" % particle.get('mass'))
-                    res_strings.append( prefix+"    %(width)s = -std::abs( %(width)s );" % {"width": particle.get('width')})
+                    res_strings.append( prefix+"    %(width)s = -fpabs( %(width)s );" % {"width": particle.get('width')})
         if len( res_strings ) != 0 : res_strings = [ prefix + "  // Fixes for Majorana particles" ] + res_strings
         if not hardcoded: return '\n' + '\n'.join(res_strings) if res_strings else ''
         else: return '\n' + '\n'.join(res_strings) + '\n' if res_strings else '\n'


### PR DESCRIPTION
support for __float128 through libquadmath (i think intel also supports an equivalent library), run using  floating_type=q in the CLI or compile with fptype=q to enable it (assuming quadmath is installed on the machine)

some minor modifications to account for non-std functionality: abs, min, max, pow, operator<<, sqrt etc, as well as some abstraction to account for these changes

changed order of make_opts and cudacpp_config to pass the fptype earlier to allow for config-level flags based on the fptype; passing a quadflag through the compilation which is either a null string or -lquadmath