### PR TITLE
Fix cppauto backend detection using echo instead of file

### DIFF
--- a/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
+++ b/epochX/cudacpp/CODEGEN/PLUGIN/CUDACPP_SA_OUTPUT/madgraph/iolibs/template_files/gpu/cudacpp.mk
@@ -89,7 +89,7 @@ endif
 # Create file with the resolved backend in case user chooses 'cppauto'
 BACKEND_LOG ?= .resolved-backend
 ifneq ($(BACKEND_ORIG),$(BACKEND))
-  $(file >$(BACKEND_LOG),$(BACKEND))
+  $(shell echo '$(BACKEND)' > $(BACKEND_LOG))
 endif
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
The `file` function used may not be available, use the good old `echo`.